### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "name": "ws",
   "description": "simple to use, blazing fast and thoroughly tested websocket client, server and console for node.js, up-to-date against RFC-6455",
   "version": "0.4.32",
+  "licenses" : [
+    {
+      "type" : "MIT",
+      "url" : "https://raw.githubusercontent.com/einaros/ws/master/README.md"
+    }
+  ],
   "keywords": [
     "Hixie",
     "HyBi",


### PR DESCRIPTION
Allows license to be read programatically.
