### PR TITLE
wss (ssl) support

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -7,6 +7,7 @@
 var util = require('util')
   , events = require('events')
   , http = require('http')
+  , https = require('https')
   , crypto = require('crypto')
   , url = require('url')
   , fs = require('fs')
@@ -69,6 +70,7 @@ function WebSocket(address, options) {
 
     var serverUrl = url.parse(address);
     if (!serverUrl.host) throw new Error('invalid url');
+    http = (serverUrl.protocol === 'wss:' || serverUrl.protocol === 'https:') ? https : http;
 
     options = new Options({
       origin: null,


### PR DESCRIPTION
This patch allows users to use ws on ssl. Thanks
## Client

var WebSocket = require('ws');
var ws = new WebSocket('wss://www.host.com/path');
## Server

var options = {
  key: fs.readFileSync('server.key'),
  cert: fs.readFileSync('server.cert')
};
var app = require('https').createServer(options);
app.listen(8082);
var WebSocketServer = require('ws').Server;
var wsServer = new WebSocketServer({server: app});
