### PR TITLE
fix WebSocketServer options' judgement

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -40,7 +40,7 @@ function WebSocketServer(options, callback) {
     maxPayload: null
   }).merge(options);
 
-  if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {
+  if (!options.value.noServer && (!options.isDefinedAndNonNull('port') || !options.isDefinedAndNonNull('server'))) {
     throw new TypeError('`port` or a `server` must be provided');
   }
 


### PR DESCRIPTION
there is a logic mistake to judge if port or server is provided
I change it as the following logic:
if noServer not true,look for port or server in the options.If both of them are not in the options,throw TypeError