### PR TITLE
Race condition: Socket's first data event received before readyState is OPEN

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -641,20 +641,12 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
     self._receiver.add(data);
   }
   var dataHandler = firstHandler;
-  process.nextTick(function () {
-    // It could happen that a `data` event is
-    // fired even before our readyState is set
-    // to WebSocket.OPEN, so we start listening
-    // to the event on the next tick
-    socket.on('data', dataHandler);
-
-    // if data was passed along with the http upgrade,
-    // this will schedule a push of that on to the receiver.
-    // this has to be done on next tick, since the caller
-    // hasn't had a chance to set event handlers on this client
-    // object yet.
-    firstHandler();
-  );
+  // if data was passed along with the http upgrade,
+  // this will schedule a push of that on to the receiver.
+  // this has to be done on next tick, since the caller
+  // hasn't had a chance to set event handlers on this client
+  // object yet.
+  process.nextTick(firstHandler);
 
   // receiver event handlers
   self._receiver.ontext = function (data, flags) {
@@ -692,6 +684,8 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   });
   this.readyState = WebSocket.OPEN;
   this.emit('open');
+
+  socket.on('data', dataHandler);
 }
 
 function startQueue(instance) {


### PR DESCRIPTION
I'm using socket.io and socket.io-client at the same time in my tests (socket.io-client uses `ws`) and I found a race condition in lib/Websocket.js.

On line 644 (master branch) we start listening to `data` events on the socket:

``` js
socket.on('data', dataHandler);
```

But we set the readyState of our Websocket to `WebSocket.OPEN` later, on line 686:

``` js
this.readyState = WebSocket.OPEN;
```

Now, I believe that if the client and the server live on the same process, they both handle the connection on the same tick, which results in a `dataHandler` call, even before `this.readyState` is set to open. This results in ws.onmessage not being called.

My solution is to start listening to data events on the next tick (see pull request) to make sure that our readyState has the right value.
