### PR TITLE
Remove 'new' from docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --save ws
 
 ```js
 var WebSocket = require('ws');
-var ws = new WebSocket('ws://www.host.com/path');
+var ws = WebSocket('ws://www.host.com/path');
 
 ws.on('open', function open() {
   ws.send('something');
@@ -42,7 +42,7 @@ ws.on('message', function(data, flags) {
 
 ```js
 var WebSocket = require('ws');
-var ws = new WebSocket('ws://www.host.com/path');
+var ws = WebSocket('ws://www.host.com/path');
 
 ws.on('open', function open() {
   var array = new Float32Array(5);
@@ -63,7 +63,7 @@ data.
 
 ```js
 var WebSocketServer = require('ws').Server
-  , wss = new WebSocketServer({ port: 8080 });
+  , wss = WebSocketServer({ port: 8080 });
 
 wss.on('connection', function connection(ws) {
   ws.on('message', function incoming(message) {
@@ -80,7 +80,7 @@ wss.on('connection', function connection(ws) {
 var server = require('http').createServer()
   , url = require('url')
   , WebSocketServer = require('ws').Server
-  , wss = new WebSocketServer({ server: server })
+  , wss = WebSocketServer({ server: server })
   , express = require('express')
   , app = express()
   , port = 4080;
@@ -109,7 +109,7 @@ server.listen(port, function () { console.log('Listening on ' + server.address()
 
 ```js
 var WebSocketServer = require('ws').Server
-  , wss = new WebSocketServer({ port: 8080 });
+  , wss = WebSocketServer({ port: 8080 });
 
 wss.broadcast = function broadcast(data) {
   wss.clients.forEach(function each(client) {
@@ -143,7 +143,7 @@ catch (e) { /* handle error */ }
 
 ```js
 var WebSocket = require('ws');
-var ws = new WebSocket('ws://echo.websocket.org/', {
+var ws = WebSocket('ws://echo.websocket.org/', {
   protocolVersion: 8, 
   origin: 'http://websocket.org'
 });

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -4,7 +4,7 @@
 
 This class is a WebSocket server. It is an `EventEmitter`.
 
-### new ws.Server([options], [callback])
+### ws.Server([options], [callback])
 
 * `options` Object
   * `host` String
@@ -99,7 +99,7 @@ When a new WebSocket connection is established. `socket` is an object of type `w
 
 This class represents a WebSocket connection. It is an `EventEmitter`.
 
-### new ws.WebSocket(address, [protocols], [options])
+### ws.WebSocket(address, [protocols], [options])
 
 * `address` String
 * `protocols` String|Array


### PR DESCRIPTION
Remove `new` keyword from examples and docs. Forgot to include this with PR https://github.com/websockets/ws/pull/572.