### PR TITLE
Allow passing arbitrary headers

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -393,7 +393,8 @@ function initAsClient(address, options) {
     origin: null,
     protocolVersion: protocolVersion,
     host: null,
-    protocol: null
+    protocol: null,
+    headers: null
   }).merge(options);
   if (options.value.protocolVersion != 8 && options.value.protocolVersion != 13) {
     throw new Error('unsupported protocol version');
@@ -443,6 +444,14 @@ function initAsClient(address, options) {
   }
   if (options.value.host) {
     requestOptions.headers['Host'] = options.value.host;
+  }
+
+  if (options.value.headers) {
+    for (var key in options.value.headers) {
+      if (!requestOptions.headers.hasOwnProperty(key)) {
+        requestOptions.headers[key] = options.value.headers[key];
+      }
+    }
   }
 
   if (isNodeV4) {


### PR DESCRIPTION
We are using ws library for our websocket proxy server in openshift - https://github.com/openshift/origin-server/tree/master/node-proxy

With the way things are today, there isn't a way to pass down headers such as "Cookie".
Adding this code will make it easier to use ws within proxy servers.
