### PR TITLE
allow passing custom headers in upgrade-request

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -393,7 +393,8 @@ function initAsClient(address, options) {
     origin: null,
     protocolVersion: protocolVersion,
     host: null,
-    protocol: null
+    protocol: null,
+    headers: null
   }).merge(options);
   if (options.value.protocolVersion != 8 && options.value.protocolVersion != 13) {
     throw new Error('unsupported protocol version');
@@ -438,8 +439,8 @@ function initAsClient(address, options) {
       'Sec-WebSocket-Key': key
     }
   };
-  if (options.value.headers) {
-    var optHeaders = options.value.headers;
+  var optHeaders = options.value.headers;
+  if (optHeaders) {
     for (var headerKey in optHeaders) {
       if (!optHeaders.hasOwnProperty(headerKey)) continue;
       requestOptions.headers[headerKey] = optHeaders[headerKey];


### PR DESCRIPTION
// example:
var ws = new WebSocket('ws://host:port/ws', {headers: {cookie: 'key=value;'}});
