### PR TITLE
Improve Server API documentation and fix EventEmitter usage

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -11,6 +11,7 @@ This class is a WebSocket server. It is an `EventEmitter`.
   * `port` Number
   * `server` http.Server
   * `verifyClient` Function
+  * `handleProtocols` Function
   * `path` String
   * `noServer` Boolean
   * `disableHixie` Boolean
@@ -23,7 +24,36 @@ Either `port` or `server` must be provided, otherwise you might enable
 `noServer` if you want to pass the requests directly. Please note that the
 `callback` is only used when you supply the a `port` number in the options.
 
-### server.close([code], [data])
+### options.verifyClient
+
+`verifyClient` can be used in two different ways. If it is provided with two arguments then those are:
+* `info` Object:
+  * `origin` String: The value in the Origin header indicated by the client.
+  * `req` http.ClientRequest: The client HTTP GET request.
+  * `secure` Boolean: `true` if `req.connection.authorized` or `req.connection.encypted` is set.
+* `cb` Function: A callback that must be called by the user upon inspection of the `info` fields. Arguments in this callback are:
+  * `result` Boolean: Whether the user accepts or not the handshake.
+  * `code` Number: If `result` is `false` this field determines the HTTP error status code to be sent to the client.
+  * `name` String: If `result` is `false` this field determines the HTTP reason phrase.
+
+If `verifyClient` is provided with a single argument then that is:
+* `info` Object: Same as above.
+
+In this case the return code (Boolean) of the function determines whether the handshake is accepted or not.
+
+If `verifyClient` is not set then the handshake is automatically accepted.
+
+### options.handleProtocols
+
+`handleProtocols` receives two arguments:
+* `protocols` Array: The list of WebSocket sub-protocols indicated by the client in the Sec-WebSocket-Protocol header.
+* `cb` Function: A callback that must be called by the user upon inspection of the protocols. Arguments in this callback are:
+  * `result` Boolean: Whether the user accepts or not the handshake.
+  * `protocol` String: If `result` is `true` then this field sets the value of the Sec-WebSocket-Protocol header in the HTTP 101 response.
+
+If `handleProtocols` is not set then the handshake is accepted regardless the value of Sec-WebSocket-Protocol header. If it is set but the user does not invoke the `cb` callback then the handshake is rejected with error HTTP 501.
+
+### server.close()
 
 Close the server and terminate all clients
 
@@ -178,4 +208,3 @@ Is emitted when a pong is received. `flags` is an object with member `binary`.
 `function () { }`
 
 Emitted when the connection is established.
-

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -34,6 +34,7 @@ var closeTimeout = 30000; // Allow 5 seconds to terminate the connection cleanly
  */
 
 function WebSocket(address, protocols, options) {
+  events.EventEmitter.call(this);
 
   if (protocols && !Array.isArray(protocols) && 'object' == typeof protocols) {
     // accept the "options" Object as the 2nd argument

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -18,6 +18,8 @@ var util = require('util')
  */
 
 function WebSocketServer(options, callback) {
+  events.EventEmitter.call(this);
+
   options = new Options({
     host: '0.0.0.0',
     port: null,


### PR DESCRIPTION
- Improve Server API documentation.
- Explicitly invoke events.EventEmitter.call(this) in WebSocketServer() and WebSocket() (fixes #373).
