### PR TITLE
Don't force npm to use "node install.js"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "wscat": "./bin/wscat"
   },
   "scripts": {
-    "test": "make test",
-    "install": "node install.js"
+    "test": "make test"
   },
   "engines": {
     "node": ">=0.4.0"


### PR DESCRIPTION
This is for systems that have "nodejs" as a command and not "node"
