### PR TITLE
Add io.js 3 to the testing matrix and test only major versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 npm_args: --ws:native
 node_js:
   - "0.12"
@@ -6,16 +7,14 @@ node_js:
   - "0.10"
   - "0.9"
   - "0.8"
-  - "iojs-v1.1"
-  - "iojs-v1.0"
-  - "iojs-v2.0"
+  - "iojs-v1"
+  - "iojs-v2"
+  - "iojs-v3"
 before_install:
-  - "npm install -g npm@2.1.18"
+  - "if [[ $(node --version) == v0.8.* ]]; then npm install -g npm@2.1.18; fi"
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: "0.11"
     - node_js: "0.9"
-    - node_js: "iojs-v1.1"
-    - node_js: "iojs-v1.0"
-    - node_js: "iojs-v2.0"
+    - node_js: "iojs-v3"


### PR DESCRIPTION
Adds io.js to the Travis tests. Also removes tests for minor versions because versions like io.js 1.8.x and 2.5.x weren't being tested.

Also adds `sudo: false` which runs the tests on Travis' docker infrastructure, which launches tests more quickly: http://docs.travis-ci.com/user/migrating-from-legacy/