### PR TITLE
Fix binary mode sending of strings

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -155,7 +155,7 @@ Sender.prototype.frameAndSend = function(opcode, data, finalFragment, maskData, 
     if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
       data = getArrayBuffer(data);
     } else {
-      data = new Buffer(data);
+      data = new Buffer(data, opcode == 2? 'binary' : 'utf8');
     }
   }
 


### PR DESCRIPTION
See http://stackoverflow.com/a/7094957

When using fs.createReadStream with binary encoding, passing data into send() leads to corruption.
