### PR TITLE
Don't use byteLength when sending ArrayBufferView

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -103,7 +103,11 @@ Sender.prototype.frameAndSend = function(opcode, data, finalFragment, maskData, 
 
   if (!Buffer.isBuffer(data)) {
     canModifyData = true;
-    data = (data && typeof data.buffer !== 'undefined') ? getArrayBuffer(data.buffer) : new Buffer(data);
+    if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
+      data = getArrayBuffer(data);
+    } else {
+      data = new Buffer(data);
+    }
   }
 
   var dataLength = data.length
@@ -201,8 +205,10 @@ function writeUInt32BE(value, offset) {
   this[offset+3] = value & 0xff;
 }
 
-function getArrayBuffer(array) {
-  var l = array.byteLength
+function getArrayBuffer(data) {
+  // data is either an ArrayBuffer or ArrayBufferView.
+  var array = data.buffer || data
+    , l = data.byteLength || data.length
     , buffer = new Buffer(l);
   for (var i = 0; i < l; ++i) {
     buffer[i] = array[i];


### PR DESCRIPTION
Currently the send code is using the byteLength property of the ArrayBuffer object when prepping the internal Node Buffer to send. This means if you're passing in an ArrayBufferView representing a smaller portion of the ArrayBuffer it sends more than necessary.

I've changed it to use byteLength if passed a raw ArrayBuffer, and to use length if working with an ArrayBufferView.
