### PR TITLE
Do not override the "fin" property of the send options

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -188,7 +188,9 @@ WebSocket.prototype.send = function(data, options, cb) {
     return;
   }
   options = options || {};
-  options.fin = true;
+  if (!options.hasOwnProperty('fin')) {
+    options.fin = true;
+  }
   if (typeof options.binary == 'undefined') {
     options.binary = (data instanceof ArrayBuffer || data instanceof Buffer ||
       data instanceof Uint8Array ||


### PR DESCRIPTION
Setting the "fin" porperty to false is needed to send fragmented messages to the client.