### PR TITLE
Removed unused arguments from WebSocketServer#close

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -88,7 +88,7 @@ util.inherits(WebSocketServer, events.EventEmitter);
  * @api public
  */
 
-WebSocketServer.prototype.close = function(code, data) {
+WebSocketServer.prototype.close = function() {
   // terminate all associated clients
   var error = null;
   try {


### PR DESCRIPTION
The WebSocketServer#close() function receives a code and data argument but never uses them.
