### PR TITLE
Honor ArrayBufferView's byteOffset when sending

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -209,9 +209,10 @@ function getArrayBuffer(data) {
   // data is either an ArrayBuffer or ArrayBufferView.
   var array = data.buffer || data
     , l = data.byteLength || data.length
+    , o = data.byteOffset || 0
     , buffer = new Buffer(l);
   for (var i = 0; i < l; ++i) {
-    buffer[i] = array[i];
+    buffer[i] = array[o+i];
   }
   return buffer;
 }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -183,7 +183,15 @@ WebSocket.prototype.send = function(data, options, cb) {
   options = options || {};
   options.fin = true;
   if (typeof options.binary == 'undefined') {
-    options.binary = (data instanceof ArrayBuffer || data instanceof Buffer);
+    options.binary = (data instanceof ArrayBuffer || data instanceof Buffer ||
+      data instanceof Uint8Array ||
+      data instanceof Uint16Array ||
+      data instanceof Uint32Array ||
+      data instanceof Int8Array ||
+      data instanceof Int16Array ||
+      data instanceof Int32Array ||
+      data instanceof Float32Array ||
+      data instanceof Float64Array);
   }
   if (typeof options.mask == 'undefined') options.mask = !this._isServer;
   if (data instanceof fs.ReadStream) {

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -509,14 +509,15 @@ describe('WebSocket', function() {
     it('send and receive binary data as an array', function(done) {
       server.createServer(++port, function(srv) {
         var ws = new WebSocket('ws://localhost:' + port);
-        var array = new Float32Array(5);
+        var array = new Float32Array(6);
         for (var i = 0; i < array.length; ++i) array[i] = i / 2;
+        var partial = array.subarray(2, 5);
         ws.on('open', function() {
-          ws.send(array, {binary: true});
+          ws.send(partial, {binary: true});
         });
         ws.on('message', function(message, flags) {
           assert.ok(flags.binary);
-          assert.ok(areArraysEqual(array, new Float32Array(getArrayBuffer(message))));
+          assert.ok(areArraysEqual(partial, new Float32Array(getArrayBuffer(message))));
           ws.terminate();
           srv.close();
           done();


### PR DESCRIPTION
Added support to honor an ArrayBufferView's byteOffset when sending and updated the typed array test to send / receive a sliced array view.
