### PR TITLE
Fixes commander dependency and adds node >= 0.7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=0.4.0"
   },
   "dependencies": {
-    "commander": "0.5.0",
+    "commander": "0.5.x",
     "options": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
`commander@0.5.0` does not have node >= 0.7 support, causing `ws` and libraries that depend on `ws` to be incompatible as well. This should fix it.
