### PR TITLE
Sender.hixie is given data of type 'Buffer' while expecting type 'string'

### DIFF
--- a/lib/Sender.hixie.js
+++ b/lib/Sender.hixie.js
@@ -36,11 +36,11 @@ Sender.prototype.send = function(data, options, cb) {
     return;
   }
 
-  var length = Buffer.byteLength(data)
+  var length = (typeof data === 'string') ? Buffer.byteLength(data) : data.length
     , buffer = new Buffer(2 + length);
 
   buffer.write('\x00', 'binary');
-  buffer.write(data, 1, 'utf8');
+  (typeof data === 'string') ? buffer.write(data, 1, 'utf8') : data.copy(buffer,1,0);
   buffer.write('\xff', 1 + length, 'binary');
 
   try {


### PR DESCRIPTION
When using Safari (5.1.6),  Sender.hixie raises a TypeError in send method, expecting parameter `data` to be a string while it is a `Buffer`. 

```
var length = Buffer.byteLength(data)
                      ^
TypeError: Argument must be a string
```

I just added 2 tests to support both data types, `string` and `Buffer`.
