### PR TITLE
package.json: add bufferutil and utf-8-validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
     "test": "make test"
   },
   "dependencies": {
+    "bufferutil": "1.2.x",
     "options": ">=0.0.5",
-    "ultron": "1.0.x"
+    "ultron": "1.0.x",
+    "utf-8-validate": "1.2.x"
   },
   "devDependencies": {
     "ansi": "0.3.x",
     "benchmark": "0.3.x",
-    "bufferutil": "1.2.x",
     "expect.js": "0.3.x",
     "mocha": "2.3.x",
     "should": "8.0.x",
-    "tinycolor": "0.0.x",
-    "utf-8-validate": "1.2.x"
+    "tinycolor": "0.0.x"
   },
   "gypfile": true
 }


### PR DESCRIPTION
It seems this library needs [bufferutil][] and [utf-8-validate][].

> Error: Cannot find module 'bufferutil' from 'xxx/node_modules/ws/lib'
> Error: Cannot find module 'utf-8-validate' from 'xxx/node_modules/ws/lib'

They're defined in package.json as `devDependencies`, not `dependencies`. This fixes that.

[bufferutil]: https://www.npmjs.com/package/bufferutil
[utf-8-validate]: https://github.com/websockets/utf-8-validate

As seen in [browserify-hmr](https://www.npmjs.com/package/browserify-hmr) (cc @AgentME).