### PR TITLE
Change the way to get a native WebSocket constructor in browser.js

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,43 +1,31 @@
-
-/**
- * Module dependencies.
- */
-
-var global = (function() { return this; })();
-
 /**
  * WebSocket constructor.
  */
 
-var WebSocket = global.WebSocket || global.MozWebSocket;
+var BrowserWebSocket = WebSocket || MozWebSocket;
+
+/**
+ * WebSocket constructor.
+ *
+ * @param {String} uri
+ * @param {Array} protocols (optional)
+ * @api public
+ */
+
+function ws(uri, protocols) {
+  var instance;
+  if (protocols) {
+    instance = new BrowserWebSocket(uri, protocols);
+  } else {
+    instance = new BrowserWebSocket(uri);
+  }
+  return instance;
+}
+
+if (BrowserWebSocket) ws.prototype = BrowserWebSocket.prototype;
 
 /**
  * Module exports.
  */
 
-module.exports = WebSocket ? ws : null;
-
-/**
- * WebSocket constructor.
- *
- * The third `opts` options object gets ignored in web browsers, since it's
- * non-standard, and throws a TypeError if passed to the constructor.
- * See: https://github.com/einaros/ws/issues/227
- *
- * @param {String} uri
- * @param {Array} protocols (optional)
- * @param {Object) opts (optional)
- * @api public
- */
-
-function ws(uri, protocols, opts) {
-  var instance;
-  if (protocols) {
-    instance = new WebSocket(uri, protocols);
-  } else {
-    instance = new WebSocket(uri);
-  }
-  return instance;
-}
-
-if (WebSocket) ws.prototype = WebSocket.prototype;
+module.exports = BrowserWebSocket ? ws : null;


### PR DESCRIPTION
This makes it works in strict mode and fixes #478. I refered [this](https://github.com/websockets/ws/commit/c6570298126fcbbb46fa70bcfeb51b08a14ba7c5) when writing this patch.