### PR TITLE
fix: shrinkStrategy should always return an integer

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -26,7 +26,7 @@ function Receiver (extensions) {
     return db.used + length;
   }, function(db) {
     return fragmentedPoolPrevUsed = fragmentedPoolPrevUsed >= 0 ?
-      (fragmentedPoolPrevUsed + db.used) / 2 :
+      Math.ceil((fragmentedPoolPrevUsed + db.used) / 2) :
       db.used;
   });
 
@@ -36,7 +36,7 @@ function Receiver (extensions) {
     return db.used + length;
   }, function(db) {
     return unfragmentedPoolPrevUsed = unfragmentedPoolPrevUsed >= 0 ?
-      (unfragmentedPoolPrevUsed + db.used) / 2 :
+      Math.ceil((unfragmentedPoolPrevUsed + db.used) / 2) :
       db.used;
   });
 


### PR DESCRIPTION
`Buffer` inherits from `Uint8Arry` so the constructor needs to be
called with integers and mustn't be called with floats.

This patch ensures that the result of the the calculation
in the `shrinkStrategy` in `Receiver` returns an integer.

The reason why this has not been a problem up to now is that
a there is a [V8 Bug](https://code.google.com/p/v8/issues/detail?id=4552)
that the [spec](http://tc39.github.io/ecma262/#sec-typedarray-length)
is not adhered in this case.

This is a blocking issue for [Karma](https://github.com/karma-runner/karma/issues/1768)
as the upgrade to [core-js@2.0.0](https://github.com/zloirock/core-js)
now enforces this error.