### PR TITLE
Fix for cleanupWebsocketResources using the wrong 'this'

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -665,7 +665,7 @@ function initAsClient(address, protocols, options) {
 
   req.on('error', function onerror(error) {
     self.emit('error', error);
-    cleanupWebsocketResources.call(this, error);
+    cleanupWebsocketResources.call(self, error);
   });
 
   req.once('response', function response(res) {
@@ -677,7 +677,7 @@ function initAsClient(address, protocols, options) {
       self.emit('error', error);
     }
 
-    cleanupWebsocketResources.call(this, error);
+    cleanupWebsocketResources.call(self, error);
   });
 
   req.once('upgrade', function upgrade(res, socket, upgradeHead) {

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -342,6 +342,25 @@ describe('WebSocket', function() {
       });
     });
 
+    it('can handle error before request is upgraded', function(done) {
+        // Here, we don't create a server, to guarantee that the connection will
+        // fail before the request is upgraded
+        ++port;
+        var ws = new WebSocket('ws://localhost:' + port);
+        ws.on('open', function() {
+          assert.fail('connect shouldnt be raised here');
+        });
+        ws.on('close', function() {
+          assert.fail('close shouldnt be raised here');
+        });
+        ws.on('error', function() {
+          setTimeout(function() {
+            assert.equal(ws.readyState, WebSocket.CLOSED);
+            done();
+          }, 50)
+        });
+    });
+
     it('invalid server key is denied', function(done) {
       server.createServer(++port, server.handlers.invalidKey, function(srv) {
         var ws = new WebSocket('ws://localhost:' + port);


### PR DESCRIPTION
When the WebSocket's HTTP request gets either an error or a response event, the cleanupWebsocketResources is called on this, which is the HTTP request, rather than self which prevents a clean close.