### PR TITLE
Add cookie support to websocket client

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -445,6 +445,7 @@ function initAsClient(address, options) {
     host: null,
     protocol: null,
     agent: null,
+    cookies: null,
 
     // ssl-related options
     pfx: null,
@@ -521,6 +522,21 @@ function initAsClient(address, options) {
   }
   if (options.value.host) {
     requestOptions.headers['Host'] = options.value.host;
+  }
+
+  if (options.value.cookies) {
+  if (Object.prototype.toString.call(options.value.cookies) == '[object String]') {
+      requestOptions.headers['Cookie'] = options.value.cookies;
+  } else {
+      var cookies = [];
+      for (var name in options.value.cookies) {
+          cookies.push(name + "=" + options.value.cookies[name]);
+      }
+
+      if (cookies.length > 0) {
+          requestOptions.headers['Cookie'] = cookies.join("; ");
+      }
+  }
   }
 
   if (options.isDefinedAndNonNull('pfx')


### PR DESCRIPTION
Adds support in the form of a string or dictionary.
