### PR TITLE
Added support for "node-gyp" build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,14 @@
+{
+  'targets': [
+    {
+      'target_name': 'validation',
+      'cflags': [ '-O3' ],
+      'sources': [ 'src/validation.cc' ]
+    },
+    {
+      'target_name': 'bufferutil',
+      'cflags': [ '-O3' ],
+      'sources': [ 'src/bufferutil.cc' ]
+    }
+  ]
+}


### PR DESCRIPTION
Hey @einaros. Here's the `bindings.gyp` file so that you can compile the native addon parts on Windows. node-waf is still the default and I didn't touch the Windows.js fallback files, but presumably you could phase those out at this point.

Cheers!
