### PR TITLE
Fix hixie close frame handling and allow empty messages

### DIFF
--- a/lib/Sender.hixie.js
+++ b/lib/Sender.hixie.js
@@ -35,7 +35,6 @@ Sender.prototype.send = function(data, options, cb) {
     this.error('hixie websockets do not support binary');
     return;
   }
-  if (data == '') return;
 
   var length = Buffer.byteLength(data)
     , buffer = new Buffer(2 + length);
@@ -58,7 +57,7 @@ Sender.prototype.send = function(data, options, cb) {
  */
 
 Sender.prototype.close = function(code, data, mask, cb) {
-  var buffer = new Buffer([0x0, 0xff]);
+  var buffer = new Buffer([0xff, 0x00]);
   try {
     this.socket.write(buffer, 'binary', cb);
   } catch (e) {

--- a/test/Sender.hixie.test.js
+++ b/test/Sender.hixie.test.js
@@ -21,15 +21,14 @@ describe('Sender', function() {
       });
     });
 
-    it('silently ignores empty messages (which would be close frames)', function(done) {
+    it('frames and sends an empty message', function(done) {
       var socket = {
         write: function(data, encoding, cb) {
-          done(new Error('should not write this empty message'));
+          done();
         }
       };
       var sender = new Sender(socket, {});
       sender.send('', {}, function() {});
-      done();
     });
 
     it('throws an exception for binary data', function(done) {
@@ -57,7 +56,7 @@ describe('Sender', function() {
       };
       var sender = new Sender(socket, {});
       sender.close(null, null, null, function() {
-        received.toString('utf8').should.eql('\u0000\ufffd');
+        received.toString('utf8').should.eql('\ufffd\u0000');
         done();
       });
     });


### PR DESCRIPTION
Hixie close frames are [0xff, 0x00], not [0x00, 0xff], according to the spec. 

This fix changes the hixie sender and the test to send the right frame, and to allow empty messages (which are [0x00, 0xff]).
