### PR TITLE
wscat: set http headers from cli

### DIFF
--- a/bin/wscat
+++ b/bin/wscat
@@ -86,6 +86,7 @@ program
   .option('-o, --origin <origin>', 'optional origin')
   .option('--host <host>', 'optional host')
   .option('-s, --subprotocol <protocol>', 'optional subprotocol')
+  .option('--headers <key=value[,..]>', 'upgrade request http headers')
   .parse(process.argv);
 
 if (program.listen && program.connect) {
@@ -154,6 +155,7 @@ else if (program.connect) {
   if (program.origin) options.origin = program.origin;
   if (program.subprotocol) options.protocol = program.subprotocol;
   if (program.host) options.host = program.host;
+  if (program.headers) options.headers = parseHeaders(program.headers);
   var ws = new WebSocket(program.connect, options);
   ws.on('open', function() {
     wsConsole.print('connected (press CTRL+C to quit)', Console.Colors.Green);
@@ -187,4 +189,19 @@ else if (program.connect) {
 else {
   console.error('\033[33merror: use either --listen or --connect\033[39m');
   process.exit(-1);
+}
+
+function parseHeaders (headers) {
+  var obj = {};
+  headers = headers.split(',');
+  headers.forEach(function (header) {
+    // Only split on the first occurrence of '='
+    var i = header.indexOf('=');
+    if (i != -1) {
+      var key = header.substr(0, i);
+      var val = header.substr(i + 1);
+      if (key && val) obj[key] = val;
+    }
+  });
+  return obj;
 }


### PR DESCRIPTION
Implemented a --headers option to specify a comma-seperated list of headers.
Example: wscat --connect ws://localhost --headers x-myheader=myvalue,Authorization='Basic ..'
