### PR TITLE
Fix an error when permessage-deflate is enabled and closing socket

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -325,7 +325,7 @@ Receiver.prototype.error = function (reason, protocolErrorCode) {
  */
 
 Receiver.prototype.flush = function() {
-  if (this.processing) return;
+  if (this.processing || this.dead) return;
 
   var handler = this.messageHandlers.shift();
   if (!handler) return;
@@ -349,6 +349,7 @@ Receiver.prototype.applyExtensions = function(messageBuffer, fin, compressed, ca
   var self = this;
   if (compressed) {
     this.extensions[PerMessageDeflate.extensionName].decompress(messageBuffer, fin, function(err, buffer) {
+      if (self.dead) return;
       if (err) {
         callback(new Error('invalid compressed data'));
         return;

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -38,7 +38,7 @@ util.inherits(Sender, events.EventEmitter);
  * @api public
  */
 
-Sender.prototype.close = function(code, data, mask) {
+Sender.prototype.close = function(code, data, mask, cb) {
   if (typeof code !== 'undefined') {
     if (typeof code !== 'number' ||
       !ErrorCodes.isValidErrorCode(code)) throw new Error('first argument must be a valid error code number');
@@ -52,6 +52,7 @@ Sender.prototype.close = function(code, data, mask) {
   this.messageHandlers.push(function(callback) {
     self.frameAndSend(0x8, dataBuffer, true, mask);
     callback();
+    cb();
   });
   this.flush();
 };

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -105,16 +105,18 @@ WebSocket.prototype.close = function close(code, data) {
     return;
   }
 
+  var self = this;
   try {
     this.readyState = WebSocket.CLOSING;
     this._closeCode = code;
     this._closeMessage = data;
     var mask = !this._isServer;
-    this._sender.close(code, data, mask);
+    this._sender.close(code, data, mask, function(err) {
+      if (err) self.emit('error', err);
+      self.terminate();
+    });
   } catch (e) {
     this.emit('error', e);
-  } finally {
-    this.terminate();
   }
 };
 
@@ -311,6 +313,8 @@ WebSocket.prototype.terminate = function terminate() {
   if (this.readyState === WebSocket.CLOSED) return;
 
   if (this._socket) {
+    this.readyState = WebSocket.CLOSING;
+
     // End the connection
     try { this._socket.end(); }
     catch (e) {

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -32,7 +32,7 @@ function WebSocketServer(options, callback) {
     noServer: false,
     disableHixie: false,
     clientTracking: true,
-    perMessageDeflate: false
+    perMessageDeflate: true
   }).merge(options);
 
   if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -294,5 +294,22 @@ describe('Receiver', function() {
       });
     });
   });
+  it('can cleanup during consuming data', function(done) {
+    var perMessageDeflate = new PerMessageDeflate();
+    perMessageDeflate.accept([{}]);
+
+    var p = new Receiver({ 'permessage-deflate': perMessageDeflate });
+    var buf = new Buffer('Hello');
+
+    perMessageDeflate.compress(buf, true, function(err, compressed) {
+      if (err) return done(err);
+      var data = Buffer.concat([new Buffer([0xc1, compressed.length]), compressed]);
+      p.add(data);
+      p.add(data);
+      p.add(data);
+      p.cleanup();
+      setTimeout(done, 1000);
+    });
+  });
 });
 

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -49,4 +49,27 @@ describe('Sender', function() {
       sender.send('hi', { compress: true });
     });
   });
+
+  describe('#close', function() {
+    it('should consume all data before closing', function(done) {
+      var perMessageDeflate = new PerMessageDeflate();
+      perMessageDeflate.accept([{}]);
+
+      var count = 0;
+      var sender = new Sender({
+        write: function(data) {
+          count++;
+        }
+      }, {
+        'permessage-deflate': perMessageDeflate
+      });
+      sender.send('foo', {compress: true});
+      sender.send('bar', {compress: true});
+      sender.send('baz', {compress: true});
+      sender.close(1000, null, false, function(err) {
+        count.should.be.equal(4);
+        done(err);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixed an error and data loss happen when socket closing.
I enabled `permessage-deflate` by default again, but at least, we might should disable it until are convinced it's stable enough.

Related: https://github.com/einaros/ws/pull/409, https://github.com/primus/primus/issues/319
