### PR TITLE
fix Origin request options.

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -508,7 +508,7 @@ function initAsClient(address, protocols, options) {
       'Connection': 'Upgrade',
       'Upgrade': 'websocket',
       'Host': headerHost,
-      'Origin': 'http://' + headerHost,
+      'Origin': (isSecure ? 'https://' : 'http://') + headerHost,
       'Sec-WebSocket-Version': options.value.protocolVersion,
       'Sec-WebSocket-Key': key
     }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -508,7 +508,7 @@ function initAsClient(address, protocols, options) {
       'Connection': 'Upgrade',
       'Upgrade': 'websocket',
       'Host': headerHost,
-      'Origin': headerHost,
+      'Origin': 'http://' + headerHost,
       'Sec-WebSocket-Version': options.value.protocolVersion,
       'Sec-WebSocket-Key': key
     }


### PR DESCRIPTION
some server will return 403 if Origin header is not a url.

here's the sample code that have the issue.

var WebSocket = require('ws'),
    ws = new WebSocket('wss://websocket.mtgox.com/mtgox?Currency=USD');

ws.on('message', function() { console.log(arguments); });