### PR TITLE
Fix for sending typed arrays or ArrayBuffer when perMessageDeflate is enabled

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -267,6 +267,9 @@ Sender.prototype.flush = function() {
 
 Sender.prototype.applyExtensions = function(data, fin, compress, callback) {
   if (compress && data) {
+    if ((data.buffer || data) instanceof ArrayBuffer) {
+      data = getArrayBuffer(data);
+    }
     this.extensions[PerMessageDeflate.extensionName].compress(data, fin, callback);
   } else {
     callback(null, data);

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1902,6 +1902,50 @@ describe('WebSocket', function() {
       });
     });
 
+    it('can send and receive a typed array', function(done) {
+      var array = new Float32Array(5);
+      for (var i = 0; i < array.length; i++) array[i] = i / 2;
+      var wss = new WebSocketServer({port: ++port, perMessageDeflate: true}, function() {
+        var ws = new WebSocket('ws://localhost:' + port, {perMessageDeflate: true});
+        ws.on('open', function() {
+          ws.send(array, {compress: true});
+        });
+        ws.on('message', function(message, flags) {
+          assert.ok(areArraysEqual(array, new Float32Array(getArrayBuffer(message))));
+          ws.terminate();
+          wss.close();
+          done();
+        });
+      });
+      wss.on('connection', function(ws) {
+        ws.on('message', function(message, flags) {
+          ws.send(message, {compress: true});
+        });
+      });
+    });
+
+    it('can send and receive ArrayBuffer', function(done) {
+      var array = new Float32Array(5);
+      for (var i = 0; i < array.length; i++) array[i] = i / 2;
+      var wss = new WebSocketServer({port: ++port, perMessageDeflate: true}, function() {
+        var ws = new WebSocket('ws://localhost:' + port, {perMessageDeflate: true});
+        ws.on('open', function() {
+          ws.send(array.buffer, {compress: true});
+        });
+        ws.on('message', function(message, flags) {
+          assert.ok(areArraysEqual(array, new Float32Array(getArrayBuffer(message))));
+          ws.terminate();
+          wss.close();
+          done();
+        });
+      });
+      wss.on('connection', function(ws) {
+        ws.on('message', function(message, flags) {
+          ws.send(message, {compress: true});
+        });
+      });
+    });
+
     it('with binary stream will send fragmented data', function(done) {
       var wss = new WebSocketServer({port: ++port, perMessageDeflate: true}, function() {
         var ws = new WebSocket('ws://localhost:' + port, {perMessageDeflate: true});


### PR DESCRIPTION
Related: https://github.com/websockets/ws/issues/523