### PR TITLE
mocha 1.2.1 actually suffices

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "options": "latest"
   },
   "devDependencies": {
-    "mocha": "~1.2.2",
+    "mocha": "~1.2.1",
     "should": "0.6.x",
     "expect.js": "0.1.x",
     "benchmark": "0.3.x",


### PR DESCRIPTION
seems 1.2.1 actually included the change, could've sworn i tried it with that version though
