### PR TITLE
unhandled exception if socket closes and 'error' is emitted

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -502,6 +502,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   // socket cleanup handlers
   socket.on('end', cleanupWebsocketResources.bind(this));
   socket.on('close', cleanupWebsocketResources.bind(this));
+  socket.on('error', cleanupWebsocketResources.bind(this));
 
   // ensure that the upgradeHead is added to the receiver
   function firstHandler(data) {


### PR DESCRIPTION
The following stack trace shows the exception thrown if the socket fails with ECONNABORTED.  

Gist that reproduces the error: https://gist.github.com/3219285

I'm not 100% confident that this fix is in the right place.  The uncaught exception appears to be from an unhandled 'error' event from eventemitter. This can occur if Socket._write (net.js:558:19) fails and Socket::_destroy() is called. If there is no callback specified to Socket::_destroy, then the 'error' event is emitted on next tick, which also bypasses any immediate try/catch blocks in Sender::frameAndSend().

events.js:66
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: write ECONNABORTED
    at errnoException (net.js:782:11)
    at Socket._write (net.js:558:19)
    at Socket.write (net.js:517:15)
    at Sender.frameAndSend (c:\mydir\node-ws-exception\node_modules\ws\lib\Sender.js:146:22)
    at Sender.close (c:\mydir\node-ws-exception\node_modules\ws\lib\Sender.js:43:8)
    at WebSocket.close (c:\mydir\node-ws-exception\node_modules\ws\lib\WebSocket.js:89:18)
    at Timer.<anonymous> (c:\mydir\node-ws-exception\client.js:35:20)
    at Timer.exports.setInterval.timer.ontimeout (timers.js:234:14)
