### PR TITLE
WebSocket: default the `bufferedAmount` to 0 even once the _socket it connected

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -301,7 +301,11 @@ WebSocket.prototype.terminate = function() {
 
 Object.defineProperty(WebSocket.prototype, 'bufferedAmount', {
   get: function get() {
-    return this._socket ? this._socket.bufferSize : 0;
+    var amount = 0;
+    if (this._socket) {
+      amount = this._socket.bufferSize || 0;
+    }
+    return amount;
   }
 });
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -122,6 +122,21 @@ describe('WebSocket', function() {
         });
       });
 
+      it('defaults to zero upon "open"', function(done) {
+        server.createServer(++port, function(srv) {
+          var url = 'ws://localhost:' + port;
+          var ws = new WebSocket(url);
+          ws.onopen = function() {
+            assert.equal(0, ws.bufferedAmount);
+            ws.terminate();
+            ws.on('close', function() {
+              srv.close();
+              done();
+            });
+          };
+        });
+      });
+
       it('stress kernel write buffer', function(done) {
         var wss = new WebSocketServer({port: ++port}, function() {
           var ws = new WebSocket('ws://localhost:' + port);


### PR DESCRIPTION
Closes #230.
