### PR TITLE
Allow application selection of subprotocol value

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -24,6 +24,7 @@ function WebSocketServer(options, callback) {
     port: null,
     server: null,
     verifyClient: null,
+    handleProtocols: null,
     path: null,
     noServer: false,
     disableHixie: false,
@@ -169,6 +170,9 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     return;
   }
 
+  // verify protocol
+  var protocols = req.headers['sec-websocket-protocol'];
+
   // verify client
   var origin = version < 13 ?
     req.headers['sec-websocket-origin'] :
@@ -176,8 +180,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
 
   // handler to call when the connection sequence completes
   var self = this;
-  var completeHybiUpgrade = function() {
-     var protocol = req.headers['sec-websocket-protocol'];
+  var completeHybiUpgrade2 = function(protocol) {
 
     // calc key
     var key = req.headers['sec-websocket-key'];
@@ -230,6 +233,25 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     cb(client);
   }
 
+  // optionally call external protocol selection handler
+  var completeHybiUpgrade1 = function() {
+    // choose from the sub-protocols
+    if (typeof self.options.handleProtocols == 'function') {
+        self.options.handleProtocols(protocols, function(result, protocol) {
+          if (!result) abortConnection(socket, 404, 'Unauthorized')
+          else completeHybiUpgrade2(protocol);
+        });
+        return;
+    } else {
+        if (typeof protocols !== 'undefined') {
+            completeHybiUpgrade2(protocols.split(',')[0]);
+        }
+        else {
+            completeHybiUpgrade2();
+        }
+    }
+  }
+
   // optionally call external client verification handler
   if (typeof this.options.verifyClient == 'function') {
     var info = {
@@ -240,7 +262,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     if (this.options.verifyClient.length == 2) {
       this.options.verifyClient(info, function(result) {
         if (!result) abortConnection(socket, 401, 'Unauthorized')
-        else completeHybiUpgrade();
+        else completeHybiUpgrade1();
       });
       return;
     }
@@ -250,7 +272,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     }
   }
 
-  completeHybiUpgrade();
+  completeHybiUpgrade1();
 }
 
 function handleHixieUpgrade(req, socket, upgradeHead, cb) {


### PR DESCRIPTION
If the handleProtocols attribute is set in the options for
WebSocketServer then this function will be called to select
a subprotocol otherwise the first subprotocol sent by the client will
be returned.

The handleProtocols function takes two arguments: a list of subprotocol
strings and a callback. The callback takes two arguments: the result
and the selected subprotocol. The handleProtocols handler routine
should select a subprotocol from the subprotocols first argument based
on whatever criteria the application uses and call the callback with
first argument set to true and the selected subprotocol string as the
second argument. If the application determines that the client
subprotocol list does not have a valid subprotocol then it should call
the callback with a false first argument. This will cause the
handshake to fail with a 404 (not found) error.
