### PR TITLE
Fix "zlib binding closed" errors

### DIFF
--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -76,12 +76,20 @@ PerMessageDeflate.prototype.accept = function(paramsList) {
 
 PerMessageDeflate.prototype.cleanup = function() {
   if (this._inflate) {
-    if (this._inflate.close) this._inflate.close();
-    this._inflate = null;
+    if (this._inflate.writeInProgress) {
+      this._inflate.pendingClose = true;
+    } else {
+      if (this._inflate.close) this._inflate.close();
+      this._inflate = null;
+    }
   }
   if (this._deflate) {
-    if (this._deflate.close) this._deflate.close();
-    this._deflate = null;
+    if (this._deflate.writeInProgress) {
+      this._deflate.pendingClose = true;
+    } else {
+      if (this._deflate.close) this._deflate.close();
+      this._deflate = null;
+    }
   }
 };
 
@@ -224,6 +232,7 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
       windowBits: 'number' === typeof maxWindowBits ? maxWindowBits : DEFAULT_WINDOW_BITS
     });
   }
+  this._inflate.writeInProgress = true;
 
   var self = this;
   var buffers = [];
@@ -251,7 +260,8 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
     if (!self._inflate) return;
     self._inflate.removeListener('error', onError);
     self._inflate.removeListener('data', onData);
-    if (fin && self.params[endpoint + '_no_context_takeover']) {
+    self._inflate.writeInProgress = false;
+    if ((fin && self.params[endpoint + '_no_context_takeover']) || self._inflate.pendingClose) {
       if (self._inflate.close) self._inflate.close();
       self._inflate = null;
     }
@@ -275,6 +285,7 @@ PerMessageDeflate.prototype.compress = function (data, fin, callback) {
       memLevel: this._options.memLevel || DEFAULT_MEM_LEVEL
     });
   }
+  this._deflate.writeInProgress = true;
 
   var self = this;
   var buffers = [];
@@ -303,7 +314,8 @@ PerMessageDeflate.prototype.compress = function (data, fin, callback) {
     if (!self._deflate) return;
     self._deflate.removeListener('error', onError);
     self._deflate.removeListener('data', onData);
-    if (fin && self.params[endpoint + '_no_context_takeover']) {
+    self._deflate.writeInProgress = false;
+    if ((fin && self.params[endpoint + '_no_context_takeover']) || self._deflate.pendingClose) {
       if (self._deflate.close) self._deflate.close();
       self._deflate = null;
     }


### PR DESCRIPTION
This should fix https://github.com/websockets/ws/issues/628, which I think is caused by:

- deflate is closed
- `deflate.write()` then triggers an 'error' event
- `cleanup()` removes the listener attached to the 'error' event
- `deflate.flush()` triggers the uncaught error 'zlib binding closed' 

Does this make any sense?
