### PR TITLE
Protocol Options Update

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -33,21 +33,7 @@ var closeTimeout = 30000; // Allow 5 seconds to terminate the connection cleanly
  * WebSocket implementation
  */
 
-function WebSocket(address, protocols, options) {
-
-  if (protocols && !Array.isArray(protocols) && 'object' == typeof protocols) {
-    // accept the "options" Object as the 2nd argument
-    options = protocols;
-    protocols = null;
-  }
-  if ('string' == typeof protocols) {
-    protocols = [ protocols ];
-  }
-  if (!Array.isArray(protocols)) {
-    protocols = [];
-  }
-  // TODO: actually handle the `Sub-Protocols` part of the WebSocket client
-
+function WebSocket(address, options) {
   this._socket = null;
   this.bytesReceived = 0;
   this.readyState = null;
@@ -56,7 +42,7 @@ function WebSocket(address, protocols, options) {
   if (Array.isArray(address)) {
     initAsServerClient.apply(this, address.concat(options));
   } else {
-    initAsClient.apply(this, [address, protocols, options]);
+    initAsClient.apply(this, [address, options]);
   }
 }
 
@@ -449,7 +435,7 @@ function initAsServerClient(req, socket, upgradeHead, options) {
   else establishConnection.call(this, Receiver, Sender, socket, upgradeHead);
 }
 
-function initAsClient(address, protocols, options) {
+function initAsClient(address, options) {
   options = new Options({
     origin: null,
     protocolVersion: protocolVersion,
@@ -467,10 +453,19 @@ function initAsClient(address, protocols, options) {
     ciphers: null,
     rejectUnauthorized: null
   }).merge(options);
+  
   if (options.value.protocolVersion != 8 && options.value.protocolVersion != 13) {
     throw new Error('unsupported protocol version');
   }
-
+  
+  if (options.value.protocol) {
+    var protocol = options.value.protocol,
+        protocol = Array.isArray(protocol) ? protocol.join(", ") : protocol,
+        protocol = 'string' == typeof protocol ? protocol.toLowerCase() : null;
+        
+    options.value.protocol = protocol;
+  }
+  
   // verify url and establish http class
   var serverUrl = url.parse(address);
   var isUnixSocket = serverUrl.protocol === 'ws+unix:';
@@ -521,7 +516,7 @@ function initAsClient(address, protocols, options) {
   }
 
   if (options.value.protocol) {
-    requestOptions.headers['Sec-WebSocket-Protocol'] = options.value.protocol;
+      requestOptions.headers['Sec-WebSocket-Protocol'] = options.value.protocol;
   }
 
   if (options.value.host) {


### PR DESCRIPTION
- Parameter "Protocols" in WebSocket constructor is not documented/used anywhere.
- Object "Options" can contain property "protocol" which is probably the same thing as "Protocols".
- "Options.protocol" can contain (After update):
  String -> "chat" or "chat, superchat"
  Array -> ["chat"] or ["chat", "superchat", "..."]
