### PR TITLE
Provide original request object for initial connection

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -84,8 +84,8 @@ function WebSocketServer(options, callback) {
       upgradeHead.copy(head);
 
       self.handleUpgrade(req, socket, head, function(client) {
-        self.emit('connection'+req.url, client);
-        self.emit('connection', client);
+        self.emit('connection'+req.url, client, req);
+        self.emit('connection', client, req);
       });
     });
   }


### PR DESCRIPTION
I could be useful if we have access to the request object that initiated the connection. In my use case this is a way to provide initial parameters for the client.

