### PR TITLE
Update gcc/g++ during Travis tests so that we get C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,26 @@ language: node_js
 sudo: false
 npm_args: --ws:native
 node_js:
+  - "iojs-v3"
+  - "iojs-v2"
+  - "iojs-v1"
   - "0.12"
   - "0.11"
   - "0.10"
   - "0.9"
   - "0.8"
-  - "iojs-v1"
-  - "iojs-v2"
-  - "iojs-v3"
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
 before_install:
+  - export CC="gcc-4.9" CXX="g++-4.9"
   - "if [[ $(node --version) == v0.8.* ]]; then npm install -g npm@2.1.18; fi"
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: "0.11"
     - node_js: "0.9"
-    - node_js: "iojs-v3"


### PR DESCRIPTION
Building the native modules (utf-8-validate and bufferutil) with io.js 3.0 requires C++11. Travis uses an ancient version of gcc (4.6) which doesn't support C++11, so this commit tells Travis to install gcc/g++ 4.9 and use it with node-gyp.