### PR TITLE
Update the `save` flag with two hyphens, not three

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for the full reports.
 ### Installing
 
 ```
-npm install ---save ws
+npm install --save ws
 ```
 
 ### Sending and receiving text data


### PR DESCRIPTION
Just a quick update--in the installation instructions, it looks like there's an extra hyphen in the `--save` flag. :)
