### PR TITLE
Also copy WebSocket Ready state constants

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -40,4 +40,10 @@ function ws(uri, protocols, opts) {
   return instance;
 }
 
+// also copy WebSocket Ready state constants
+ws.CONNECTING = WebSocket.CONNECTING;
+ws.OPEN       = WebSocket.OPEN;
+ws.CLOSING    = WebSocket.CLOSING;
+ws.CLOSED     = WebSocket.CLOSED;
+
 if (WebSocket) ws.prototype = WebSocket.prototype;


### PR DESCRIPTION
If you use browserify, ws exports a function called `ws` that doesn't expose the WebSocket Ready state constants. Here is a PR that fixes that. Below you can see an example of this.

http://plnkr.co/edit/pRnHvMs4vYgnGQJEYWzN