### PR TITLE
Fix for slab buffer retention, leading to large memory consumption

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -64,7 +64,11 @@ function WebSocketServer(options, callback) {
       self.emit('error', error)
     });
     this._server.on('upgrade', function(req, socket, upgradeHead) {
-      self.handleUpgrade(req, socket, upgradeHead, function(client) {
+      //copy upgradeHead to avoid retention of large slab buffers used in node core
+      var head = new Buffer(upgradeHead.length);
+      upgradeHead.copy(head); 
+
+      self.handleUpgrade(req, socket, head, function(client) {
         self.emit('connection'+req.url, client);
         self.emit('connection', client);
       });


### PR DESCRIPTION
See: https://github.com/jmatthewsr-ms/node-slab-memory-issues
