### PR TITLE
Return new instance if new keyword is missing.

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -45,7 +45,7 @@ var closeTimeout = 30 * 1000; // Allow 30 seconds to terminate the connection cl
  */
 function WebSocket(address, protocols, options) {
   if (this instanceof WebSocket === false) {
-    throw new TypeError("Classes can't be function-called");
+    return new WebSocket(address, protocols, options);
   }
 
   EventEmitter.call(this);

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -21,7 +21,7 @@ var util = require('util')
 
 function WebSocketServer(options, callback) {
   if (this instanceof WebSocketServer === false) {
-    throw new TypeError("Classes can't be function-called");
+    return new WebSocketServer(options, callback);
   }
 
   events.EventEmitter.call(this);

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -40,15 +40,6 @@ describe('WebSocket', function() {
         done();
       }
     });
-    it('throws TypeError when called without new', function(done) {
-      try {
-        var ws = WebSocket('ws://localhost:' + port);
-      }
-      catch (e) {
-        e.should.be.instanceof(TypeError);
-        done();
-      }
-    });
   });
 
   describe('options', function() {

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -40,6 +40,12 @@ describe('WebSocket', function() {
         done();
       }
     });
+    
+    it('should return a new instance if called without new', function(done) {
+      var ws = WebSocket('ws://localhost:' + port);
+      ws.should.be.an.instanceOf(WebSocket);
+      done();
+    });
   });
 
   describe('options', function() {

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -26,16 +26,6 @@ function areArraysEqual(x, y) {
 
 describe('WebSocketServer', function() {
   describe('#ctor', function() {
-    it('throws TypeError when called without new', function(done) {
-      try {
-        var ws = WebSocketServer({noServer: true});
-      }
-      catch (e) {
-        e.should.be.instanceof(TypeError);
-        done();
-      }
-    });
-
     it('throws an error if no option object is passed', function() {
       var gotException = false;
       try {

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -26,6 +26,12 @@ function areArraysEqual(x, y) {
 
 describe('WebSocketServer', function() {
   describe('#ctor', function() {
+    it('should return a new instance if called without new', function(done) {
+      var ws = WebSocketServer({noServer: true});
+      ws.should.be.an.instanceOf(WebSocketServer);
+      done();
+    });
+    
     it('throws an error if no option object is passed', function() {
       var gotException = false;
       try {


### PR DESCRIPTION
When `WebSocket` and `WebSocketServer` are invoked as a function (i.e. without the `new` keyword), instead of throwing an error (change introduced in PR https://github.com/websockets/ws/pull/468/), it should create and return a new instance.

In addition to this I also removed the related test cases.