### PR TITLE
Remove Object.defineProperties and set properties directly

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -38,31 +38,10 @@ var isNodeV4 = /^v0\.4/.test(process.version);
 function WebSocket(address, options) {
   var self = this;
 
-  var realEmit = this.emit;
-  this.emit = function(event) {
-    if (event == 'error') delete self._queue;
-    realEmit.apply(this, arguments);
-  }
-
-  Object.defineProperty(this, '_socket', { writable: true, value: null });
-  Object.defineProperty(this, '_bytesReceived', { writable: true, value: null });
-  Object.defineProperty(this, 'bytesReceived', {
-    get: function() {
-      return self._bytesReceived;
-    }
-  });
-  Object.defineProperty(this, 'readyState', {
-    get: function() {
-      return self._readyState;
-    }
-  });
-  Object.defineProperty(this, 'supports', {
-    get: function() {
-      return {
-        'binary': self.protocolVersion != 'hixie-76'
-      };
-    }
-  });
+  this._socket = null;
+  this.bytesReceived = 0;
+  this.readyState = null;
+  this.supports = {};
 
   if (Object.prototype.toString.call(address) == '[object Array]') {
     initAsServerClient.apply(this, address.concat(options));
@@ -80,19 +59,10 @@ util.inherits(WebSocket, events.EventEmitter);
  * Ready States
  */
 
-(function() {
-  var readyStates = {
-      CONNECTING: 0
-    , OPEN: 1
-    , CLOSING: 2
-    , CLOSED: 3
-  };
-
-  for (var state in readyStates) {
-    if (!readyStates.hasOwnProperty(state)) continue;
-    Object.defineProperty(WebSocket, state, { enumerable: true, value: readyStates[state]});
-  }
-})();
+WebSocket.CONNECTING = 0;
+WebSocket.OPEN = 1;
+WebSocket.CLOSING = 2;
+WebSocket.CLOSED = 3;
 
 /**
  * Gracefully closes the connection, after sending a description message to the server
@@ -104,11 +74,11 @@ util.inherits(WebSocket, events.EventEmitter);
 WebSocket.prototype.close = function(code, data) {
   if (this.readyState == WebSocket.CLOSING || this.readyState == WebSocket.CLOSED) return;
   if (this.readyState == WebSocket.CONNECTING) {
-    this._readyState = WebSocket.CLOSED;
+    this.readyState = WebSocket.CLOSED;
     return;
   }
   try {
-    this._readyState = WebSocket.CLOSING;
+    this.readyState = WebSocket.CLOSING;
     this._closeCode = code;
     this._closeMessage = data;
     var mask = !this._isServer;
@@ -116,6 +86,7 @@ WebSocket.prototype.close = function(code, data) {
     this.terminate();
   }
   catch (e) {
+    delete this._queue;
     this.emit('error', e);
   }
 }
@@ -257,7 +228,10 @@ WebSocket.prototype.stream = function(options, cb) {
     }
     catch (e) {
       if (typeof cb == 'function') cb(e);
-      else self.emit('error', e);
+      else {
+        delete self._queue;
+        self.emit('error', e);
+      }
     }
   }
   process.nextTick(cb.bind(null, null, send));
@@ -272,7 +246,7 @@ WebSocket.prototype.stream = function(options, cb) {
 WebSocket.prototype.terminate = function() {
   if (this._socket) this._socket.end();
   else if (this.readyState == WebSocket.CONNECTING) {
-    this._readyState = WebSocket.CLOSED;
+    this.readyState = WebSocket.CLOSED;
   }
 };
 
@@ -363,23 +337,12 @@ function MessageEvent(dataArg) {
   }).merge(options);
 
   // expose state properties
-  Object.defineProperty(this, 'protocol', {
-    value: options.value.protocol,
-    configurable: false,
-    enumerable: true
-  });
-  Object.defineProperty(this, 'protocolVersion', {
-    value: options.value.protocolVersion,
-    configurable: false,
-    enumerable: true
-  });
-  Object.defineProperty(this, 'upgradeReq', {
-    value: req,
-    configurable: false,
-    enumerable: true
-  });
-  Object.defineProperty(this, '_readyState', { writable: true, value: WebSocket.CONNECTING });
-  Object.defineProperty(this, '_isServer', { writable: false, value: true });
+  this.protocol = options.value.protocol;
+  this.protocolVersion = options.value.protocolVersion;
+  this.supports.binary = (this.protocolVersion != 'hixie-76');
+  this.upgradeReq = req;
+  this.readyState = WebSocket.CONNECTING;
+  this._isServer = true;
 
   // establish connection
   if (options.value.protocolVersion == 'hixie-76') establishConnection.call(this, ReceiverHixie, SenderHixie, socket, upgradeHead);
@@ -402,18 +365,10 @@ function initAsClient(address, options) {
   var httpObj = (serverUrl.protocol === 'wss:' || serverUrl.protocol === 'https:') ? https : http;
 
   // expose state properties
-  Object.defineProperty(this, '_isServer', { writable: false, value: false });
-  Object.defineProperty(this, 'url', {
-    writable: false,
-    configurable: false,
-    enumerable: true,
-    value: address
-  });
-  Object.defineProperty(this, 'protocolVersion', {
-    value: options.value.protocolVersion,
-    configurable: false,
-    enumerable: true
-  });
+  this._isServer = false;
+  this.url = address;
+  this.protocolVersion = options.value.protocolVersion;
+  this.supports.binary = (this.protocolVersion != 'hixie-76');
 
   // begin handshake
   var key = new Buffer(options.value.protocolVersion + '-' + Date.now()).toString('base64');
@@ -457,6 +412,7 @@ function initAsClient(address, options) {
   var self = this;
   var req = httpObj.request(requestOptions);
   (isNodeV4 ? agent : req).on('error', function(error) {
+    delete self._queue;
     self.emit('error', error);
   });
   (isNodeV4 ? agent : req).once('upgrade', function(res, socket, upgradeHead) {
@@ -469,6 +425,7 @@ function initAsClient(address, options) {
     }
     var serverKey = res.headers['sec-websocket-accept'];
     if (typeof serverKey == 'undefined' || serverKey !== expectedServerKey) {
+      delete self._queue;
       self.emit('error', 'invalid server key');
       removeAllListeners(self);
       socket.end();
@@ -484,7 +441,7 @@ function initAsClient(address, options) {
   });
 
   req.end();
-  Object.defineProperty(this, '_readyState', { writable: true, value: WebSocket.CONNECTING });
+  this.readyState = WebSocket.CONNECTING;
 }
 
 function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
@@ -497,7 +454,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   // socket cleanup handlers
   function closeSocket() {
     if (self.readyState == WebSocket.CLOSED) return;
-    self._readyState = WebSocket.CLOSED;
+    self.readyState = WebSocket.CLOSED;
     if (socket) {
       removeAllListeners(socket);
       socket.end();
@@ -522,20 +479,20 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   // ensure that the upgradeHead is added to the receiver
   function firstHandler(data) {
     if (upgradeHead && upgradeHead.length > 0) {
-      self._bytesReceived += upgradeHead.length;
+      self.bytesReceived += upgradeHead.length;
       var head = upgradeHead;
       upgradeHead = null;
       receiver.add(head);
     }
     dataHandler = realHandler;
     if (data) {
-      self._bytesReceived += data.length;
+      self.bytesReceived += data.length;
       receiver.add(data);
     }
   }
   // subsequent packets are pushed straight to the receiver
   function realHandler(data) {
-    if (data) self._bytesReceived += data.length;
+    if (data) self.bytesReceived += data.length;
     receiver.add(data);
   }
   var dataHandler = firstHandler;
@@ -574,15 +531,17 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
     if (typeof errorCode !== 'undefined') {
       self.close(errorCode, '', {mask: !self._isServer});
     }
+    delete self._queue;
     self.emit('error', reason, errorCode);
   });
 
   // finalize the client
-  Object.defineProperty(this, '_sender', { value: new SenderClass(socket), configurable: true });
+  this._sender = new SenderClass(socket);
   this._sender.on('error', function(error) {
+    delete self._queue;
     self.emit('error', error);
   });
-  this._readyState = WebSocket.OPEN;
+  this.readyState = WebSocket.OPEN;
   this.emit('open');
 }
 
@@ -603,7 +562,10 @@ function sendStream(instance, stream, options, cb) {
   stream.on('data', function(data) {
     if (instance.readyState != WebSocket.OPEN) {
       if (typeof cb == 'function') cb(new Error('not opened'));
-      else instance.emit('error', new Error('not opened'));
+      else {
+        delete instance._queue;
+        instance.emit('error', new Error('not opened'));
+      }
       return;
     }
     options.fin = false;
@@ -612,7 +574,10 @@ function sendStream(instance, stream, options, cb) {
   stream.on('end', function() {
     if (instance.readyState != WebSocket.OPEN) {
       if (typeof cb == 'function') cb(new Error('not opened'));
-      else instance.emit('error', new Error('not opened'));
+      else {
+        delete instance._queue;
+        instance.emit('error', new Error('not opened'));
+      }
       return;
     }
     options.fin = true;

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -36,20 +36,15 @@ function WebSocketServer(options, callback) {
   var self = this;
 
   if (options.value.port) {
-    Object.defineProperty(this, '_server', {
-      configurable: true,
-      value: http.createServer(function (req, res) {
-        res.writeHead(200, {'Content-Type': 'text/plain'});
-        res.end('Not implemented');
-      })
+    this._server = http.createServer(function (req, res) {
+      res.writeHead(200, {'Content-Type': 'text/plain'});
+      res.end('Not implemented');
     });
     this._server.listen(options.value.port, options.value.host || '127.0.0.1', callback);
-    Object.defineProperty(this, '_closeServer', {
-      value: function() { self._server.close(); }
-    });
+    this._closeServer = function() { self._server.close(); };
   }
   else if (options.value.server) {
-    Object.defineProperty(this, '_server', { value: options.value.server, configurable: true });
+    this._server = options.value.server;
     if (options.value.path) {
       // take note of the path, to avoid collisions when multiple websocket servers are
       // listening on the same http server
@@ -57,7 +52,7 @@ function WebSocketServer(options, callback) {
         throw new Error('two instances of WebSocketServer cannot listen on the same http server path');
       }
       if (typeof this._server._webSocketPaths !== 'object') {
-        Object.defineProperty(this._server, '_webSocketPaths', { value: {}, configurable: true });
+        this._server._webSocketPaths = {};
       }
       this._server._webSocketPaths[options.value.path] = 1;
     }
@@ -74,12 +69,9 @@ function WebSocketServer(options, callback) {
     });
   }
 
-  Object.defineProperty(this, 'options', { value: options.value });
-  Object.defineProperty(this, 'path', { value: options.value.path });
-  Object.defineProperty(this, '_clients', { value: [] });
-  Object.defineProperty(this, 'clients', {
-    get: function() { return self._clients; }
-  });
+  this.options = options.value;
+  this.path = options.value.path;
+  this.clients = [];
 }
 
 /**
@@ -98,8 +90,8 @@ WebSocketServer.prototype.close = function(code, data) {
   // terminate all associated clients
   var error = null;
   try {
-    for (var i = 0, l = this._clients.length; i < l; ++i) {
-      this._clients[i].terminate();
+    for (var i = 0, l = this.clients.length; i < l; ++i) {
+      this.clients[i].terminate();
     }
   }
   catch (e) {
@@ -231,12 +223,12 @@ function completeUpgrade(req, socket, upgradeHead, version, cb) {
   });
 
   if (this.options.clientTracking) {
-    this._clients.push(client);
+    this.clients.push(client);
     var self = this;
     client.on('close', function() {
-      var index = self._clients.indexOf(client);
+      var index = self.clients.indexOf(client);
       if (index != -1) {
-        self._clients.splice(index, 1);
+        self.clients.splice(index, 1);
       }
     });
   }
@@ -307,11 +299,11 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
         protocol: protocol
       });
       if (this.options.clientTracking) {
-        self._clients.push(client);
+        self.clients.push(client);
         client.on('close', function() {
-          var index = self._clients.indexOf(client);
+          var index = self.clients.indexOf(client);
           if (index != -1) {
-            self._clients.splice(index, 1);
+            self.clients.splice(index, 1);
           }
         });
       }

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -146,12 +146,10 @@ describe('WebSocket', function() {
 
     Object.keys(readyStates).forEach(function(state) {
       describe('.' + state, function() {
-        it('is enumerable and immutable property', function() {
+        it('is enumerable property', function() {
           var propertyDescripter = Object.getOwnPropertyDescriptor(WebSocket, state)
           assert.equal(readyStates[state], propertyDescripter.value);
-          assert.equal(false, propertyDescripter.writable);
           assert.equal(true, propertyDescripter.enumerable);
-          assert.equal(false, propertyDescripter.configurable);
         });
       });
     });


### PR DESCRIPTION
Fixes #43 and makes code clearer and simpler.

I'm aware that read-only properties are nice, but 

1) even in the node core libraries, properties are set directly. If anyone overwrites them, well...

2) Object.defineProperty seems to break garbage collection (see #43 and http://code.google.com/p/v8/issues/detail?id=2073)

3) The code is much cleaner with properties directly set. They are still enumerable (see tests). 
