### PR TITLE
adhere to RFC by removing default Origin header

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -578,7 +578,7 @@ function initAsClient(address, protocols, options) {
   var agent = options.value.agent;
 
   var headerHost = serverUrl.hostname;
-  // Append port number to Host and Origin header, only if specified in the url
+  // Append port number to Host header, only if specified in the url
   // and non-default
   if (serverUrl.port) {
     if ((isSecure && (port !== 443)) || (!isSecure && (port !== 80))){
@@ -593,7 +593,6 @@ function initAsClient(address, protocols, options) {
       'Connection': 'Upgrade',
       'Upgrade': 'websocket',
       'Host': headerHost,
-      'Origin': headerHost,
       'Sec-WebSocket-Version': options.value.protocolVersion,
       'Sec-WebSocket-Key': key
     }

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1798,15 +1798,28 @@ describe('WebSocket', function() {
       });
     });
 
-    it('includes the origin header with port number', function(done) {
+    it('lacks default origin header', function(done) {
       var srv = http.createServer();
       srv.listen(++port, function() {
         srv.on('upgrade', function(req, socket, upgradeHeade) {
-          assert.equal('localhost:' + port, req.headers['origin']);
+          req.headers.should.not.have.property('origin');
           srv.close();
           done();
         });
         var ws = new WebSocket('ws://localhost:' + port);
+      });
+    });
+
+    it('honors origin set in options', function(done) {
+      var srv = http.createServer();
+      srv.listen(++port, function() {
+        var options = {origin: 'https://example.com:8000'}
+        srv.on('upgrade', function(req, socket, upgradeHeade) {
+          assert.equal(options.origin, req.headers['origin']);
+          srv.close();
+          done();
+        });
+        var ws = new WebSocket('ws://localhost:' + port, options);
       });
     });
   });


### PR DESCRIPTION
This fixes the long-running issue https://github.com/websockets/ws/pull/272 by removing the Origin header by default.

The default value "host:port" was not syntactically valid according to RFCs, which caused (some) servers to reject such connections. According to the WebSocket RFC 6455 it should be one of 1) missing 2) "null" 3) "scheme://host:port" (defined by the Origin RFC 6454).

Semantically, an origin header is not required for non-browser clients, and if present it should describe the source of the resource which caused this request. If the caller of ws has such origin, it can set it in the options (test case provided).