### PR TITLE
update `should` version to 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "mocha": "0.8.x",
-    "should": "0.4.2",
+    "should": "0.6.3",
     "expect.js": "0.1.2",
     "benchmark": "0.3.x",
     "tinycolor": "0.x",


### PR DESCRIPTION
When I run tests with node 0.7.9,  some are failed.

```
✖ 48 of 158 tests failed:
```

For example:

```
 21) WebSocketServer #close cleans up websocket data on a precreated server:
     AssertionError: expected { '0': 'o', '1': 'b', '2': 'j', '3': 'e', '4': 'c', '5': 't' } to equal 'object'
      at Object.eql (/Users/tricknotes/Documents/dev/ws/node_modules/should/lib/should.js:280:10)
      at Server.<anonymous> (/Users/tricknotes/Documents/dev/ws/test/WebSocketServer.test.js:201:45)
      at Server.g (events.js:184:14)
      at Server.emit (events.js:84:17)
      at net.js:895:10
      at EventEmitter._tickCallback (node.js:238:9)
```

This cause is that comparing by should.js 0.4.2 is failed in node 0.7.x.

So I updated `should` version and confirmed that succeeded.
