### PR TITLE
No masking of frames from server in wscat

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -115,7 +115,7 @@ else if (program.listen) {
   });
   wsConsole.on('line', function(data) {
     if (ws) {
-      ws.send(data, {mask: true});
+      ws.send(data, {mask: false});
       wsConsole.prompt();
     }
   });


### PR DESCRIPTION
With this change it works in Chrome 25.0.1364.29 dev and 26.0.1384.2 canary.
