### PR TITLE
Release memory used by PerMessageDeflate extension

### DIFF
--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -69,6 +69,23 @@ PerMessageDeflate.prototype.accept = function(paramsList) {
 };
 
 /**
+ * Releases all resources used by the extension
+ *
+ * @api public
+ */
+
+PerMessageDeflate.prototype.cleanup = function() {
+  if (this._inflate) {
+    this._inflate.close();
+    this._inflate = null;
+  }
+  if (this._deflate) {
+    this._deflate.close();
+    this._deflate = null;
+  }
+};
+
+/**
  * Accept extension offer from client
  *
  * @api private
@@ -231,9 +248,11 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
   }
 
   function cleanup() {
+    if (!self._inflate) return;
     self._inflate.removeListener('error', onError);
     self._inflate.removeListener('data', onData);
     if (fin && self.params[endpoint + '_no_context_takeover']) {
+      self._inflate.close();
       self._inflate = null;
     }
   }
@@ -281,9 +300,11 @@ PerMessageDeflate.prototype.compress = function (data, fin, callback) {
   }
 
   function cleanup() {
+    if (!self._deflate) return;
     self._deflate.removeListener('error', onError);
     self._deflate.removeListener('data', onData);
     if (fin && self.params[endpoint + '_no_context_takeover']) {
+      self._deflate.close();
       self._deflate = null;
     }
   }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -952,6 +952,12 @@ function cleanupWebsocketResources(error) {
     this._receiver = null;
   }
 
+  if (this.extensions[PerMessageDeflate.extensionName]) {
+    this.extensions[PerMessageDeflate.extensionName].cleanup();
+  }
+
+  this.extensions = null;
+
   this.removeAllListeners();
   this.on('error', function onerror() {}); // catch all errors after this
   delete this._queue;


### PR DESCRIPTION
Hi! It seemed the memory allocated by perMessageDeflate is not properly freed, thus causing memory leaks when this feature is enabled (as reported here https://github.com/websockets/ws/issues/497)

As documented [here](http://www.zlib.net/manual.html) and implemented [here](https://github.com/nodejs/node/blob/master/src/node_zlib.cc#L79), calling `.close()` on DeflateRaw and InflateRaw objects should (at least partially) fix these leaks.

Related: https://github.com/socketio/socket.io/issues/2251

*(please tell me this is it)*