### PR TITLE
Add subprotocol support

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -541,6 +541,25 @@ function initAsClient(address, options) {
       return;
     }
 
+    var serverProt = res.headers['sec-websocket-protocol'];
+    var protList = (options.value.protocol || "").split(/, */); 
+    var protError = null;
+    if (!options.value.protocol && serverProt) {
+        protError = 'server sent a subprotocol even though none requested';
+    } else if (options.value.protocol && !serverProt) {
+        protError = 'server sent no subprotocol even though requested';
+    } else if (serverProt && protList.indexOf(serverProt) === -1) {
+        protError = 'server responded with an invalid protocol';
+    }
+    if (protError) {
+        self.emit('error', protError);
+        removeAllListeners(self);
+        socket.end();
+        return;
+    } else if (serverProt) {
+        self.protocol = serverProt;
+    }
+
     establishConnection.call(self, Receiver, Sender, socket, upgradeHead);
 
     // perform cleanup on http resources

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -24,6 +24,7 @@ function WebSocketServer(options, callback) {
     port: null,
     server: null,
     verifyClient: null,
+    handleProtocols: null,
     path: null,
     noServer: false,
     disableHixie: false,
@@ -174,6 +175,9 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     return;
   }
 
+  // verify protocol
+  var protocols = req.headers['sec-websocket-protocol'];
+
   // verify client
   var origin = version < 13 ?
     req.headers['sec-websocket-origin'] :
@@ -181,8 +185,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
 
   // handler to call when the connection sequence completes
   var self = this;
-  var completeHybiUpgrade = function() {
-     var protocol = req.headers['sec-websocket-protocol'];
+  var completeHybiUpgrade2 = function(protocol) {
 
     // calc key
     var key = req.headers['sec-websocket-key'];
@@ -235,6 +238,33 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     cb(client);
   }
 
+  // optionally call external protocol selection handler before
+  // calling completeHybiUpgrade2
+  var completeHybiUpgrade1 = function() {
+    // choose from the sub-protocols
+    if (typeof self.options.handleProtocols == 'function') {
+        var protList = (protocols || "").split(/, */);
+        var callbackCalled = false;
+        var res = self.options.handleProtocols(protList, function(result, protocol) {
+          callbackCalled = true;
+          if (!result) abortConnection(socket, 404, 'Unauthorized')
+          else completeHybiUpgrade2(protocol);
+        });
+        if (!callbackCalled) {
+            // the handleProtocols handler never called our callback
+            abortConnection(socket, 501, 'Could not process protocols');
+        }
+        return;
+    } else {
+        if (typeof protocols !== 'undefined') {
+            completeHybiUpgrade2(protocols.split(/, */)[0]);
+        }
+        else {
+            completeHybiUpgrade2();
+        }
+    }
+  }
+
   // optionally call external client verification handler
   if (typeof this.options.verifyClient == 'function') {
     var info = {
@@ -245,7 +275,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     if (this.options.verifyClient.length == 2) {
       this.options.verifyClient(info, function(result) {
         if (!result) abortConnection(socket, 401, 'Unauthorized')
-        else completeHybiUpgrade();
+        else completeHybiUpgrade1();
       });
       return;
     }
@@ -255,7 +285,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     }
   }
 
-  completeHybiUpgrade();
+  completeHybiUpgrade1();
 }
 
 function handleHixieUpgrade(req, socket, upgradeHead, cb) {


### PR DESCRIPTION
- The client will set ws.protocol based on the subprotocol returned by
  the server. Fixes #192.
- The server application can select from multiple client subprotocol
  options by specifying a handleProtocols in initialization options.
  This function takes two arguments; the first is an array of
  subprotocols sent by the client (empty array if no subprotocol
  specified by the client), the second is a callback function. The
  callback function takes two arguments; the first indicates if the
  client subprotocols are valid, the second argument (only passed when
  first is true) is the subprotocol string selected to return to the
  client. Fixes #29. Fixes #193.
- The default subprotocol behavior of the server is to select/return
  the first subprotocol in the list.
- Includes 6 tests to test subprotocol support:
  - test default behavior of selecting first subprotocol
  - test custom handleProtocols that selects a subprotocol
  - detect server sending invalid subprotocol
  - detect server sent no subprotocol even though client sent
    subprotocol header.
  - test custom handleProtocols that rejects connection based on
    invalid client subprotocol request.
  - server responds with 501 to client if the handleProtocols
    handler neither selects a protocol nor rejects the connection.
