### PR TITLE
add "clientTracking" option to disable client references

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -26,7 +26,8 @@ function WebSocketServer(options, callback) {
     verifyClient: null,
     path: null,
     noServer: false,
-    disableHixie: false
+    disableHixie: false,
+    clientTracking: true
   }).merge(options);
   if (!options.value.port && !options.value.server && !options.value.noServer) {
     throw new TypeError('`port` or a `server` must be provided');
@@ -228,14 +229,16 @@ function completeUpgrade(req, socket, upgradeHead, version, cb) {
     protocolVersion: version,
     protocol: protocol
   });
-  this._clients.push(client);
-  var self = this;
-  client.on('close', function() {
-    var index = self._clients.indexOf(client);
-    if (index != -1) {
-      self._clients.splice(index, 1);
-    }
-  });
+  if (this.options.clientTracking) {
+    this._clients.push(client);
+    var self = this;
+    client.on('close', function() {
+      var index = self._clients.indexOf(client);
+      if (index != -1) {
+        self._clients.splice(index, 1);
+      }
+    });
+  }
   cb(client);
 }
 
@@ -302,13 +305,15 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
         protocolVersion: 'hixie-76',
         protocol: protocol
       });
-      self._clients.push(client);
-      client.on('close', function() {
-        var index = self._clients.indexOf(client);
-        if (index != -1) {
-          self._clients.splice(index, 1);
-        }
-      });
+      if (this.options.clientTracking) {
+        self._clients.push(client);
+        client.on('close', function() {
+          var index = self._clients.indexOf(client);
+          if (index != -1) {
+            self._clients.splice(index, 1);
+          }
+        });
+      }
       cb(client);
     }
 

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -194,6 +194,18 @@ describe('WebSocketServer', function() {
       });
     });
 
+    it('can be disabled', function(done) {
+      var wss = new WebSocketServer({port: ++port, clientTracking: false}, function() {
+        wss.clients.length.should.eql(0);
+        var ws = new WebSocket('ws://localhost:' + port);
+      });
+      wss.on('connection', function(client) {
+        wss.clients.length.should.eql(0);
+        wss.close();
+        done();
+      });
+    });
+
     it('is updated when client terminates the connection', function(done) {
       var ws;
       var wss = new WebSocketServer({port: ++port}, function() {


### PR DESCRIPTION
Client tracking should be optional, as it consumes quite some memory if enabled.
