### PR TITLE
KeepAlive implementation

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -17,6 +17,7 @@ This class is a WebSocket server. It is an `EventEmitter`.
   * `disableHixie` Boolean
   * `clientTracking` Boolean
   * `perMessageDeflate` Boolean|Object
+  * `keepAlive` Boolean|Object
 * `callback` Function
 
 Construct a new server object.
@@ -66,7 +67,14 @@ If `handleProtocols` is not set then the handshake is accepted regardless the va
 
 If a property is empty then either an offered configuration or a default value is used.
 
-### server.close([callback])
+### options.keepAlive
+
+`keepAlive` Makes available a ping pong protocol which allows to check if the connection is alive for all websockets. The extension is disable when false (default value).The extension is enable when an object is instead provided in parameters:
+
+* `interval` Number: the interval of time in milliseconds between a ping request and a pong response. default: 2000.
+* `timeout`  Number: the maximum waiting time between a ping request and the pong response before close the socket. default: 10000.
+
+### server.close()
 
 Close the server and terminate all clients, calls callback when done with an error if one occured.
 
@@ -107,7 +115,7 @@ This class represents a WebSocket connection. It is an `EventEmitter`.
   * `protocol` String
   * `agent` Agent
   * `headers` Object
-  * `protocolVersion` Number|String  
+  * `protocolVersion` Number|String
     -- the following only apply if `address` is a String
   * `host` String
   * `origin` String
@@ -167,6 +175,10 @@ Sends a ping. `data` is sent, `options` is an object with members `mask` and `bi
 
 Sends a pong. `data` is sent, `options` is an object with members `mask` and `binary`. `dontFailWhenClosed` indicates whether or not to throw if the connection isnt open.
 
+### websocket.setKeepAlive([enabled], [interval], [timeout])
+
+Starts a ping pong protocol to check if the connection stays alive. The protocol closes the connection if the client doesn't reply to the ping request before the end of the timeout. enabled boolean enable or disable the keepAlive protocol, interval default: 2000 the time laps in milliseconds between a pong response and a ping request. timeout the maximum waiting time between a ping request and the pong response before closing the socket.
+/!\ Warning: The websocket client must respond to the ping request with a pong message. That is not necessarily the case if you use an other websocket client than WS.
 
 ### websocket.resume()
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -192,6 +192,61 @@ WebSocket.prototype.pong = function(data, options, dontFailWhenClosed) {
 };
 
 /**
+ * Enabled a keepAlive based on ping pong process
+ *
+ * /!\ Warning : The websocket client must respond to the ping request with a pong message.
+ *               That is not necessarily the case if you use an other websocket client than WS.
+ *
+ * @param {boolean} enabled - enable or disable the keepAlive protocol.
+ * @param {number} interval - the interval of time in milliseconds between a ping request and a pong response. default: 2000.
+ * @param {number} timeout - the maximum waiting time between a ping request and the pong response before closing the socket. default: 10000.
+ * @api public
+ */
+WebSocket.prototype.setKeepAlive = function(enabled,interval,timeout){
+  var self = this;
+  if (enabled === false) return remove();
+
+  if (typeof interval !== "number" && interval !== undefined) throw new TypeError('interval must be a number')
+  if (typeof timeout !== "number" && timeout !== undefined) throw new TypeError('timeout must be a number')
+
+  this._keepAliveInterval = interval || 2000;
+  this._keepAliveTimeout = timeout || 10000;
+  this._keepAliveEnabled = enabled || true;
+  this._keepAliveIdTimeout = pingRequest(this,this._keepAliveTimeout);
+  this._keepAliveIdInterval = null;
+
+  this.on('pong',pongResponse);
+  this.on('close',remove);
+
+  function pongResponse(){
+    clearTimeout(self._keepAliveIdTimeout);
+    self._keepAliveIdInterval = setTimeout(function(){
+      self._keepAliveIdTimeout = pingRequest(self,self._keepAliveTimeout);
+    },self._keepAliveInterval);
+  }
+
+  function pingRequest(ws,timeout){
+    ws.ping();
+    return setTimeout(ws.close.bind(ws),timeout);
+  }
+
+  function remove(){
+    if(typeof self._keepAliveIdTimeout == "object"){
+      clearTimeout(self._keepAliveIdTimeout);
+    }
+    if(typeof self._keepAliveIdInterval == "object"){
+      clearTimeout(self._keepAliveIdInterval);
+    }
+    if(typeof self._keepAliveIntervalFunction == "function"){
+      self.removeListener("pong",self._keepAliveIntervalFunction);
+    }
+
+    self.removeListener("close",remove);
+    self._keepAliveEnabled = false;
+  };
+};
+
+/**
  * Resume the client stream
  *
  * @api public

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -43,6 +43,7 @@ function WebSocketServer(options, callback) {
     perMessageDeflate: true,
     maxPayload: 100 * 1024 * 1024,
     backlog: null // use default (511 as implemented in net.js)
+    keepAlive:false
   }, options);
 
   if (!isDefinedAndNonNull(options, 'port') && !isDefinedAndNonNull(options, 'server') && !options.noServer) {
@@ -105,6 +106,15 @@ function WebSocketServer(options, callback) {
       });
     };
     this._server.on('upgrade', this._onServerUpgrade);
+  }
+
+ if (options.keepAlive){
+    if (typeof options.keepAlive.interval !== "number" && options.keepAlive.interval !== undefined){
+      throw new TypeError('the option keepAlive.interval must be a number')
+    }
+    if (typeof options.keepAlive.timeout !== "number" && options.keepAlive.timeout !== undefined){
+      throw new TypeError('the option keepAlive.timeout must be a number')
+    }
   }
 
   this.options = options;
@@ -292,6 +302,10 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
       });
     }
 
+    if (self.options.keepAlive){
+      client.setKeepAlive(true,self.options.keepAlive.interval,self.options.keepAlive.timeout);
+    }
+
     // signal upgrade complete
     socket.removeListener('error', errorHandler);
     cb(client);
@@ -464,6 +478,9 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
                 self.clients.splice(index, 1);
               }
             });
+          }
+          if (self.options.keepAlive){
+            client.setKeepAlive(true,self.options.keepAlive.interval,self.options.keepAlive.timeout);
           }
 
           // signal upgrade complete


### PR DESCRIPTION
Hi ! @nkzawa @humingchun @3rd-Eden
As discussed in the #459 issue.

I implement a Keep Alive protocol using websocket ping/pong.
When the websocket don't reply to a ping with a pong, the serveur close the dead connection .

As it say in the documentation you can active it with a function : 
`websocket.setKeepAlive([enabled], [interval],  [timeout])`

or as recommend @glennschler you can configure a server to enable it for all websockets:
`new ws.Server([options], [callback])`
- `options` Object
  - `keepAlive` Boolean|Object
    - `interval` Number
    - `timeout` Number

This new feacture is documented and unit tested.

Aside from that, I remain open to all suggestions.
