### PR TITLE
speed up by not copying for non-fragmented data in Receiver.prototype.concatBuffer

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -128,7 +128,7 @@ Receiver.prototype.expectHeader = function(length, handler) {
   var toRead = length;
   while (toRead > 0 && this.overflow.length > 0) {
     var buf = this.overflow.pop();
-    if (toRead < buf.length) this.overflow.push(buf.slice(toRead))
+    if (toRead < buf.length) this.overflow.push(buf.slice(toRead));
     var read = Math.min(buf.length, toRead);
     this.add(buf.slice(0, read));
     toRead -= read;
@@ -152,7 +152,7 @@ Receiver.prototype.expectData = function(length, handler) {
   var toRead = length;
   while (toRead > 0 && this.overflow.length > 0) {
     var buf = this.overflow.pop();
-    if (toRead < buf.length) this.overflow.push(buf.slice(toRead))
+    if (toRead < buf.length) this.overflow.push(buf.slice(toRead));
     var read = Math.min(buf.length, toRead);
     this.add(buf.slice(0, read));
     toRead -= read;
@@ -188,7 +188,7 @@ Receiver.prototype.processPacket = function (data) {
     this.state.fragmentedOperation = true;
     this.state.opcode = this.state.activeFragmentedOperation;
     if (!(this.state.opcode == 1 || this.state.opcode == 2)) {
-      this.error('continuation frame cannot follow current opcode', 1002)
+      this.error('continuation frame cannot follow current opcode', 1002);
       return;
     }
   }
@@ -276,6 +276,7 @@ Receiver.prototype.unmask = function (mask, buf, binary) {
 
 Receiver.prototype.concatBuffers = function(buffers) {
   var length = 0;
+  if (buffers.length === 1) return buffers[0];
   for (var i = 0, l = buffers.length; i < l; ++i) length += buffers[i].length;
   var mergedBuffer = new Buffer(length);
   bufferUtil.merge(mergedBuffer, buffers);


### PR DESCRIPTION
I observed approx. 50% performance improvement with this patch.
The benchmark is the same as before (https://github.com/kazuyukitanimura/websocketBinaryTransferBenchmark).

On my MacBook Air Mid 2011 (Core i 5 4GB RAM), I got 3Gbps for sending 2^20 bytes binary data.
