### PR TITLE
Add client-cert support for websocket clients

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -353,7 +353,13 @@ function initAsClient(address, options) {
   options = new Options({
     origin: null,
     protocolVersion: protocolVersion,
-    protocol: null
+    protocol: null,
+	key: null,
+	cert: null,
+	pfx: null,
+	passphrase: null,
+	ciphers: null,
+	rejectUnauthorized: null
   }).merge(options);
   if (options.value.protocolVersion != 8 && options.value.protocolVersion != 13) {
     throw new Error('unsupported protocol version');
@@ -398,14 +404,35 @@ function initAsClient(address, options) {
       'Sec-WebSocket-Key': key
     }
   };
+  
+  if (isNodeV4) {
+    requestOptions.path = (serverUrl.pathname || '/') + (serverUrl.search || '');
+  }
+  else requestOptions.path = serverUrl.path || '/';
+
+  if (options.value.key || options.value.cert || options.value.ca || options.value.pfx || options.value.passphrase || options.value.ciphers || options.value.rejectUnauthorized)
+  {
+    if (isNodeV4) {
+	  throw new Error("Client SSL certificate not supported on Node 4.x");
+	}
+	
+    requestOptions.key = options.value.key;
+    requestOptions.cert = options.value.cert;
+    requestOptions.pfx = options.value.pfx;
+    requestOptions.passphrase = options.value.passphrase;
+    requestOptions.ciphers = options.value.ciphers;
+    requestOptions.rejectUnauthorized = options.value.rejectUnauthorized;
+	
+	agent = new httpObj.Agent(requestOptions);
+  }
+  
   if (options.value.protocol) {
     requestOptions.headers['Sec-WebSocket-Protocol'] = options.value.protocol;
   }
-  if (isNodeV4) {
-    requestOptions.path = (serverUrl.pathname || '/') + (serverUrl.search || '');
+
+  if (agent) {  
     requestOptions.agent = agent;
   }
-  else requestOptions.path = serverUrl.path || '/';
   if (isUnixSocket) {
     requestOptions.socketPath = serverUrl.pathname;
   }


### PR DESCRIPTION
Per https://github.com/einaros/ws/issues/123

You cannot currently specify a cert/key (or pfx + password) to pass through to the underlying https connection.  This pull request adds this support, at least as far back as Node 0.6 (I don't have a running environment to test prior versions).  Due to some old Node 0.4 compatibility code in there (with regards to using a custom Agent) I wasn't sure how to meld the two together.
