### PR TITLE
Update WebSocket.js

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -484,7 +484,7 @@ function initAsClient(address, protocols, options) {
   this._isServer = false;
   this.url = address;
   this.protocolVersion = options.value.protocolVersion;
-  this.supports.binary = (this.protocolVersion != 'hixie-76');
+  this.supports.binary = true;
 
   // begin handshake
   var key = new Buffer(options.value.protocolVersion + '-' + Date.now()).toString('base64');


### PR DESCRIPTION
On the line 470 will be thrown an error if `protocolVersion` is not `8` or `13`

`if (options.value.protocolVersion !== 8 && options.value.protocolVersion !== 13) {
    throw new Error('unsupported protocol version');
}`

Below on the line 487 is `this.supports.binary = (this.protocolVersion !== 'hixie-76');` which is completely pointless since `protocolVersion` can be only `8` or `13` anyway.