### PR TITLE
Clean event handlers on WebSocketServer's internal http server when closing

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -72,13 +72,15 @@ function WebSocketServer(options, callback) {
       this._server._webSocketPaths[options.value.path] = 1;
     }
   }
-  if (this._server) this._server.once('listening', function() { self.emit('listening'); });
+  if (this._server) {
+    this._onceServerListening = function() { self.emit('listening'); };
+    this._server.once('listening', this._onceServerListening);
+  }
 
   if (typeof this._server != 'undefined') {
-    this._server.on('error', function(error) {
-      self.emit('error', error)
-    });
-    this._server.on('upgrade', function(req, socket, upgradeHead) {
+    this._onServerError = function(error) { self.emit('error', error) };
+    this._server.on('error', this._onServerError);
+    this._onServerUpgrade = function(req, socket, upgradeHead) {
       //copy upgradeHead to avoid retention of large slab buffers used in node core
       var head = new Buffer(upgradeHead.length);
       upgradeHead.copy(head);
@@ -87,7 +89,8 @@ function WebSocketServer(options, callback) {
         self.emit('connection'+req.url, client);
         self.emit('connection', client);
       });
-    });
+    };
+    this._server.on('upgrade', this._onServerUpgrade);
   }
 
   this.options = options.value;
@@ -134,6 +137,11 @@ WebSocketServer.prototype.close = function() {
     }
   }
   finally {
+    if (this._server) {
+      this._server.removeListener('listening', this._onceServerListening);
+      this._server.removeListener('error', this._onServerError);
+      this._server.removeListener('upgrade', this._onServerUpgrade);
+    }
     delete this._server;
   }
   if (error) throw error;

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -232,6 +232,18 @@ describe('WebSocketServer', function() {
       });
     });
 
+    it('cleans event handlers on precreated server', function(done) {
+      var srv = http.createServer();
+      srv.listen(++port, function() {
+        var wss = new WebSocketServer({server: srv});
+        wss.close();
+        srv.emit('upgrade');
+        srv.on('error', function() {});
+        srv.emit('error');
+        done()
+      });
+    });
+
     it('cleans up websocket data on a precreated server', function(done) {
       var srv = http.createServer();
       srv.listen(++port, function () {


### PR DESCRIPTION
This gave me quite a headache to debug in a test suite where I had an express server running on the same port as the `WebSocketServer`. I had no need to close the express server, but I needed to close the `WebSocketServer` to do some clean-up between tests. And I had weird error messages popping-up at second test. Turns-out all event handlers (e.g. `"upgrade"`) where still called on the old `WebSocketServer` even though I had closed it after end of first test. 