### PR TITLE
Allow user-defined error status of verifyClient

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -274,7 +274,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     if (this.options.verifyClient.length == 2) {
       this.options.verifyClient(info, function(result, code, name) {
         if (typeof code === 'undefined') code = 401;
-        if (typeof name === 'undefined') name = 'Unauthorized';
+        if (typeof name === 'undefined') name = http.STATUS_CODES[code];
 
         if (!result) abortConnection(socket, code, name);
         else completeHybiUpgrade1();
@@ -432,7 +432,7 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
       var self = this;
       this.options.verifyClient(info, function(result, code, name) {
         if (typeof code === 'undefined') code = 401;
-        if (typeof name === 'undefined') name = 'Unauthorized';
+        if (typeof name === 'undefined') name = http.STATUS_CODES[code];
 
         if (!result) abortConnection(socket, code, name);
         else onClientVerified.apply(self);

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -589,7 +589,7 @@ describe('WebSocketServer', function() {
       it('client can be denied asynchronously with custom response code', function(done) {
         var wss = new WebSocketServer({port: ++port, verifyClient: function(o, cb) {
           process.nextTick(function() {
-            cb(false, 404, 'Not Found');
+            cb(false, 404);
           });
         }}, function() {
           var options = {


### PR DESCRIPTION
Right now verifyClient can only return 401, but other codes might be more appropriate, so allow the caller to specify them.

This was needed in production to return 500 to clients when unable to connect to redis.
