### PR TITLE
websocket: allow path to be specified with unix domain sockets

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -652,7 +652,16 @@ function initAsClient(address, protocols, options) {
   }
 
   if (isUnixSocket) {
-    requestOptions.socketPath = serverUrl.pathname;
+    // An example URL with unix domain socket (UDS) would like:
+    //   ws+unix:///absolule/path/to/uds_socket:/pathname?query_params
+    // At this point, serverUrl.pathname is set to
+    // '/absolule/path/to/uds_socket:/pathname?query_params'
+    // Extract the unix domain socket (UDS) path
+    var udsParts = serverUrl.pathname.split(':'),
+        socketPath = udsParts[0],
+        path = udsParts[1] || '/';
+    requestOptions.socketPath = socketPath;
+    requestOptions.path = path;
   }
   if (options.value.origin) {
     if (options.value.protocolVersion < 13) requestOptions.headers['Sec-WebSocket-Origin'] = options.value.origin;

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -108,6 +108,21 @@ describe('WebSocketServer', function() {
           });
         });
       });
+
+      it('uses http server listening on unix socket at /foo path', function (done) {
+        var srv = http.createServer();
+        var sockPath = '/tmp/ws_socket_'+new Date().getTime()+'.'+Math.floor(Math.random() * 1000);
+        srv.listen(sockPath, function () {
+          var wss = new WebSocketServer({server: srv, path: '/foo'});
+          var ws = new WebSocket('ws+unix://'+sockPath+':/foo?param1=bar');
+
+          wss.on('connection', function(client) {
+            wss.close();
+            srv.close();
+            done();
+          });
+        });
+      });
     }
 
     it('emits path specific connection event', function (done) {


### PR DESCRIPTION
This change allows URL path with params to be specified with
unix domain socket URLs.

And example URL with unix domain socket looks like:
  ws+unix:///absolule/path/to/uds_socket:/pathname?query_params

Note, ':' is the separator between socket path and URL path.

Existing URLs like the following also work:
  ws+unix:///absolule/path/to/uds_socket

In the above case, path gets set to '/'.
