### PR TITLE
Proper browserify shim

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,3 @@
 /// shim for browser packaging
 
-module.exports = function() {
-  return global.WebSocket || global.MozWebSocket;
-}
+module.exports = global.WebSocket || global.MozWebSocket;


### PR DESCRIPTION
This package does not give the very same interface in the browser and on node.js.

This is needed by https://github.com/maxogden/websocket-stream/pull/19.
