### PR TITLE
Throw TypeError when class constructor called without new

### DIFF
--- a/lib/BufferPool.js
+++ b/lib/BufferPool.js
@@ -7,6 +7,10 @@
 var util = require('util');
 
 function BufferPool(initialSize, growStrategy, shrinkStrategy) {
+  if (this instanceof BufferPool === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   if (typeof initialSize === 'function') {
     shrinkStrategy = growStrategy;
     growStrategy = initialSize;

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -12,6 +12,10 @@ PerMessageDeflate.extensionName = 'permessage-deflate';
  */
 
 function PerMessageDeflate(options, isServer) {
+  if (this instanceof PerMessageDeflate === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   this._options = options || {};
   this._isServer = !!isServer;
   this._inflate = null;
@@ -286,4 +290,3 @@ PerMessageDeflate.prototype.compress = function (data, fin, callback) {
 };
 
 module.exports = PerMessageDeflate;
-

--- a/lib/Receiver.hixie.js
+++ b/lib/Receiver.hixie.js
@@ -20,6 +20,10 @@ var BINARYLENGTH = 2
  */
 
 function Receiver () {
+  if (this instanceof Receiver === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   this.state = EMPTY;
   this.buffers = [];
   this.messageEnd = -1;

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -16,6 +16,10 @@ var util = require('util')
  */
 
 function Receiver (extensions) {
+  if (this instanceof Receiver === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   // memory pool for fragmented messages
   var fragmentedPoolPrevUsed = -1;
   this.fragmentedBufferPool = new BufferPool(1024, function(db, length) {

--- a/lib/Sender.hixie.js
+++ b/lib/Sender.hixie.js
@@ -13,6 +13,10 @@ var events = require('events')
  */
 
 function Sender(socket) {
+  if (this instanceof Sender === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   events.EventEmitter.call(this);
 
   this.socket = socket;

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -16,6 +16,10 @@ var events = require('events')
  */
 
 function Sender(socket, extensions) {
+  if (this instanceof Sender === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   events.EventEmitter.call(this);
 
   this._socket = socket;

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -44,6 +44,10 @@ var closeTimeout = 30 * 1000; // Allow 30 seconds to terminate the connection cl
  * @api public
  */
 function WebSocket(address, protocols, options) {
+  if (this instanceof WebSocket === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   EventEmitter.call(this);
 
   if (protocols && !Array.isArray(protocols) && 'object' === typeof protocols) {

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -20,6 +20,10 @@ var util = require('util')
  */
 
 function WebSocketServer(options, callback) {
+  if (this instanceof WebSocketServer === false) {
+    throw new TypeError("Classes can't be function-called");
+  }
+
   events.EventEmitter.call(this);
 
   options = new Options({

--- a/test/BufferPool.test.js
+++ b/test/BufferPool.test.js
@@ -1,11 +1,20 @@
 var BufferPool = require('../lib/BufferPool');
 require('should');
 
-describe('BufferPool', function() {  
+describe('BufferPool', function() {
   describe('#ctor', function() {
     it('allocates pool', function() {
       var db = new BufferPool(1000);
       db.size.should.eql(1000);
+    });
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var db = BufferPool(1000);
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
     });
   });
   describe('#get', function() {
@@ -39,7 +48,7 @@ describe('BufferPool', function() {
       var db = new BufferPool(1000);
       var buf = db.get(1000);
       db.size.should.eql(1000);
-      buf.length.should.eql(1000);      
+      buf.length.should.eql(1000);
     });
   });
   describe('#reset', function() {

--- a/test/PerMessageDeflate.test.js
+++ b/test/PerMessageDeflate.test.js
@@ -3,6 +3,18 @@ var Extensions = require('../lib/Extensions');
 require('should');
 
 describe('PerMessageDeflate', function() {
+  describe('#ctor', function() {
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var perMessageDeflate = PerMessageDeflate();
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
+  });
+
   describe('#offer', function() {
     it('should create default params', function() {
       var perMessageDeflate = new PerMessageDeflate();

--- a/test/Receiver.hixie.test.js
+++ b/test/Receiver.hixie.test.js
@@ -4,6 +4,18 @@ var assert = require('assert')
 require('./hybi-common');
 
 describe('Receiver', function() {
+  describe('#ctor', function() {
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var p = Receiver();
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
+  });
+
   it('can parse text message', function() {
     var p = new Receiver();
     var packet = '00 48 65 6c 6c 6f ff';

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -5,6 +5,18 @@ require('should');
 require('./hybi-common');
 
 describe('Receiver', function() {
+  describe('#ctor', function() {
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var p = Receiver();
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
+  });
+
   it('can parse unmasked text message', function() {
     var p = new Receiver();
     var packet = '81 05 48 65 6c 6c 6f';
@@ -312,4 +324,3 @@ describe('Receiver', function() {
     });
   });
 });
-

--- a/test/Sender.hixie.test.js
+++ b/test/Sender.hixie.test.js
@@ -4,6 +4,18 @@ require('should');
 require('./hybi-common');
 
 describe('Sender', function() {
+  describe('#ctor', function() {
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var sender = Sender({ write: function() {} });
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
+  });
+
   describe('#send', function() {
     it('frames and sends a text message', function(done) {
       var message = 'Hello world';

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -3,6 +3,18 @@ var Sender = require('../lib/Sender')
 require('should');
 
 describe('Sender', function() {
+  describe('#ctor', function() {
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var sender = Sender({ write: function() {} });
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
+  });
+
   describe('#frameAndSend', function() {
     it('does not modify a masked binary buffer', function() {
       var sender = new Sender({ write: function() {} });

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -39,6 +39,15 @@ describe('WebSocket', function() {
         done();
       }
     });
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var ws = WebSocket('ws://localhost:' + port);
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
   });
 
   describe('options', function() {

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -26,6 +26,16 @@ function areArraysEqual(x, y) {
 
 describe('WebSocketServer', function() {
   describe('#ctor', function() {
+    it('throws TypeError when called without new', function(done) {
+      try {
+        var ws = WebSocketServer({noServer: true});
+      }
+      catch (e) {
+        e.should.be.instanceof(TypeError);
+        done();
+      }
+    });
+
     it('throws an error if no option object is passed', function() {
       var gotException = false;
       try {


### PR DESCRIPTION
I had the strangest bug where it would throw an error instead of emitting `connected`. Turns out that I wasn't using the `new` keyword when creating my `WebSocketServer`. This pull requests throws an error when creating the instance as to alert the user of the misstake as soon as possible. It follows closely how it's done in [ES6 (9.2.2 - [[call]])](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-ecmascript-function-objects-call-thisargument-argumentslist) with the new `class` keyword.

I have added new tests and all test passes.