### PR TITLE
Improve Server API documentation

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -11,6 +11,7 @@ This class is a WebSocket server. It is an `EventEmitter`.
   * `port` Number
   * `server` http.Server
   * `verifyClient` Function
+  * `handleProtocols` Function
   * `path` String
   * `noServer` Boolean
   * `disableHixie` Boolean
@@ -23,7 +24,36 @@ Either `port` or `server` must be provided, otherwise you might enable
 `noServer` if you want to pass the requests directly. Please note that the
 `callback` is only used when you supply the a `port` number in the options.
 
-### server.close([code], [data])
+### options.verifyClient
+
+`verifyClient` can be used in two different ways. If it is provided with two arguments then those are:
+* `info` Object:
+  * `origin` String: The value in the Origin header indicated by the client.
+  * `req` http.ClientRequest: The client HTTP GET request.
+  * `secure` Boolean: `true` if `req.connection.authorized` or `req.connection.encypted` is set.
+* `cb` Function: A callback that must be called by the user upon inspection of the `info` fields. Arguments in this callback are:
+  * `result` Boolean: Whether the user accepts or not the handshake.
+  * `code` Number: If `result` is `false` this field determines the HTTP error status code to be sent to the client.
+  * `name` String: If `result` is `false` this field determines the HTTP reason phrase.
+
+If `verifyClient` is provided with a single argument then that is:
+* `info` Object: Same as above.
+
+In this case the return code (Boolean) of the function determines whether the handshake is accepted or not.
+
+If `verifyClient` is not set then the handshake is automatically accepted.
+
+### options.handleProtocols
+
+`handleProtocols` receives two arguments:
+* `protocols` Array: The list of WebSocket sub-protocols indicated by the client in the Sec-WebSocket-Protocol header.
+* `cb` Function: A callback that must be called by the user upon inspection of the protocols. Arguments in this callback are:
+  * `result` Boolean: Whether the user accepts or not the handshake.
+  * `protocol` String: If `result` is `true` then this field sets the value of the Sec-WebSocket-Protocol header in the HTTP 101 response.
+
+If `handleProtocols` is not set then the handshake is accepted regardless the value of Sec-WebSocket-Protocol header. If it is set but the user does not invoke the `cb` callback then the handshake is rejected with error HTTP 501.
+
+### server.close()
 
 Close the server and terminate all clients
 


### PR DESCRIPTION
This pull request improves the API documentation of the `ws.Server` class by documenting both `options.handleProtocols` and `options.verifyClient`.
