### PR TITLE
Do not remove sockets' internal event listeners

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -11,6 +11,7 @@ var util = require('util')
   , crypto = require('crypto')
   , url = require('url')
   , stream = require('stream')
+  , assert = require('assert')
   , Options = require('options')
   , Sender = require('./Sender')
   , Receiver = require('./Receiver')
@@ -53,6 +54,7 @@ function WebSocket(address, protocols, options) {
   this.bytesReceived = 0;
   this.readyState = null;
   this.supports = {};
+  this.customEventListeners = {};
 
   if (Array.isArray(address)) {
     initAsServerClient.apply(this, address.concat(options));
@@ -637,6 +639,46 @@ function initAsClient(address, protocols, options) {
   this.readyState = WebSocket.CONNECTING;
 }
 
+function addCustomEventListener(emitter, event, handler) {
+  assert(typeof this.customEventListeners === 'object');
+  assert(typeof emitter === 'object' && emitter != null);
+  assert(typeof event === 'string');
+  assert(typeof handler === 'function');
+
+  emitter.on(event, handler);
+
+  var customEventListener = { event: event, handler: handler };
+  if (!this.customEventListeners[emitter]) {
+    this.customEventListeners[emitter] = [customEventListener];
+  } else {
+    this.customEventListeners[emitter].push(customEventListener);
+  }
+}
+
+function addCustomEventListeners(emitter, eventsList, handler) {
+  assert(typeof this.customEventListeners === 'object');
+  assert(Array.isArray(eventsList));
+
+  var self = this;
+  eventsList.forEach(function eachEvent(event) {
+    addCustomEventListener.call(self, emitter, event, handler);
+  })
+}
+
+function removeAllCustomEventListeners(emitter) {
+  assert(typeof this.customEventListeners === 'object');
+  assert(typeof emitter === 'object');
+
+  var customListeners = this.customEventListeners[emitter];
+  if (customListeners) {
+    customListeners.forEach(function removeCustomListener(listener) {
+      emitter.removeListener(listener.event, listener.handler);
+    });
+  }
+
+  delete this.customEventListeners[emitter];
+}
+
 function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   this._socket = socket;
   socket.setTimeout(0);
@@ -645,9 +687,10 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   this._receiver = new ReceiverClass();
 
   // socket cleanup handlers
-  socket.on('end', cleanupWebsocketResources.bind(this));
-  socket.on('close', cleanupWebsocketResources.bind(this));
-  socket.on('error', cleanupWebsocketResources.bind(this));
+  addCustomEventListeners.call(this,
+                               socket,
+                               ['end', 'close', 'error'],
+                               cleanupWebsocketResources.bind(this));
 
   // ensure that the upgradeHead is added to the receiver
   function firstHandler(data) {
@@ -714,7 +757,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   this.readyState = WebSocket.OPEN;
   this.emit('open');
 
-  socket.on('data', dataHandler);
+  addCustomEventListener.call(this, socket, 'data', dataHandler);
 }
 
 function startQueue(instance) {
@@ -768,7 +811,7 @@ function cleanupWebsocketResources(error) {
   if (emitClose) this.emit('close', this._closeCode || 1000, this._closeMessage || '');
 
   if (this._socket) {
-    this._socket.removeAllListeners();
+    removeAllCustomEventListeners.call(this, this._socket);
     // catch all socket error after removing all standard handlers
     var socket = this._socket;
     this._socket.on('error', function() {


### PR DESCRIPTION
When adding a "custom" event listener to the underlyin socket, use the
functions named "addCustomEventListener" or "addCustomEventListeners".
This will keep track of which event listeners have been added. When it's
time to remove custom events listeners, use
removeAllCustomEventListeners.

Fixes #392
