### PR TITLE
Add some properties to WebSocket to match spec

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -22,6 +22,15 @@ var protocolPrefix = "HyBi-";
 var protocolVersion = 13;
 
 /**
+ * Ready States
+ */
+ 
+var CONNECTING = 0;
+var OPEN = 1;
+var CLOSING = 2;
+var CLOSED = 3;
+
+/**
  * WebSocket implementation
  */
 
@@ -161,6 +170,20 @@ function WebSocket(address, options) {
     value: this._state,
     configurable: false,
     enumerable: true
+  });
+  Object.defineProperty(this, 'readyState', {
+    get: function() {
+      switch(this._state) {
+        case 'connecting':
+          return CONNECTING;
+        case 'connected':
+          return OPEN;
+        case 'closing':
+          return CLOSING;
+        case 'disconnected':
+          return CLOSED;
+      }
+    }
   });
 }
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -47,6 +47,60 @@ describe('WebSocket', function() {
         });
       });
     });
+    
+    describe('#readyState', function() {
+      var CONNECTING = 0;
+      var OPEN = 1;
+      var CLOSING = 2;
+      var CLOSED = 3;
+      
+      it('defaults to connecting', function(done) {
+        server.createServer(++port, function(srv) {
+          var ws = new WebSocket('ws://localhost:' + port);
+          assert.equal(CONNECTING, ws.readyState);
+          ws.terminate();
+          ws.on('close', function() {
+            srv.close();
+            done();
+          });
+        });
+      });
+      
+      it('set to connected once connection is established', function(done) {
+        server.createServer(++port, function(srv) {
+          var ws = new WebSocket('ws://localhost:' + port);
+          ws.on('open', function() {
+            assert.equal(OPEN, ws.readyState);
+            srv.close();
+            done();
+          });
+        });
+      });
+     
+      it('set to closed once connection is closed', function(done) {
+        server.createServer(++port, function(srv) {
+          var ws = new WebSocket('ws://localhost:' + port);
+          ws.close(1001);
+          ws.on('close', function() {
+            assert.equal(CLOSED, ws.readyState);
+            srv.close();
+            done();
+          });
+        });
+      });
+      
+      it('set to closed once connection is terminated', function(done) {
+        server.createServer(++port, function(srv) {
+          var ws = new WebSocket('ws://localhost:' + port);
+          ws.terminate();
+          ws.on('close', function() {
+            assert.equal(CLOSED, ws.readyState);
+            srv.close();
+            done();
+          });
+        });
+      });
+    });
   });
 
   it('can disconnect before connection is established', function(done) {


### PR DESCRIPTION
I've added some properties (`url` and `readyState`) to the WebSocket interface to match the spec as defined here: http://dev.w3.org/html5/websockets/#websocket - Some low hanging fruit - still some more to go. Added tests etc.

Thanks!
