### PR TITLE
Add 'Host' and 'Origin' to request header, fixes problems with mtgox websocket

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -383,7 +383,7 @@ function CloseEvent(code, reason) {
  * which may or may not be bound to a sepcific WebSocket instance.
  */
 
- function initAsServerClient(req, socket, upgradeHead, options) {
+function initAsServerClient(req, socket, upgradeHead, options) {
   options = new Options({
     protocolVersion: protocolVersion,
     protocol: null
@@ -428,6 +428,7 @@ function initAsClient(address, options) {
   if (!serverUrl.host && !isUnixSocket) throw new Error('invalid url');
   var isSecure = serverUrl.protocol === 'wss:' || serverUrl.protocol === 'https:';
   var httpObj = isSecure ? https : http;
+  var port = serverUrl.port || (isSecure ? 443 : 80);
 
   // expose state properties
   this._isServer = false;
@@ -447,16 +448,19 @@ function initAsClient(address, options) {
     isNodeV4 = true;
     agent = new httpObj.Agent({
       host: serverUrl.hostname,
-      port: serverUrl.port || (isSecure ? 443 : 80)
+      port: port
     });
   }
 
+  var headerHost = serverUrl.hostname + ':' + port;
   var requestOptions = {
-    port: serverUrl.port || (isSecure ? 443 : 80),
+    port: port,
     host: serverUrl.hostname,
     headers: {
       'Connection': 'Upgrade',
       'Upgrade': 'websocket',
+      'Host': headerHost,
+      'Origin': headerHost,
       'Sec-WebSocket-Version': options.value.protocolVersion,
       'Sec-WebSocket-Key': key
     }
@@ -511,6 +515,7 @@ function initAsClient(address, options) {
 
   var self = this;
   var req = httpObj.request(requestOptions);
+
   (isNodeV4 ? agent : req).on('error', function(error) {
     self.emit('error', error);
     cleanupWebsocketResources.call(this, error);


### PR DESCRIPTION
Fixes https://github.com/einaros/ws/issues/188

Mtgox causes the 'response' event to fire because the request header was missing 'Host' and 'Origin'.
