### PR TITLE
Added maximumPayload option for non-hixie protocols

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -17,6 +17,7 @@ This class is a WebSocket server. It is an `EventEmitter`.
   * `disableHixie` Boolean
   * `clientTracking` Boolean
   * `perMessageDeflate` Boolean|Object
+  * `maximumPayload` Number (requires `disableHixie`)
 * `callback` Function
 
 Construct a new server object.
@@ -119,6 +120,7 @@ This class represents a WebSocket connection. It is an `EventEmitter`.
   * `ciphers` String
   * `rejectUnauthorized` Boolean
   * `perMessageDeflate` Boolean|Object
+  * `maximumPayload` Number (requires `disableHixie`)
 
 Instantiating with an `address` creates a new WebSocket client object. If `address` is an Array (request, socket, rest), it is instantiated as a Server client (e.g. called from the `ws.Server`).
 

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -15,7 +15,7 @@ var util = require('util')
  * HyBi Receiver implementation
  */
 
-function Receiver (extensions) {
+function Receiver (maximumPayload, extensions) {
   // memory pool for fragmented messages
   var fragmentedPoolPrevUsed = -1;
   this.fragmentedBufferPool = new BufferPool(1024, function(db, length) {
@@ -37,6 +37,7 @@ function Receiver (extensions) {
   });
 
   this.extensions = extensions || {};
+  this.maximumPayload = maximumPayload || 0;
   this.state = {
     activeFragmentedOperation: null,
     lastFragment: false,
@@ -54,6 +55,7 @@ function Receiver (extensions) {
   this.expectHeader(2, this.processPacket);
   this.dead = false;
   this.processing = false;
+  this.fragmentedFullLength = 0;
 
   this.onerror = function() {};
   this.ontext = function() {};
@@ -220,6 +222,7 @@ Receiver.prototype.processPacket = function (data) {
     }
     this.state.compressed = compressed;
     this.state.opcode = opcode;
+    this.fragmentedFullLength = 0;
     if (this.state.lastFragment === false) {
       this.state.fragmentedOperation = true;
       this.state.activeFragmentedOperation = opcode;
@@ -278,6 +281,7 @@ Receiver.prototype.reset = function() {
   this.overflow = [];
   this.currentMessage = [];
   this.messageHandlers = [];
+  this.fragmentedFullLength = 0;
 };
 
 /**
@@ -362,6 +366,24 @@ Receiver.prototype.applyExtensions = function(messageBuffer, fin, compressed, ca
 };
 
 /**
+ * Checks the maximum payload and disconnects the socket when invalid.
+ *
+ * @api private
+ */
+Receiver.prototype.checkMaximumPayload = function(length) {
+  if (!this.maximumPayload) {
+    return false;
+  }
+  var fullLength = this.fragmentedFullLength + length;
+  if (fullLength < this.maximumPayload) {
+    this.fragmentedFullLength = fullLength;
+    return false;
+  }
+  this.error('payload cannot exceed ' + this.maximumPayload + ' bytes', 1002);
+  return true;
+};
+
+/**
  * Buffer utilities
  */
 
@@ -421,11 +443,14 @@ var opcodes = {
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
+        if (self.checkMaximumPayload(firstLength)) return;
         opcodes['1'].getData.call(self, firstLength);
       }
       else if (firstLength == 126) {
         self.expectHeader(2, function(data) {
-          opcodes['1'].getData.call(self, readUInt16BE.call(data, 0));
+          var length = readUInt16BE.call(data, 0);
+          if (self.checkMaximumPayload(length)) return;
+          opcodes['1'].getData.call(self, length);
         });
       }
       else if (firstLength == 127) {
@@ -434,7 +459,9 @@ var opcodes = {
             self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
             return;
           }
-          opcodes['1'].getData.call(self, readUInt32BE.call(data, 4));
+          var length = readUInt32BE.call(data, 4);
+          if (self.checkMaximumPayload(length)) return;
+          opcodes['1'].getData.call(self, length);
         });
       }
     },
@@ -462,7 +489,6 @@ var opcodes = {
         self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
           if (err) return self.error(err.message, 1007);
           if (buffer != null) self.currentMessage.push(buffer);
-
           if (state.lastFragment) {
             var messageBuffer = self.concatBuffers(self.currentMessage);
             self.currentMessage = [];
@@ -486,11 +512,14 @@ var opcodes = {
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
+        if (self.checkMaximumPayload(firstLength)) return;
         opcodes['2'].getData.call(self, firstLength);
       }
       else if (firstLength == 126) {
         self.expectHeader(2, function(data) {
-          opcodes['2'].getData.call(self, readUInt16BE.call(data, 0));
+          var length = readUInt16BE.call(data, 0);
+          if (self.checkMaximumPayload(length)) return;
+          opcodes['2'].getData.call(self, length);
         });
       }
       else if (firstLength == 127) {
@@ -499,7 +528,9 @@ var opcodes = {
             self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
             return;
           }
-          opcodes['2'].getData.call(self, readUInt32BE.call(data, 4, true));
+          var length = readUInt32BE.call(data, 4)
+          if (self.checkMaximumPayload(length)) return;
+          opcodes['2'].getData.call(self, length);
         });
       }
     },

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -502,12 +502,14 @@ function initAsServerClient(req, socket, upgradeHead, options) {
   options = new Options({
     protocolVersion: protocolVersion,
     protocol: null,
-    extensions: {}
+    extensions: {},
+    maximumPayload: null
   }).merge(options);
 
   // expose state properties
   this.protocol = options.value.protocol;
   this.protocolVersion = options.value.protocolVersion;
+  this.maximumPayload = options.value.maximumPayload;
   this.extensions = options.value.extensions;
   this.supports.binary = (this.protocolVersion !== 'hixie-76');
   this.upgradeReq = req;
@@ -749,7 +751,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   socket.setTimeout(0);
   socket.setNoDelay(true);
   var self = this;
-  this._receiver = new ReceiverClass(this.extensions);
+  this._receiver = new ReceiverClass(this.maximumPayload, this.extensions);
 
   // socket cleanup handlers
   ultron.on('end', cleanupWebsocketResources.bind(this));

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -32,7 +32,8 @@ function WebSocketServer(options, callback) {
     noServer: false,
     disableHixie: false,
     clientTracking: true,
-    perMessageDeflate: true
+    perMessageDeflate: true,
+    maximumPayload: null
   }).merge(options);
 
   if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {
@@ -244,7 +245,8 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     var client = new WebSocket([req, socket, upgradeHead], {
       protocolVersion: version,
       protocol: protocol,
-      extensions: extensions
+      extensions: extensions,
+      maximumPayload: self.options.maximumPayload
     });
 
     if (self.options.clientTracking) {
@@ -394,7 +396,8 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
           if (err) return; // do not create client if an error happens
           var client = new WebSocket([req, socket, rest], {
             protocolVersion: 'hixie-76',
-            protocol: protocol
+            protocol: protocol,
+            maximumPayload: self.options.maximumPayload
           });
           if (self.options.clientTracking) {
             self.clients.push(client);


### PR DESCRIPTION
See https://github.com/websockets/ws/issues/515

maximumPayload operates on the length of a packet. Fragments are
supported. Essentially it checks the size of a packet against the
configured maximumPayload and throws an error if the client sends a
packet that exceeds the maximum size. This way your server won't have to
allocate resources for it. Do note that with compression enabled, the
deflated resulting buffer can be larger than the maximum payload.