### PR TITLE
Document compress option

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -154,7 +154,7 @@ Resume the client stream
 
 ### websocket.send(data, [options], [callback])
 
-Sends `data` through the connection. `options` can be an object with members `mask` and `binary`. The optional `callback` is executed after the send completes.
+Sends `data` through the connection. `options` can be an object with members `mask`, `binary` and `compress`. The optional `callback` is executed after the send completes.
 
 ### websocket.stream([options], callback)
 


### PR DESCRIPTION
I've added a mention of the compress option, there wasn't a single reference to it in the docs, readme or examples.
