### PR TITLE
Check socket status before writing handshake response (may fix #74)

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -287,6 +287,7 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
       if (typeof protocol != 'undefined') headers.push('Sec-WebSocket-Protocol: ' + protocol);
       if (typeof origin != 'undefined') headers.push('Sec-WebSocket-Origin: ' + origin);
 
+      if (! socket.writable) return;
       socket.setTimeout(0);
       socket.setNoDelay(true);
       try {


### PR DESCRIPTION
I still don't get it, but my server ran into this if-statement twice this day, when it would otherwise crash because of #74.
