### PR TITLE
Fix use with browserify/webpack by adding back browser shim.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,9 @@
+/**
+ * Browser stub so we don't break bundlers.
+ * Don't use the export. Instead, check for global.WebSocket presence.
+ */
+module.exports = function removed() {
+  throw new Error('Usage of require("ws") in browsers has been removed. Please instead ' +
+    'attempt to use global.WebSocket first or use process.browser in bundling environments. For example: ' +
+    'var WS = global.WebSocket || global.MozWebSocket || require("ws");')
+}

--- a/package.json
+++ b/package.json
@@ -34,5 +34,11 @@
     "tinycolor": "0.0.x",
     "utf-8-validate": "1.2.x"
   },
+  "browser": "./lib/browser.js",
+  "component": {
+    "scripts": {
+      "ws/index.js": "./lib/browser.js"
+    }
+  },
   "gypfile": true
 }


### PR DESCRIPTION
The shim now errors when you try to use it. Its sole purpose is to prevent
browserify/webpack from trying to bundle the WebsocketServer, which will
obviously fail when trying to bundle 'fs', 'tls', et al.

This fixes some of the problems affecting users in https://github.com/socketio/engine.io-client/issues/450, and fixes compatibility with browserify/webpack without having to explicitly ignore or shim 'ws'.