### PR TITLE
Fixed server hanging on close

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -274,6 +274,9 @@ WebSocket.prototype.terminate = function() {
     // Add a timeout to ensure that the connection is completely
     // cleaned up within 30 seconds, even if the clean close procedure
     // fails for whatever reason
+    if (this._closeTimer) {
+      clearTimeout(this._closeTimer);
+    }
     this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
   }
   else if (this.readyState == WebSocket.CONNECTING) {


### PR DESCRIPTION
I ran into an issue with WebSocketServer not shutting down cleanly.

I traced it to the fact that I'm closing all the open sockets right before closing the server (due to some business logic that handles other cases as well), which causes two terminate calls to open sockets in rapid succession, which causes a zombie 30s timeout for cleanupWebsocketResources.

Fixed by clearing close timer in socket if terminate is called more than once in rapid succession.

Here is a gist displaying the issue: https://gist.github.com/kenpratt/6042782 (the example is a bit contrived, but that's the underlying problem I'm having). To get it working just run the server and connect with a client (I'm using https://gist.github.com/kenpratt/6042788.
