### PR TITLE
Callback for close() on WebSocketServer

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -107,7 +107,7 @@ util.inherits(WebSocketServer, events.EventEmitter);
  * @api public
  */
 
-WebSocketServer.prototype.close = function() {
+WebSocketServer.prototype.close = function(callback) {
   // terminate all associated clients
   var error = null;
   try {
@@ -136,7 +136,10 @@ WebSocketServer.prototype.close = function() {
   finally {
     delete this._server;
   }
-  if (error) throw error;
+  if(callback)
+    callback(error);
+  else if(error)
+    throw error;
 }
 
 /**


### PR DESCRIPTION
This will make close() compatible with Promise libraries like bluebird by providing a callback when its finished.
Note that this version only works correctly for the cases where the http server was **not** internally created.
If you like, you can support the other case as well (would need to pass a callback to `this._closeServer()`).