### PR TITLE
Correctly switch the socket data handler

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -744,13 +744,15 @@ function initAsClient(address, protocols, options) {
 }
 
 function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
-  var ultron = this._ultron = new Ultron(socket);
-  this._socket = socket;
+  var ultron = this._ultron = new Ultron(socket)
+    , called = false
+    , self = this;
 
   socket.setTimeout(0);
   socket.setNoDelay(true);
-  var self = this;
+
   this._receiver = new ReceiverClass(this.extensions);
+  this._socket = socket;
 
   // socket cleanup handlers
   ultron.on('end', cleanupWebsocketResources.bind(this));
@@ -759,30 +761,27 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
 
   // ensure that the upgradeHead is added to the receiver
   function firstHandler(data) {
-    if (self.readyState !== WebSocket.OPEN && self.readyState !== WebSocket.CLOSING) return;
+    if (called || self.readyState === WebSocket.CLOSED) return;
+
+    called = true;
+    socket.removeListener('data', firstHandler);
+    ultron.on('data', realHandler);
 
     if (upgradeHead && upgradeHead.length > 0) {
-      self.bytesReceived += upgradeHead.length;
-      var head = upgradeHead;
+      realHandler(upgradeHead);
       upgradeHead = null;
-      self._receiver.add(head);
     }
 
-    dataHandler = realHandler;
-
-    if (data) {
-      self.bytesReceived += data.length;
-      self._receiver.add(data);
-    }
+    if (data) realHandler(data);
   }
 
   // subsequent packets are pushed straight to the receiver
   function realHandler(data) {
-    if (data) self.bytesReceived += data.length;
+    self.bytesReceived += data.length;
     self._receiver.add(data);
   }
 
-  var dataHandler = firstHandler;
+  ultron.on('data', firstHandler);
 
   // if data was passed along with the http upgrade,
   // this will schedule a push of that on to the receiver.
@@ -842,8 +841,6 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
 
   this.readyState = WebSocket.OPEN;
   this.emit('open');
-
-  ultron.on('data', dataHandler);
 }
 
 function startQueue(instance) {


### PR DESCRIPTION
I think that the `realHandler` function was designed to push data efficiently to the receiver after the first chunk of data, but it seems that it never worked as intended.

If you look at the commit where it was intruduced (1faa9525) you'll see that the socket data handler is set to be `dataHandler` which points to `firstHandler` when the listener is registered. When `firstHandler` is invoked the value of `dataHandler` is changed to `realHandler`, but this doesn't replace the listener which will keep to be `firstHandler`.

With this patch the listener is correclty switched.

P.S. In #212 `socket.on('data', dataHandler);` was moved at the end of the function to ensure that the `readyState` was set to `WebSocket.OPEN` before receiving any data, but this is not needed because a net stream data event does not fire in the same tick.
