### PR TITLE
moved utf-8-validate to normal dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
     "test": "make test"
   },
   "dependencies": {
+    "bufferutil": "1.2.x",
     "options": ">=0.0.5",
-    "ultron": "1.0.x"
+    "ultron": "1.0.x",
+    "utf-8-validate": "1.2.x"
   },
   "devDependencies": {
     "ansi": "0.3.x",
     "benchmark": "0.3.x",
-    "bufferutil": "1.2.x",
     "expect.js": "0.3.x",
     "mocha": "2.3.x",
     "should": "8.0.x",
-    "tinycolor": "0.0.x",
-    "utf-8-validate": "1.2.x"
+    "tinycolor": "0.0.x"
   },
   "gypfile": true
 }


### PR DESCRIPTION
This module is installed as a `devDependency` but is required at runtime.  This just moves it over so it is installed when run with `NODE_ENV=production npm install`.