### PR TITLE
Allow agent to be set through options

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -444,6 +444,7 @@ function initAsClient(address, options) {
     protocolVersion: protocolVersion,
     host: null,
     protocol: null,
+    agent: null,
 
     // ssl-related options
     pfx: null,
@@ -479,9 +480,9 @@ function initAsClient(address, options) {
   shasum.update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11');
   var expectedServerKey = shasum.digest('base64');
 
+  var agent = options.value.agent;
   // node<=v0.4.x compatibility
-  var agent;
-  if (isNodeV4) {
+  if (!agent && isNodeV4) {
     isNodeV4 = true;
     agent = new httpObj.Agent({
       host: serverUrl.hostname,
@@ -535,8 +536,10 @@ function initAsClient(address, options) {
     if (options.isDefinedAndNonNull('ciphers')) requestOptions.ciphers = options.value.ciphers;
     if (options.isDefinedAndNonNull('rejectUnauthorized')) requestOptions.rejectUnauthorized = options.value.rejectUnauthorized;
 
-    // global agent ignores client side certificates
-    agent = new httpObj.Agent(requestOptions);
+    if (!agent) {
+        // global agent ignores client side certificates
+        agent = new httpObj.Agent(requestOptions);
+    }
   }
 
   if (isNodeV4) {


### PR DESCRIPTION
This allows ws to be used with already open sockets by writing a custom agent.
