### PR TITLE
Add loadbalancer and proxy support with X-Forwarded-Proto

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -342,7 +342,7 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
   }
 
   // verify client
-  var location = (socket.encrypted ? 'wss' : 'ws') + '://' + req.headers.host + req.url
+  var location = ((req.headers['x-forwarded-proto'] === 'https' || socket.encrypted) ? 'wss' : 'ws') + '://' + req.headers.host + req.url
     , origin = req.headers['origin'];
   if (typeof this.options.verifyClient == 'function') {
     var info = {


### PR DESCRIPTION
When using ws with a forwarding proxy (e.g. stunnel) to add SSL support (i.e. not through a https server instance), the "Location" header is wrong, as Node thinks it's a http connection.

With this patch, the forwarding proxy can set the "X-Forwarded-Proto: https" header, and ws knows the "Location" must start with "wss".
