### PR TITLE
Sender: Don't reuse masking key

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -189,7 +189,7 @@ Sender.prototype.frameAndSend = function(opcode, data, finalFragment, maskData, 
 
   if (maskData) {
     outputBuffer[1] = secondByte | 0x80;
-    var mask = this._randomMask || (this._randomMask = getRandomMask());
+    var mask = getRandomMask();
     outputBuffer[dataOffset - 4] = mask[0];
     outputBuffer[dataOffset - 3] = mask[1];
     outputBuffer[dataOffset - 2] = mask[2];


### PR DESCRIPTION
This creates a new masking key for each frame.

Ref: #634 