### PR TITLE
Change read state values to unique strings

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -88,7 +88,7 @@ util.inherits(WebSocket, EventEmitter);
  * Ready States
  */
 ["CONNECTING", "OPEN", "CLOSING", "CLOSED"].forEach(function each(state, index) {
-    WebSocket.prototype[state] = WebSocket[state] = index;
+    WebSocket.prototype[state] = WebSocket[state] = ('WEBSOCKET_STATE_' + state);
 });
 
 /**


### PR DESCRIPTION
Currently, the ready state values are low integers (0 – 3 inclusive). This could very likely conflict with other constants or cause subtle errors else. Replacing the constants with more unique strings helps prevent conflicts.