### PR TITLE
Add maxpayload limit to hybi clients

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Guidelines
+
+Please contact us directly at **security@3rd-Eden.com** for any bug that might
+impact the security of this project. Please prefix the subject of your email
+with `[security]` in lowercase and square brackets. Our email filters will
+automatically prevent these messages from being moved to our spam box.
+
+You will receive an acknowledgement of your report within **24 hours**.
+
+All emails that do not include security vulnerabilities will be removed and
+blocked instantly.
+
+## Exceptions
+
+If you do not receive an acknowledgement within the said time frame please give
+us the benefit of the doubt as it's possible that we haven't seen it yet. In
+this case please send us a message **without details** using one of the
+following methods:
+
+- Contact the lead developers of this project on their personal e-mails. You
+  can find the e-mails in the git logs, for example using the following command:
+  `git --no-pager show -s --format='%an <%ae>' <gitsha>` where `<gitsha>` is the
+  SHA1 of their latest commit in the project.
+- Create a GitHub issue stating contact details and the severity of the issue.
+
+Once we have acknowledged receipt of your report and confirmed the bug
+ourselves we will work with you to fix the vulnerability and publicly acknowledge
+your responsible disclosure, if you wish. In addition to that we will report
+all vulnerabilities to the [Node Security Project](https://nodesecurity.io/).
+
+## History
+
+04 Jan 2016: [Buffer vulnerablity](https://github.com/websockets/ws/releases/tag/1.0.1)

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -11,7 +11,7 @@ PerMessageDeflate.extensionName = 'permessage-deflate';
  * Per-message Compression Extensions implementation
  */
 
-function PerMessageDeflate(options, isServer) {
+function PerMessageDeflate(options, isServer,maxPayload) {
   if (this instanceof PerMessageDeflate === false) {
     throw new TypeError("Classes can't be function-called");
   }
@@ -21,6 +21,7 @@ function PerMessageDeflate(options, isServer) {
   this._inflate = null;
   this._deflate = null;
   this.params = null;
+  this._maxPayload = maxPayload || 0;
 }
 
 /**
@@ -236,6 +237,7 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
 
   var self = this;
   var buffers = [];
+  var cumulativeBufferLength=0;
 
   this._inflate.on('error', onError).on('data', onData);
   this._inflate.write(data);
@@ -253,7 +255,17 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
   }
 
   function onData(data) {
-    buffers.push(data);
+      if(self._maxPayload!==undefined && self._maxPayload!==null && self._maxPayload>0){
+          cumulativeBufferLength+=data.length;
+          if(cumulativeBufferLength>self._maxPayload){
+            buffers=[];
+            cleanup();
+            var err={type:1009};
+            callback(err);
+            return;
+          }
+      }
+      buffers.push(data);
   }
 
   function cleanup() {

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -15,10 +15,15 @@ var util = require('util')
  * HyBi Receiver implementation
  */
 
-function Receiver (extensions) {
+function Receiver (extensions,maxPayload) {
   if (this instanceof Receiver === false) {
     throw new TypeError("Classes can't be function-called");
   }
+  if(typeof extensions==='number'){
+    maxPayload=extensions;
+    extensions={};
+  }
+
 
   // memory pool for fragmented messages
   var fragmentedPoolPrevUsed = -1;
@@ -39,8 +44,9 @@ function Receiver (extensions) {
       Math.ceil((unfragmentedPoolPrevUsed + db.used) / 2) :
       db.used;
   });
-
   this.extensions = extensions || {};
+  this.maxPayload = maxPayload || 0;
+  this.currentPayloadLength = 0;
   this.state = {
     activeFragmentedOperation: null,
     lastFragment: false,
@@ -54,6 +60,7 @@ function Receiver (extensions) {
   this.expectBuffer = null;
   this.expectHandler = null;
   this.currentMessage = [];
+  this.currentMessageLength = 0;
   this.messageHandlers = [];
   this.expectHeader(2, this.processPacket);
   this.dead = false;
@@ -253,6 +260,7 @@ Receiver.prototype.endPacket = function() {
     // end current fragmented operation
     this.state.activeFragmentedOperation = null;
   }
+  this.currentPayloadLength = 0;
   this.state.lastFragment = false;
   this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
   this.state.masked = false;
@@ -281,7 +289,9 @@ Receiver.prototype.reset = function() {
   this.expectHandler = null;
   this.overflow = [];
   this.currentMessage = [];
+  this.currentMessageLength = 0;
   this.messageHandlers = [];
+  this.currentPayloadLength = 0;
 };
 
 /**
@@ -366,6 +376,27 @@ Receiver.prototype.applyExtensions = function(messageBuffer, fin, compressed, ca
 };
 
 /**
+* Checks payload size, disconnects socket when it exceeds maxPayload
+*
+* @api private
+*/
+Receiver.prototype.maxPayloadExceeded = function(length) {
+  if (this.maxPayload=== undefined || this.maxPayload === null || this.maxPayload < 1) {
+    return false;
+  }
+  var fullLength = this.currentPayloadLength + length;
+  if (fullLength < this.maxPayload) {
+    this.currentPayloadLength = fullLength;
+    return false;
+  }
+  this.error('payload cannot exceed ' + this.maxPayload + ' bytes', 1009);
+  this.messageBuffer=[];
+  this.cleanup();
+
+  return true;
+};
+
+/**
  * Buffer utilities
  */
 
@@ -425,17 +456,31 @@ var opcodes = {
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
+        if (self.maxPayloadExceeded(firstLength)){
+          self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+          return;
+        }
         opcodes['1'].getData.call(self, firstLength);
       }
       else if (firstLength == 126) {
         self.expectHeader(2, function(data) {
-          opcodes['1'].getData.call(self, readUInt16BE.call(data, 0));
+          var length = readUInt16BE.call(data, 0);
+          if (self.maxPayloadExceeded(length)){
+            self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+            return;
+          }
+          opcodes['1'].getData.call(self, length);
         });
       }
       else if (firstLength == 127) {
         self.expectHeader(8, function(data) {
           if (readUInt32BE.call(data, 0) != 0) {
             self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
+            return;
+          }
+          var length = readUInt32BE.call(data, 4);
+          if (self.maxPayloadExceeded(length)){
+            self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
             return;
           }
           opcodes['1'].getData.call(self, readUInt32BE.call(data, 4));
@@ -464,12 +509,29 @@ var opcodes = {
       var state = clone(this.state);
       this.messageHandlers.push(function(callback) {
         self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
-          if (err) return self.error(err.message, 1007);
-          if (buffer != null) self.currentMessage.push(buffer);
-
+          if (err) {
+            if(err.type===1009){
+                return self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+            }
+            return self.error(err.message, 1007);
+          }
+          if (buffer != null) {
+            if( self.maxPayload==0 || (self.maxPayload > 0 && (self.currentMessageLength + buffer.length) < self.maxPayload) ){
+              self.currentMessage.push(buffer);
+            }
+            else{
+                self.currentMessage=null;
+                self.currentMessage = [];
+                self.currentMessageLength = 0;
+                self.error(new Error('Maximum payload exceeded. maxPayload: '+self.maxPayload), 1009);
+                return;
+            }
+            self.currentMessageLength += buffer.length;
+          }
           if (state.lastFragment) {
             var messageBuffer = self.concatBuffers(self.currentMessage);
             self.currentMessage = [];
+            self.currentMessageLength = 0;
             if (!Validation.isValidUTF8(messageBuffer)) {
               self.error('invalid utf8 sequence', 1007);
               return;
@@ -490,11 +552,20 @@ var opcodes = {
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
+          if (self.maxPayloadExceeded(firstLength)){
+            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
+            return;
+          }
         opcodes['2'].getData.call(self, firstLength);
       }
       else if (firstLength == 126) {
         self.expectHeader(2, function(data) {
-          opcodes['2'].getData.call(self, readUInt16BE.call(data, 0));
+          var length = readUInt16BE.call(data, 0);
+          if (self.maxPayloadExceeded(length)){
+            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
+            return;
+          }
+          opcodes['2'].getData.call(self, length);
         });
       }
       else if (firstLength == 127) {
@@ -503,7 +574,12 @@ var opcodes = {
             self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
             return;
           }
-          opcodes['2'].getData.call(self, readUInt32BE.call(data, 4, true));
+          var length = readUInt32BE.call(data, 4, true);
+          if (self.maxPayloadExceeded(length)){
+            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
+            return;
+          }
+          opcodes['2'].getData.call(self, length);
         });
       }
     },
@@ -529,11 +605,29 @@ var opcodes = {
       var state = clone(this.state);
       this.messageHandlers.push(function(callback) {
         self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
-          if (err) return self.error(err.message, 1007);
-          if (buffer != null) self.currentMessage.push(buffer);
+          if (err) {
+            if(err.type===1009){
+                return self.error('Max payload exceeded in compressed binary message. Aborting...', 1009);
+            }
+            return self.error(err.message, 1007);
+          }
+          if (buffer != null) {
+            if( self.maxPayload==0 || (self.maxPayload > 0 && (self.currentMessageLength + buffer.length) < self.maxPayload) ){
+              self.currentMessage.push(buffer);
+            }
+            else{
+                self.currentMessage=null;
+                self.currentMessage = [];
+                self.currentMessageLength = 0;
+                self.error(new Error('Maximum payload exceeded'), 1009);
+                return;
+            }
+            self.currentMessageLength += buffer.length;
+          }
           if (state.lastFragment) {
             var messageBuffer = self.concatBuffers(self.currentMessage);
             self.currentMessage = [];
+            self.currentMessageLength = 0;
             self.onbinary(messageBuffer, {masked: state.masked, buffer: messageBuffer});
           }
           callback();

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -523,7 +523,8 @@ function initAsServerClient(req, socket, upgradeHead, options) {
   options = new Options({
     protocolVersion: protocolVersion,
     protocol: null,
-    extensions: {}
+    extensions: {},
+    maxPayload: 0
   }).merge(options);
 
   // expose state properties
@@ -534,7 +535,7 @@ function initAsServerClient(req, socket, upgradeHead, options) {
   this.upgradeReq = req;
   this.readyState = WebSocket.CONNECTING;
   this._isServer = true;
-
+  this.maxPayload = options.value.maxPayload;
   // establish connection
   if (options.value.protocolVersion === 'hixie-76') {
     establishConnection.call(this, ReceiverHixie, SenderHixie, socket, upgradeHead);
@@ -770,7 +771,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
   socket.setTimeout(0);
   socket.setNoDelay(true);
 
-  this._receiver = new ReceiverClass(this.extensions);
+  this._receiver = new ReceiverClass(this.extensions,this.maxPayload);
   this._socket = socket;
 
   // socket cleanup handlers

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -36,7 +36,8 @@ function WebSocketServer(options, callback) {
     noServer: false,
     disableHixie: false,
     clientTracking: true,
-    perMessageDeflate: true
+    perMessageDeflate: true,
+    maxPayload: null
   }).merge(options);
 
   if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {
@@ -256,7 +257,8 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     var client = new WebSocket([req, socket, upgradeHead], {
       protocolVersion: version,
       protocol: protocol,
-      extensions: extensions
+      extensions: extensions,
+      maxPayload: self.options.maxPayload
     });
 
     if (self.options.clientTracking) {
@@ -489,8 +491,9 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
 function acceptExtensions(offer) {
   var extensions = {};
   var options = this.options.perMessageDeflate;
+  var maxPayload = this.options.maxPayload;
   if (options && offer[PerMessageDeflate.extensionName]) {
-    var perMessageDeflate = new PerMessageDeflate(options !== true ? options : {}, true);
+    var perMessageDeflate = new PerMessageDeflate(options !== true ? options : {}, true, maxPayload);
     perMessageDeflate.accept(offer[PerMessageDeflate.extensionName]);
     extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
   }

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -306,6 +306,82 @@ describe('Receiver', function() {
       });
     });
   });
+    it('will raise an error on a 200kb long masked binary message when maxpayload is 20kb', function() {
+    var p = new Receiver(20480);
+    var length = 200 * 1024;
+    var message = new Buffer(length);
+    for (var i = 0; i < length; ++i) message[i] = i % 256;
+    var originalMessage = getHexStringFromBuffer(message);
+    var packet = '82 ' + getHybiLengthAsHexString(length, true) + ' 34 83 a8 68 ' + getHexStringFromBuffer(mask(message, '34 83 a8 68'));
+
+    var gotError = false;
+    p.error = function(reason,code) {
+      gotError = true;
+      assert.equal(code, 1009);
+    };
+
+    p.add(getBufferFromHexString(packet));
+    gotError.should.be.ok;
+  });
+  it('will raise an error on a 200kb long unmasked binary message when maxpayload is 20kb', function() {
+    var p = new Receiver(20480);
+    var length = 200 * 1024;
+    var message = new Buffer(length);
+    for (var i = 0; i < length; ++i) message[i] = i % 256;
+    var originalMessage = getHexStringFromBuffer(message);
+    var packet = '82 ' + getHybiLengthAsHexString(length, false) + ' ' + getHexStringFromBuffer(message);
+
+    var gotError = false;
+    p.error = function(reason,code) {
+      gotError = true;
+      assert.equal(code, 1009);
+    };
+
+    p.add(getBufferFromHexString(packet));
+    gotError.should.be.ok;
+  });
+  it('will raise an error on a compressed message that exceeds maxpayload of 3bytes', function(done) {
+    var perMessageDeflate = new PerMessageDeflate({},false,3);
+    perMessageDeflate.accept([{}]);
+
+    var p = new Receiver({ 'permessage-deflate': perMessageDeflate },3);
+    var buf = new Buffer('Hellooooooooooooooooooooooooooooooooooooooo');
+
+    p.onerror = function(reason,code) {
+      assert.equal(code, 1009);
+      done();
+    };
+
+    perMessageDeflate.compress(buf, true, function(err, compressed) {
+      if (err) return done(err);
+      p.add(new Buffer([0xc1, compressed.length]));
+      p.add(compressed);
+    });
+  });
+  it('will raise an error on a compressed fragment that exceeds maxpayload of 2 bytes', function(done) {
+    var perMessageDeflate = new PerMessageDeflate({},false,2);
+    perMessageDeflate.accept([{}]);
+
+    var p = new Receiver({ 'permessage-deflate': perMessageDeflate },2);
+    var buf1 = new Buffer('fooooooooooooooooooooooooooooooooooooooooooooooooooooooo');
+    var buf2 = new Buffer('baaaarrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr');
+
+    p.onerror = function(reason,code) {
+      assert.equal(code, 1009);
+      done();
+    };
+
+    perMessageDeflate.compress(buf1, false, function(err, compressed1) {
+      if (err) return done(err);
+      p.add(new Buffer([0x41, compressed1.length]));
+      p.add(compressed1);
+
+      perMessageDeflate.compress(buf2, true, function(err, compressed2) {
+        p.add(new Buffer([0x80, compressed2.length]));
+        p.add(compressed2);
+      });
+    });
+  });
   it('can cleanup during consuming data', function(done) {
     var perMessageDeflate = new PerMessageDeflate();
     perMessageDeflate.accept([{}]);

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -315,6 +315,49 @@ describe('WebSocketServer', function() {
     });
   });
 
+  describe('#maxpayload #hybiOnly', function() {
+    it('maxpayload is passed on to clients,', function(done) {
+      var _maxPayload = 20480;
+      var wss = new WebSocketServer({port: ++port,maxPayload:_maxPayload, disableHixie: true}, function() {
+        wss.clients.length.should.eql(0);
+        var ws = new WebSocket('ws://localhost:' + port);
+      });
+      wss.on('connection', function(client) {
+        wss.clients.length.should.eql(1);
+        wss.clients[0].maxPayload.should.eql(_maxPayload);
+        wss.close();
+        done();
+      });
+    });
+    it('maxpayload is passed on to hybi receivers', function(done) {
+      var _maxPayload = 20480;
+      var wss = new WebSocketServer({port: ++port,maxPayload:_maxPayload,  disableHixie: true}, function() {
+        wss.clients.length.should.eql(0);
+        var ws = new WebSocket('ws://localhost:' + port);
+      });
+      wss.on('connection', function(client) {
+        wss.clients.length.should.eql(1);
+        wss.clients[0]._receiver.maxPayload.should.eql(_maxPayload);
+        wss.close();
+        done();
+      });
+    });
+    it('maxpayload is passed on to permessage-deflate', function(done) {
+      var PerMessageDeflate = require('../lib/PerMessageDeflate');
+      var _maxPayload = 20480;
+      var wss = new WebSocketServer({port: ++port,maxPayload:_maxPayload, disableHixie: true}, function() {
+        wss.clients.length.should.eql(0);
+        var ws = new WebSocket('ws://localhost:' + port);
+      });
+      wss.on('connection', function(client) {
+        wss.clients.length.should.eql(1);
+        wss.clients[0]._receiver.extensions[PerMessageDeflate.extensionName]._maxPayload.should.eql(_maxPayload);
+        wss.close();
+        done();
+      });
+    });
+  });
+
   describe('#handleUpgrade', function() {
     it('can be used for a pre-existing server', function (done) {
       var srv = http.createServer();


### PR DESCRIPTION
Limit the amount of data that can be sent to a websocketserver from a
hybi client.
Raise a 1009 - message too big error.
Tests included.

Borrows some ideas and code from https://github.com/websockets/ws/pull/574/files