### PR TITLE
Support the server listening on all interfaces

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -40,7 +40,7 @@ function WebSocketServer(options, callback) {
       res.writeHead(200, {'Content-Type': 'text/plain'});
       res.end('Not implemented');
     });
-    this._server.listen(options.value.port, options.value.host || '127.0.0.1', callback);
+    this._server.listen(options.value.port, options.value.host, callback);
     this._closeServer = function() { self._server.close(); };
     this._server.once('listening', function() { self.emit('listening'); });
   }


### PR DESCRIPTION
This patch enables the ability to pass down undefined/null to the node HTTP server listen method. Without this it's impossible to listen on all interfaces. The default value of localhost is already specified in the options block above, but this || makes it impossible to ever set 'host' equal to undefined or null.
