### PR TITLE
Documented websocket.upgradeReq

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -127,6 +127,10 @@ The URL of the WebSocket server (only for clients)
 
 Describes the feature of the used protocol version. E.g. `supports.binary` is a boolean that describes if the connection supports binary messages.
 
+### websocket.upgradeReq
+
+The http request that initiated the upgrade. Useful for parsing authorty headers, cookie headers and other information to associate a specific Websocket to a specific Client. This is only available for WebSockets constructed by a Server.
+
 ### websocket.close([code], [data])
 
 Gracefully closes the connection, after sending a description message


### PR DESCRIPTION
In my attempt to associate a websocket with a specific client I had to override `websocket.handleUpgrade` and call it abstractly inorder to get both the request and the websocket in one place. If I would have known that it was available, I wouldn't have to code so dirty for something I think many people would need.
