### PR TITLE
Return 426 for non-Upgrade requests

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -43,8 +43,12 @@ function WebSocketServer(options, callback) {
 
   if (options.isDefinedAndNonNull('port')) {
     this._server = http.createServer(function (req, res) {
-      res.writeHead(200, {'Content-Type': 'text/plain'});
-      res.end('Not implemented');
+      var body = http.STATUS_CODES[426];
+      res.writeHead(426, {
+        'Content-Length': body.length,
+        'Content-Type': 'text/plain'
+      });
+      res.end(body);
     });
     this._server.listen(options.value.port, options.value.host, callback);
     this._closeServer = function() { if (self._server) self._server.close(); };

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -92,6 +92,22 @@ describe('WebSocketServer', function() {
       });
     });
 
+    it('426s for non-Upgrade requests', function (done) {
+      var wss = new WebSocketServer({ port: ++port }, function () {
+        http.get('http://localhost:' + port, function (res) {
+          var body = '';
+
+          res.statusCode.should.equal(426);
+          res.on('data', function (chunk) { body += chunk; });
+          res.on('end', function () {
+            body.should.equal(http.STATUS_CODES[426]);
+            wss.close();
+            done();
+          });
+        });
+      });
+    });
+
     // Don't test this on Windows. It throws errors for obvious reasons.
     if(!/^win/i.test(process.platform)) {
       it('uses a precreated http server listening on unix socket', function (done) {


### PR DESCRIPTION
This patch will fix the status coded returned for non-Upgrade requests, changing it from `200` to `426`.
See #472.