### PR TITLE
Emit both an error and close event when connection establishment fails

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -936,21 +936,18 @@ function sendStream(instance, stream, options, cb) {
 function cleanupWebsocketResources(error) {
   if (this.readyState === WebSocket.CLOSED) return;
 
-  var emitClose = this.readyState !== WebSocket.CONNECTING;
   this.readyState = WebSocket.CLOSED;
 
   clearTimeout(this._closeTimer);
   this._closeTimer = null;
 
-  if (emitClose) {
-    // If the connection was closed abnormally (with an error), or if
-    // the close control frame was not received then the close code
-    // must default to 1006.
-    if (error || !this._closeReceived) {
-      this._closeCode = 1006;
-    }
-    this.emit('close', this._closeCode || 1000, this._closeMessage || '');
+  // If the connection was closed abnormally (with an error), or if
+  // the close control frame was not received then the close code
+  // must default to 1006.
+  if (error || !this._closeReceived) {
+	this._closeCode = 1006;
   }
+  this.emit('close', this._closeCode || 1000, this._closeMessage || '');
 
   if (this._socket) {
     if (this._ultron) this._ultron.destroy();

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -398,11 +398,13 @@ describe('WebSocket', function() {
         ws.on('open', function() {
           assert.fail('connect shouldnt be raised here');
         });
-        ws.on('close', function() {
-          assert.fail('close shouldnt be raised here');
-        });
+		var errorCallBackFired = false;
         ws.on('error', function() {
+		  errorCallBackFired = true;
+        });
+        ws.on('close', function() {
           setTimeout(function() {
+			assert.equal(true, errorCallBackFired);
             assert.equal(ws.readyState, WebSocket.CLOSED);
             done();
           }, 50)


### PR DESCRIPTION
Hi,

It would be foolish of me to think that the following statement in [WebSocket.js](https://github.com/websockets/ws/blob/master/lib/WebSocket.js) existed for no reason:

```var emitClose = this.readyState !== WebSocket.CONNECTING;```

But this is preventing the ```close``` event from being emitted when the initial HTTP handshake fails. It also creates a discrepancy in behavior between the browser vs a node.js app.

According to [WHATWG](https://html.spec.whatwg.org/multipage/comms.html#the-websocket-interface) and [W3C](https://www.w3.org/TR/websockets/):

> If the establish a WebSocket connection algorithm fails, it triggers the fail the WebSocket connection algorithm, which then invokes the close the WebSocket connection algorithm, which then establishes that the WebSocket connection is closed, which fires the close event

As an FYI, there are a couple of open issues regarding this matter: #672 #505 

I created this PR to find out the rationale behind the decision to suppress the ```close``` event and to address the difference in behavior between the browser and node.js apps.

Let me know your thoughts.

Thanks!