### PR TITLE
fix a request that hangs around after an unexpected response

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -551,6 +551,8 @@ function initAsClient(address, options) {
   (isNodeV4 ? agent : req).once('response', function(res) {
     var error = new Error('unexpected server response (' + res.statusCode + ')');
     self.emit('error', error);
+    
+    req.abort();
     cleanupWebsocketResources.call(this, error);
   });
   (isNodeV4 ? agent : req).once('upgrade', function(res, socket, upgradeHead) {


### PR DESCRIPTION
In my setup, sometimes my node websocket server goes away. At that point nginx tells any further clients that there is a Bad Gateway (502). Of course the WebSocket client then errors out, but it forgets to abort the request. For websocket connections, nginx must be configured with a keep-alive value, so the connection can take a long time to time out. This ties up unnecesary resources.