### PR TITLE
Emit the close event before destroying the internal _socket

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -408,7 +408,7 @@ function initAsClient(address, options) {
     protocolVersion: protocolVersion,
     host: null,
     protocol: null,
-    
+
     // ssl-related options
     pfx: null,
     key: null,
@@ -472,7 +472,7 @@ function initAsClient(address, options) {
     if (isNodeV4) {
       throw new Error('Client side certificates are not supported on Node 0.4.x');
     }
-    
+
     requestOptions.pfx = options.value.pfx;
     requestOptions.key = options.value.key;
     requestOptions.passphrase = options.value.passphrase;
@@ -480,20 +480,20 @@ function initAsClient(address, options) {
     requestOptions.ca = options.value.ca;
     requestOptions.ciphers = options.value.ciphers;
     requestOptions.rejectUnauthorized = options.value.rejectUnauthorized;
-    
+
     // global agent ignores client side certificates
     agent = new httpObj.Agent(requestOptions);
   }
-  
+
   if (isNodeV4) {
     requestOptions.path = (serverUrl.pathname || '/') + (serverUrl.search || '');
   }
   else requestOptions.path = serverUrl.path || '/';
-  
+
   if (agent) {
     requestOptions.agent = agent;
   }
-  
+
   if (isUnixSocket) {
     requestOptions.socketPath = serverUrl.pathname;
   }
@@ -667,6 +667,7 @@ function cleanupWebsocketResources(error) {
   this.readyState = WebSocket.CLOSED;
 
   clearTimeout(this._closeTimer);
+  if (emitClose) this.emit('close', this._closeCode || 1000, this._closeMessage || '');
 
   if (this._socket) {
     removeAllListeners(this._socket);
@@ -690,7 +691,6 @@ function cleanupWebsocketResources(error) {
     this._receiver.cleanup();
     this._receiver = null;
   }
-  if (emitClose) this.emit('close', this._closeCode || 1000, this._closeMessage || '');
   removeAllListeners(this);
   this.on('error', function() {}); // catch all errors after this
   delete this._queue;


### PR DESCRIPTION
This way we can still read out the bytesRead and bytesSend from the socket when it
closes the connections. This can be useful for metrics collection etc.

I can't find any other way of solving this cleanly. Moving the `close` event has no side affects as far as I'm aware off.
