### PR TITLE
Fix error when permessage-deflate is enabled

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -245,7 +245,7 @@ Receiver.prototype.processPacket = function (data) {
 
 Receiver.prototype.endPacket = function() {
   if (!this.state.fragmentedOperation) this.unfragmentedBufferPool.reset(true);
-  else if (this.state.lastFragment) this.fragmentedBufferPool.reset(false);
+  else if (this.state.lastFragment) this.fragmentedBufferPool.reset(true);
   this.expectOffset = 0;
   this.expectBuffer = null;
   this.expectHandler = null;


### PR DESCRIPTION
Fix https://github.com/websockets/ws/issues/594

This PR forces to create a new buffer on each packet process so that buffers would not be affected each other.
As far as I benchmarked this by `bench/speed.js`, there is no performance problem.