### PR TITLE
don't setup multiply timeouts for one connection

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -266,7 +266,9 @@ WebSocket.prototype.terminate = function() {
     // Add a timeout to ensure that the connection is completely
     // cleaned up within 30 seconds, even if the clean close procedure
     // fails for whatever reason
-    this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
+    if (!this._closeTimer) {
+      this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
+    }
   }
   else if (this.readyState == WebSocket.CONNECTING) {
     cleanupWebsocketResources.call(this, true);


### PR DESCRIPTION
When `WebSocket` is the last thing keep the process alive, there we sometimes be a delay of 30 seconds before the process shutsdown. In #120 I fixed this issue, but it turns out there is a minor regression when calling `.terminate()` twice (happens when also calling  `WebSocketServer.close`).

The issue is that there will be two timeouts for one connection, where the last one overwrites the first timeout reference. This means that when `clearTimeout` is called the first timeout won't be cleared.

I chose to solve this by only setting a timeout if none exists. 

If you are interested in reproducing the issue, this is the debug script I used:

``` javascript
var http = require('http');
var WebSocket = require('ws');

var server = http.createServer();

server.listen(0, 'localhost', function () {
  var address = 'ws://localhost:' + server.address().port;
  var wss = new WebSocket.Server({'server': server});

  wss.once('connection', function(ws) {
    ws.close();
  });

  var ws = new WebSocket(address);

  ws.once('close', function () {
    wss.close();
    server.close();
  });
});
```
