### PR TITLE
[pkg]: add `main` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "simple to use, blazing fast and thoroughly tested websocket client, server and console for node.js, up-to-date against RFC-6455",
   "version": "1.0.1",
   "license": "MIT",
+  "main": "index.js",
   "keywords": [
     "Hixie",
     "HyBi",


### PR DESCRIPTION
I'm attempting to use [nexe](https://github.com/jaredallard/nexe) to build a node application. Lack of the `main` field was causing the bundle to fail. Adding it appears to fix the issue.