### PR TITLE
allow verifyClient to run asynchronously

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -172,19 +172,32 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
   var origin = version < 13 ?
     req.headers['sec-websocket-origin'] :
     req.headers['origin'];
+
+  var args = [req, socket, upgradeHead, version, cb];
   if (typeof this.options.verifyClient == 'function') {
     var info = {
       origin: origin,
       secure: typeof req.connection.encrypted !== 'undefined',
       req: req
     };
-    if (!this.options.verifyClient(info)) {
+    if (this.options.verifyClient.length == 2) {
+      var _this = this;
+      this.options.verifyClient(info, function(result) {
+        if (!result) abortConnection(socket, 401, 'Unauthorized')
+        else completeUpgrade.apply(_this, args);
+      });
+      return;
+    }
+    else if (!this.options.verifyClient(info)) {
       abortConnection(socket, 401, 'Unauthorized');
       return;
     }
   }
+  completeUpgrade.apply(this, args)
+}
 
-  var protocol = req.headers['sec-websocket-protocol'];
+function completeUpgrade(req, socket, upgradeHead, version, cb) {
+   var protocol = req.headers['sec-websocket-protocol'];
 
   // calc key
   var key = req.headers['sec-websocket-key'];


### PR DESCRIPTION
If the verifyClient method has 2 parameters, then it's assumed that the 2nd parameter is a callback. This allows verifyClient to asynchronous code - say, looking up an id in the database.
