### PR TITLE
Fix global context detect in strict mode

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var global = (function() { return this; })();
+var global = typeof window !== 'undefined' ? window : global;
 
 /**
  * WebSocket constructor.


### PR DESCRIPTION
`var global = (function() { return this; })()` - isnt great solution, it should return `undefined` when ws defined in scope with 'use strict', or when node_modules transpiled by babel, which add 'use strict' by default.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Securing_JavaScript