### PR TITLE
Make websocket events be in line with browser

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -411,7 +411,7 @@ WebSocket.prototype.addEventListener = function(method, listener) {
   var target = this;
 
   function onMessage (data, flags) {
-    listener.call(target, new MessageEvent(data, flags.binary ? 'Binary' : 'Text', target));
+    listener.call(target, new MessageEvent(data, !!flags.binary, target));
   }
 
   function onClose (code, message) {
@@ -419,6 +419,7 @@ WebSocket.prototype.addEventListener = function(method, listener) {
   }
 
   function onError (event) {
+    event.type = 'error';
     event.target = target;
     listener.call(target, event);
   }
@@ -463,10 +464,11 @@ module.exports = WebSocket;
  * @constructor
  * @api private
  */
-function MessageEvent(dataArg, typeArg, target) {
+function MessageEvent(dataArg, isBinary, target) {
+  this.type = 'message';
   this.data = dataArg;
-  this.type = typeArg;
   this.target = target;
+  this.binary = isBinary; // non-standard.
 }
 
 /**
@@ -477,6 +479,7 @@ function MessageEvent(dataArg, typeArg, target) {
  * @api private
  */
 function CloseEvent(code, reason, target) {
+  this.type = 'close';
   this.wasClean = (typeof code === 'undefined' || code === 1000);
   this.code = code;
   this.reason = reason;
@@ -491,6 +494,7 @@ function CloseEvent(code, reason, target) {
  * @api private
  */
 function OpenEvent(target) {
+  this.type = 'open';
   this.target = target;
 }
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -706,7 +706,7 @@ describe('WebSocket', function() {
           ws.send(array.buffer);
         });
         ws.onmessage = function (event) {
-          assert.ok(event.type = 'Binary');
+          assert.ok(event.binary);
           assert.ok(areArraysEqual(array, new Float32Array(getArrayBuffer(event.data))));
           ws.terminate();
           srv.close();
@@ -723,7 +723,7 @@ describe('WebSocket', function() {
           ws.send(buf);
         });
         ws.onmessage = function (event) {
-          assert.ok(event.type = 'Binary');
+          assert.ok(event.binary);
           assert.ok(areArraysEqual(event.data, buf));
           ws.terminate();
           srv.close();
@@ -1595,6 +1595,32 @@ describe('WebSocket', function() {
         ws.addEventListener('error', function(errorEvent) {
           assert.equal(errorEvent.message, 'forced');
           assert.equal(ws, errorEvent.target);
+          ws.terminate();
+          done();
+        });
+      });
+      wss.on('connection', function(client) {
+        client.send('hi')
+      });
+    });
+
+    it('should have type set on Events', function(done) {
+      var wss = new WebSocketServer({port: ++port}, function() {
+        var ws = new WebSocket('ws://localhost:' + port);
+        ws.addEventListener('open', function(openEvent) {
+          assert.equal('open', openEvent.type);
+        });
+        ws.addEventListener('message', function(messageEvent) {
+          assert.equal('message', messageEvent.type);
+          wss.close();
+        });
+        ws.addEventListener('close', function(closeEvent) {
+          assert.equal('close', closeEvent.type);
+          ws.emit('error', new Error('forced'));
+        });
+        ws.addEventListener('error', function(errorEvent) {
+          assert.equal(errorEvent.message, 'forced');
+          assert.equal('error', errorEvent.type);
           ws.terminate();
           done();
         });


### PR DESCRIPTION
Fixes #511.

The `type` property of the event should refer to the event type that is being fired. Unfortunately `type` for message events was being used to pass Binary/Text which was not only non-standard but broken applications that relied on the browser behavior.

This PR fixes events to have the proper type, and adds a non-standard `binary` property that has the value of `flags.binary`. If people were relying on `event.type === 'Binary'` or `event.type === 'Text'`, then this is a breaking change.