### PR TITLE
Add "error" and "timeout" handlers before handshake

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -499,7 +499,10 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
     if (self.readyState == WebSocket.CLOSED) return;
     self._readyState = WebSocket.CLOSED;
     if (socket) {
-      removeAllListeners(socket);
+      socket.removeListener('end', closeSocket);
+      socket.removeListener('close', closeSocket);
+      socket.removeListener('data', firstHandler);
+      socket.removeListener('data', realHandler);
       socket.end();
       self._socket = null;
       socket = null;
@@ -516,7 +519,6 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
     self.emit('close', self._closeCode || 1000, self._closeMessage || '');
     removeAllListeners(self);
   }
-  socket.on('timeout', closeSocket);
   socket.on('end', closeSocket);
   socket.on('close', closeSocket);
 

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -139,14 +139,6 @@ WebSocketServer.prototype.handleUpgrade = function(req, socket, upgradeHead, cb)
     if (u && u.pathname !== this.options.path) return;
   }
 
-  socket.on('error', function() {
-    socket.destroy();
-  });
-
-  socket.on('timeout', function() {
-    socket.destroy();
-  });
-
   if (typeof req.headers.upgrade === 'undefined' || req.headers.upgrade.toLowerCase() !== 'websocket') {
     abortConnection(socket, 400, 'Bad Request');
     return;


### PR DESCRIPTION
The application did not have the chance to add those handlers to the socket, and if the handshake's 'write' fails the server crashes.

Also, despite 'socket.setTimeout(0)' I observed socket timeouts, maybe they happen during the (unfinished) handshakes, so we should catch them and destroy the socket.
