### PR TITLE
add browser field to package.json

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,5 @@
+/// shim for browser packaging
+
+module.exports = function() {
+  return global.WebSocket || global.MozWebSocket;
+}

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "expect.js": "0.1.x",
     "benchmark": "0.3.x",
     "ansi": "latest"
+  },
+  "browser": {
+    "./index.js": "./lib/browser.js"
   }
 }


### PR DESCRIPTION
When packaging this module for client side delivery, the browser field
in package.json provides a hint to the package tool about which files to
replace with client targeted counterparts.

This is currently supported by the following bundle tool:
https://github.com/shtylman/node-script

And I hope to get wider adoption of this practice. The goal is to provide a sensible way for module authors to make their packages cross environment. npm modules have the cool property of being able to work in server and client environments and this eases the burden on consumers of your module (like engine.io). Since your module aims to replicate the browser side api on the server, the browser portion simply provides the ws object.
