### PR TITLE
Makefile: use node-gyp instead of node-waf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ ALL_TESTS = $(shell find test/ -name '*.test.js')
 ALL_INTEGRATION = $(shell find test/ -name '*.integration.js')
 
 all:
-	node-waf configure build
+	node-gyp configure build
 
 clean:
-	node-waf clean
+	node-gyp clean
 
 run-tests:
 	@./node_modules/.bin/mocha \


### PR DESCRIPTION
When installing with npm, npm will use its bundled
version of `node-gyp` to compile the module.

When running make by hand, you'll have to have
node-gyp installed globally:

```
npm install -g node-gyp
```

Cheers!
