### PR TITLE
Added checkServerIdentity option to WebSocket

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -561,6 +561,7 @@ function initAsClient(address, protocols, options) {
     ca: null,
     ciphers: null,
     rejectUnauthorized: null,
+    checkServerIdentity: null,
     perMessageDeflate: true,
     localAddress: null
   }).merge(options);
@@ -645,7 +646,8 @@ function initAsClient(address, protocols, options) {
    || options.isDefinedAndNonNull('cert')
    || options.isDefinedAndNonNull('ca')
    || options.isDefinedAndNonNull('ciphers')
-   || options.isDefinedAndNonNull('rejectUnauthorized')) {
+   || options.isDefinedAndNonNull('rejectUnauthorized')
+   || options.isDefinedAndNonNull('checkServerIdentity')) {
 
     if (options.isDefinedAndNonNull('pfx')) requestOptions.pfx = options.value.pfx;
     if (options.isDefinedAndNonNull('key')) requestOptions.key = options.value.key;
@@ -654,6 +656,7 @@ function initAsClient(address, protocols, options) {
     if (options.isDefinedAndNonNull('ca')) requestOptions.ca = options.value.ca;
     if (options.isDefinedAndNonNull('ciphers')) requestOptions.ciphers = options.value.ciphers;
     if (options.isDefinedAndNonNull('rejectUnauthorized')) requestOptions.rejectUnauthorized = options.value.rejectUnauthorized;
+    if (options.isDefinedAndNonNull('checkServerIdentity')) requestOptions.checkServerIdentity = options.value.checkServerIdentity;
 
     if (!agent) {
         // global agent ignores client side certificates

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -678,8 +678,10 @@ function initAsClient(address, protocols, options) {
     if (isDefinedAndNonNull(options, 'cert')) requestOptions.cert = options.cert;
     if (isDefinedAndNonNull(options, 'ca')) requestOptions.ca = options.ca;
     if (isDefinedAndNonNull(options, 'ciphers')) requestOptions.ciphers = options.ciphers;
-    if (isDefinedAndNonNull(options, 'rejectUnauthorized')) requestOptions.rejectUnauthorized = options.rejectUnauthorized;
-    if (isDefinedAndNonNull(options, 'checkServerIdentity')) requestOptions.checkServerIdentity = options.checkServerIdentity;
+    if (isDefinedAndNonNull(options, 'rejectUnauthorized'))
+      requestOptions.rejectUnauthorized = options.rejectUnauthorized;
+    if (isDefinedAndNonNull(options, 'checkServerIdentity'))
+      requestOptions.checkServerIdentity = options.checkServerIdentity;
 
     if (!agent) {
         // global agent ignores client side certificates


### PR DESCRIPTION
This allows people to use the `checkServerIdentity` option of the underlying https agent.