### PR TITLE
Adding url to connection event so we can inspect path vars

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -72,7 +72,7 @@ function WebSocketServer(options, callback) {
 
       self.handleUpgrade(req, socket, head, function(client) {
         self.emit('connection'+req.url, client);
-        self.emit('connection', client);
+        self.emit('connection', client, req.url);	// DJG adding request url so we can discover where we are
       });
     });
   }


### PR DESCRIPTION
I have a very general use case were a request comes in with an arbitrary resource path to subscribe to a stream resource that is only created after the connection is established.  The 'connection' + req.url event doesn't work because we don't know the url we'd like to listen for in advance.
