### PR TITLE
Make sure firstHandler is called only once

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -651,22 +651,17 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   // ensure that the upgradeHead is added to the receiver
   function firstHandler(data) {
     if (self.readyState != WebSocket.OPEN) return;
-    if (upgradeHead && upgradeHead.length > 0) {
-      self.bytesReceived += upgradeHead.length;
-      var head = upgradeHead;
-      upgradeHead = null;
-      self._receiver.add(head);
-    }
+    realHandler(upgradeHead);
+    upgradeHead = null;
+    realHandler(data);
     dataHandler = realHandler;
-    if (data) {
-      self.bytesReceived += data.length;
-      self._receiver.add(data);
-    }
   }
   // subsequent packets are pushed straight to the receiver
   function realHandler(data) {
-    if (data) self.bytesReceived += data.length;
-    self._receiver.add(data);
+    if (data && data.length) {
+      self.bytesReceived += data.length;
+      self._receiver.add(data);
+    }
   }
   var dataHandler = firstHandler;
   // if data was passed along with the http upgrade,
@@ -713,7 +708,9 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   this.readyState = WebSocket.OPEN;
   this.emit('open');
 
-  socket.on('data', dataHandler);
+  socket.on('data', function(data) {
+    dataHandler(data);
+  });
 }
 
 function startQueue(instance) {


### PR DESCRIPTION
dataHandler was set to realHandler, but its previous value of firstHandler was already set as socket data handler so the change had no effect and firstHandler was still used for all data events.

Also making sure that upgradeHead is released no matter it's length or value.