### PR TITLE
pass request to connection listener

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -47,9 +47,9 @@ Emitted with the object of HTTP headers that are going to be written to the `Str
 
 ### Event: 'connection'
 
-`function (socket) { }`
+`function (socket, request) { }`
 
-When a new WebSocket connection is established. `socket` is an object of type `ws.WebSocket`.
+When a new WebSocket connection is established. `socket` is an object of type `ws.WebSocket`. `request` is the client http request that initiated the WebSocket.
 
 
 ## Class: ws.WebSocket

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -70,8 +70,8 @@ function WebSocketServer(options, callback) {
       upgradeHead.copy(head);
 
       self.handleUpgrade(req, socket, head, function(client) {
-        self.emit('connection'+req.url, client);
-        self.emit('connection', client);
+        self.emit('connection'+req.url, client, req);
+        self.emit('connection', client, req);
       });
     });
   }

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -116,6 +116,17 @@ describe('WebSocketServer', function() {
         });
       });
     });
+    
+    it('emits request object as second argument of the connection event', function (done) {
+      var wss = new WebSocketServer({port: ++port}, function() {
+        var ws = new WebSocket('ws://localhost:' + port);
+      });
+      wss.on('connection', function(client, request) {
+        (typeof request).should.eql('object');
+        wss.close();
+        done();
+      });
+    });
 
     it('can have two different instances listening on the same http server with two different paths', function(done) {
       var srv = http.createServer();


### PR DESCRIPTION
I needed this to check the HTTP request cookies before sending any data to a websocket, so that I can integrate in with my session store. There might be another way to do it but I couldn't figure it out.

It simply adds an optional second argument to the connection listener:

``` js
wss.on('connection', function(conn, req) {
  // req is the initial websocket http request
})
```

There is also a test. Before running it I had 1 failing SSL test:
![screen shot 2013-06-14 at 4 39 26 pm](https://f.cloud.github.com/assets/39759/657333/075802de-d54c-11e2-8871-91ecf4b4209b.png)
And after adding my test I still had 1 failing SSL test:
![screen shot 2013-06-14 at 4 39 35 pm](https://f.cloud.github.com/assets/39759/657334/0ec5a350-d54c-11e2-8f96-3bb68a5431fc.png)

Cheers!

Max
