### PR TITLE
Ability to add arbitrary request headers when creating a client websocket

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -453,7 +453,7 @@ function initAsClient(address, options) {
     cert: null,
     ca: null,
     ciphers: null,
-    rejectUnauthorized: null,
+    rejectUnauthorized: null
   }).merge(options);
   if (options.value.protocolVersion != 8 && options.value.protocolVersion != 13) {
     throw new Error('unsupported protocol version');


### PR DESCRIPTION
I'm not sure if this functionality would be useful to anyone else or if it breaks conformance with spec. I've been using this to test session cookie sending when connecting a websocket.

If this is useful let me know and I'll add tests.
