### PR TITLE
Plug WebSocket.terminate timeout leak

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -281,6 +281,10 @@ WebSocket.prototype.terminate = function() {
     // Add a timeout to ensure that the connection is completely
     // cleaned up within 30 seconds, even if the clean close procedure
     // fails for whatever reason
+    // First cleanup any pre-existing timeout from an earlier "terminate" call,
+    // if one exists.  Otherwise terminate calls in quick succession will leak timeouts
+    // and hold the program open for `closeTimout` time.
+    if (this._closeTimer) { clearTimeout(this._closeTimer); }
     this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
   }
   else if (this.readyState == WebSocket.CONNECTING) {


### PR DESCRIPTION
If a caller tracks server connections (`WebSocket`s) on their own and cleans them up manually right before calling `WebSocketServer.close`, the calls to `terminate` (one from the caller closing the connection manually, and one from the server loop doing it) can happen so quickly that the internal state is `WebSocket.CLOSING` in both calls.  

This means that the second call will over-write the first call's `this._closeTimer`.  That means a timer gets leaked, and holds the program open for 30s.  Not a huge problem, but a confounding one.

This one-liner will prevent that.  The "right" answer is probably to update the state machine, but as far as I can tell, this timeout is the only collateral in this scenario, so the one-liner should be sufficient in practice.
