### PR TITLE
Add handling of protocols in initAsClient function

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -455,7 +455,7 @@ function initAsClient(address, protocols, options) {
     protocolVersion: protocolVersion,
     host: null,
     headers: null,
-    protocol: null,
+    protocol: protocols.join(','),
     agent: null,
 
     // ssl-related options


### PR DESCRIPTION
Value of the variable "protocols" is not copied to the "'Sec-WebSocket-Protocol" property in websocket upgrade header. 

So far it is possible to override this functionality calling 
new WebSocket("ws://URL" , {protocol:"USER DEFINED PROTOCOL"});

Please pull this simple repair.

Thank you in advance
