### PR TITLE
Allow sending stream.Readable, not just fs.ReadStream

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -201,7 +201,8 @@ WebSocket.prototype.send = function(data, options, cb) {
       data instanceof Float64Array);
   }
   if (typeof options.mask == 'undefined') options.mask = !this._isServer;
-  if (data instanceof stream.Readable) {
+  var readable = typeof stream.Readable == 'function' ? stream.Readable : stream.Stream;
+  if (data instanceof readable) {
     startQueue(this);
     var self = this;
     sendStream(this, data, options, function(error) {


### PR DESCRIPTION
`WebSocket.send` current allows sending a `fs.ReadStream` for streaming data from the filesystem. However, it can be trivially modified to accept a `stream.Readable` instead, which is more general than a `fs.ReadStream` and would allow streaming from e.g. a remote URL.

See related issues #69, #113.
