### PR TITLE
Add code to cleanup any pending http requests when a socket is closed

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -639,7 +639,8 @@ function initAsClient(address, protocols, options) {
 }
 
 function cleanupRequest() {
-  if (! this._req) return;
+  var sock = this._req && this._req.socket;
+  if (! sock) return;
 
   this._req.removeAllListeners();
   this._req.on('error', function() {});

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -84,6 +84,8 @@ util.inherits(WebSocket, events.EventEmitter);
 WebSocket.prototype.close = function(code, data) {
   if (this.readyState == WebSocket.CLOSING || this.readyState == WebSocket.CLOSED) return;
   if (this.readyState == WebSocket.CONNECTING) {
+    if (this._req) cleanupRequest.call(this);
+
     this.readyState = WebSocket.CLOSED;
     return;
   }
@@ -573,7 +575,7 @@ function initAsClient(address, protocols, options) {
   }
 
   var self = this;
-  var req = httpObj.request(requestOptions);
+  var req = this._req = httpObj.request(requestOptions);
 
   req.on('error', function(error) {
     self.emit('error', error);
@@ -628,12 +630,21 @@ function initAsClient(address, protocols, options) {
 
     // perform cleanup on http resources
     req.removeAllListeners();
-    req = null;
+    self._req = req = null;
     agent = null;
   });
 
   req.end();
   this.readyState = WebSocket.CONNECTING;
+}
+
+function cleanupRequest() {
+  if (! this._req) return;
+
+  this._req.removeAllListeners();
+  this._req.on('error', function() {});
+  this._req.abort();
+  this._req = null;
 }
 
 function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {


### PR DESCRIPTION
I have a case where I am testing two url endpoints sequentially (e.g. `ws://test.com/a` and `ws://test.com/b`).  In the event that I haven't received a response from the first endpoint (after a short period of time), I close that websocket connection and proceed to connect to the second endpoint.

This is being done in a client library to handle an change of websocket endpoint for it's server-side counterpart.

I felt that the logic was fairly sound in this, but noticed that when running in a node environment the process was not being cleaned up due to the open HTTP request.  This patch addresses that particular issue, albeit without tests.

Let me know where you'd like me to take it from here for a possible merge :)
