### PR TITLE
fix browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,5 @@
     "benchmark": "0.3.x",
     "ansi": "latest"
   },
-  "browser": {
-    "./index.js": "./lib/browser.js"
-  }
+  "browser": "./lib/browser.js"
 }


### PR DESCRIPTION
When specifying an alternate main entry point, it is sufficient 
to just use a string for the browser field.
