### PR TITLE
clear failsafe cleanup timeout once cleanup is called

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -264,7 +264,7 @@ WebSocket.prototype.terminate = function() {
     // Add a timeout to ensure that the connection is completely
     // cleaned up within 30 seconds, even if the clean close procedure
     // fails for whatever reason
-    setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
+    this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
   }
   else if (this.readyState == WebSocket.CONNECTING) {
     cleanupWebsocketResources.call(this, true);
@@ -615,6 +615,9 @@ function cleanupWebsocketResources(error) {
   if (this.readyState == WebSocket.CLOSED) return;
   var emitClose = this.readyState != WebSocket.CONNECTING;
   this.readyState = WebSocket.CLOSED;
+
+  clearTimeout(this._closeTimer);
+
   if (this._socket) {
     removeAllListeners(this._socket);
     // catch all socket error after removing all standard handlers


### PR DESCRIPTION
If `WebSocket.close` is the last thing before `process.on('exit')` you will have to wait 30 seconds, before the process exits. That is quite frustrating and seams unnecessary.

_PS: could this land in `0.4.x` ?_
