### PR TITLE
fix https://github.com/websockets/ws/issues/452

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -11,6 +11,22 @@ var global = (function() { return this; })();
 
 var WebSocket = global.WebSocket || global.MozWebSocket;
 
+WebSocket.prototype.on = function (event, callback) {
+  this.addEventListener(event, callback);
+};
+
+WebSocket.prototype.off = function (event, callback) {
+  this.removeEventListener(event, callback);
+};
+
+WebSocket.prototype.once = function (event, callback) {
+  var self = this;
+  this.addEventListener(event, function handler() {
+    callback.apply(callback, arguments);
+    self.removeEventListener(event, handler);
+  });
+};
+
 /**
  * Module exports.
  */


### PR DESCRIPTION
This monkey-ish patch will allow the use of `.on` in browser environment when you use `einaros/ws` with **browserify**  

It will also add `.once` and `.off`