### PR TITLE
Emit 'listening' also with custom http server.

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -42,7 +42,6 @@ function WebSocketServer(options, callback) {
     });
     this._server.listen(options.value.port, options.value.host, callback);
     this._closeServer = function() { self._server.close(); };
-    this._server.once('listening', function() { self.emit('listening'); });
   }
   else if (options.value.server) {
     this._server = options.value.server;
@@ -58,6 +57,7 @@ function WebSocketServer(options, callback) {
       this._server._webSocketPaths[options.value.path] = 1;
     }
   }
+  this._server.once('listening', function() { self.emit('listening'); });
 
   if (typeof this._server != 'undefined') {
     this._server.on('error', function(error) {


### PR DESCRIPTION
I don't know if that's on purpose, but when you provide a server instance to the `WebSocketServer` constructor, the event `'listening'` is not emitted, which is annoying if you want to work transparently (i.e., without knowing how it was created) with an instance of `WebSocketServer`. This pull request fixes that.
