### PR TITLE
fix Host header port inequality check

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -581,7 +581,7 @@ function initAsClient(address, protocols, options) {
   // Append port number to Host header, only if specified in the url
   // and non-default
   if (serverUrl.port) {
-    if ((isSecure && (port !== 443)) || (!isSecure && (port !== 80))){
+    if ((isSecure && (port != 443)) || (!isSecure && (port != 80))){
       headerHost = headerHost + ':' + port;
     }
   }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -455,6 +455,7 @@ WebSocket.prototype.addEventListener = function(method, listener) {
 };
 
 module.exports = WebSocket;
+module.exports.buildHostHeader = buildHostHeader
 
 /**
  * W3C MessageEvent
@@ -492,6 +493,18 @@ function CloseEvent(code, reason, target) {
  */
 function OpenEvent(target) {
   this.target = target;
+}
+
+// Append port number to Host header, only if specified in the url
+// and non-default
+function buildHostHeader(isSecure, hostname, port) {
+  var headerHost = hostname;
+  if (hostname) {
+    if ((isSecure && (port != 443)) || (!isSecure && (port != 80))){
+      headerHost = headerHost + ':' + port;
+    }
+  }
+  return headerHost;
 }
 
 /**
@@ -577,14 +590,7 @@ function initAsClient(address, protocols, options) {
 
   var agent = options.value.agent;
 
-  var headerHost = serverUrl.hostname;
-  // Append port number to Host header, only if specified in the url
-  // and non-default
-  if (serverUrl.port) {
-    if ((isSecure && (port != 443)) || (!isSecure && (port != 80))){
-      headerHost = headerHost + ':' + port;
-    }
-  }
+  var headerHost = buildHostHeader(isSecure, serverUrl.hostname, port)
 
   var requestOptions = {
     port: port,

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1822,6 +1822,21 @@ describe('WebSocket', function() {
         var ws = new WebSocket('ws://localhost:' + port, options);
       });
     });
+
+    it('excludes default ports from host header', function(done) {
+      // can't create a server listening on ports 80 or 443
+      // so we need to expose the method that does this
+      var buildHostHeader = WebSocket.buildHostHeader
+      var host = buildHostHeader(false, 'localhost', 80)
+      assert.equal('localhost', host);
+      host = buildHostHeader(false, 'localhost', 88)
+      assert.equal('localhost:88', host);
+      host = buildHostHeader(true, 'localhost', 443)
+      assert.equal('localhost', host);
+      host = buildHostHeader(true, 'localhost', 8443)
+      assert.equal('localhost:8443', host);
+      done()
+    });
   });
 
   describe('permessage-deflate', function() {


### PR DESCRIPTION
url.parse returns an object with the port as a string. This allows interoperablity with servers with a more strict interpretation of https://tools.ietf.org/html/rfc6455#page-17

The way the RFC is worded could be interpreted to mean the port on the Host header is optional except if it is a default port, in which case it should not be included.

This will change will leave the port off of the Host header if it is a default port, even if it was explicitly specified.