### PR TITLE
Proposal for fixing a fd leak issue with node 0.11.x

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -768,7 +768,20 @@ function cleanupWebsocketResources(error) {
   if (emitClose) this.emit('close', this._closeCode || 1000, this._closeMessage || '');
 
   if (this._socket) {
-    this._socket.removeAllListeners();
+
+    var self = this;
+
+    //
+    // Fix for resource leaks
+    // https://github.com/joyent/node/issues/8615#issuecomment-60859129
+    //
+    // Remove only documented events 'connect', 'data', 'end', 'timeout', 'drain', 'error', 'close'
+    // http://nodejs.org/api/net.html
+    //    
+    ['connect', 'data', 'end', 'timeout', 'drain', 'error', 'close'].some(function(evt) {
+      self._socket.removeAllListeners(evt);
+    });
+
     // catch all socket error after removing all standard handlers
     var socket = this._socket;
     this._socket.on('error', function() {


### PR DESCRIPTION
After searching a fd leak issue with node 0.11.x we found the following problem with ws.

https://github.com/joyent/node/issues/8615#issuecomment-60859129

This is a fix proposal, but not clear what you are currently doing with the removeAllListeners function.
By invoking removeAllListeners on socket object you remove all event, and it leads in some cases to remove the finish event, which does not properly close the TLS socket at the _tls_wrap.cc.

Questions:
1. why do you use the removeAllListeners on the socket ?
2. This proposal is only a workaround for the fd leak issue found, but based on the nodejs api documentation it's dangerous to use it. 
Why do you need this ?

http://nodejs.org/api/all.html#all_emitter_removealllisteners_event
"Removes all listeners, or those of the specified event. It's not a good idea to remove listeners that were added elsewhere in the code, especially when it's on an emitter that you didn't create (e.g. sockets or file streams)."
