### PR TITLE
Status code should default to 1006 when socket closes abnormally with…

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -912,6 +912,11 @@ function cleanupWebsocketResources(error) {
   this._closeTimer = null;
 
   if (emitClose) {
+    // If the connection was closed abnormally (with an error), 
+    // then the close code must default to 1006.
+    if (error) {
+      this._closeCode = 1006;
+    }
     this.emit('close', this._closeCode || 1000, this._closeMessage || '');
   }
 


### PR DESCRIPTION
This is a fix for issue https://github.com/websockets/ws/issues/543

The new behavior is more consistent with that of the native browser WebSocket API.
According to RFC 6455, the status code 1006 is meant to be used to signify that the connection was closed abnormally (without receiving a close packet). So it looks like it's intended to be set from the client-side as I have done when an error occurs. Please confirm that I made the change in the correct place.

I tried to add a test for this, but it's difficult to do so (the socket's 'close' event did not trigger after calling srv.close() as I thought it would - I would have to launch the server in a separate process... Maybe there is another way).