### PR TITLE
Allow pending CLOSE_WAIT connections to close

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -54,6 +54,7 @@ function WebSocketServer(options, callback) {
       });
       res.end(body);
     });
+	this._server.allowHalfOpen = false;
     this._server.listen(options.value.port, options.value.host, callback);
     this._closeServer = function() { if (self._server) self._server.close(); };
   }

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -54,7 +54,7 @@ function WebSocketServer(options, callback) {
       });
       res.end(body);
     });
-	this._server.allowHalfOpen = false;
+    this._server.allowHalfOpen = false;
     this._server.listen(options.value.port, options.value.host, callback);
     this._closeServer = function() { if (self._server) self._server.close(); };
   }


### PR DESCRIPTION
HTTP server sets `allowHalfOpen` to true, but we want that to be false in websockets otherwise we get lots of connections with `CLOSE_WAIT` status 