### PR TITLE
Permessage-deflate calls zlib flush with wrong flush level

### DIFF
--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -7,6 +7,7 @@ const DEFAULT_WINDOW_BITS = 15;
 const DEFAULT_MEM_LEVEL = 8;
 const TRAILER = Buffer.from([0x00, 0x00, 0xff, 0xff]);
 const EMPTY_BLOCK = Buffer.from([0x00]);
+const FLUSH_LEVEL = zlib.Z_SYNC_FLUSH;
 
 /**
  * Per-message Compression Extensions implementation
@@ -292,7 +293,7 @@ class PerMessageDeflate {
     if (!this._deflate) {
       var maxWindowBits = this.params[endpoint + '_max_window_bits'];
       this._deflate = zlib.createDeflateRaw({
-        flush: zlib.Z_SYNC_FLUSH,
+        flush: FLUSH_LEVEL,
         windowBits: typeof maxWindowBits === 'number' ? maxWindowBits : DEFAULT_WINDOW_BITS,
         memLevel: this._options.memLevel || DEFAULT_MEM_LEVEL
       });
@@ -304,7 +305,7 @@ class PerMessageDeflate {
 
     this._deflate.on('error', onError).on('data', onData);
     this._deflate.write(data);
-    this._deflate.flush(function () {
+    this._deflate.flush(FLUSH_LEVEL, function () {
       cleanup();
       var data = Buffer.concat(buffers);
       if (fin) {

--- a/test/PerMessageDeflate.test.js
+++ b/test/PerMessageDeflate.test.js
@@ -311,5 +311,32 @@ describe('PerMessageDeflate', function () {
         });
       });
     });
+
+    it('should compress data between contexts when allowed', function (done) {
+      var perMessageDeflate = new PerMessageDeflate();
+      var extensions = Extensions.parse('permessage-deflate');
+      perMessageDeflate.accept(extensions['permessage-deflate']);
+
+      var buf = new Buffer('foofoo');
+      perMessageDeflate.compress(buf, true, function (err, compressed1) {
+        if (err) return done(err);
+
+        perMessageDeflate.decompress(compressed1, true, function (err, data) {
+          if (err) return done(err);
+
+          perMessageDeflate.compress(data, true, function (err, compressed2) {
+            if (err) return done(err);
+
+            perMessageDeflate.decompress(compressed2, true, function (err, data) {
+              if (err) return done(err);
+
+              assert.ok(compressed2.length < compressed1.length);
+              assert.deepEqual(data, buf);
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 });

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -85,9 +85,9 @@ describe('Sender', function () {
           if (fragments.length !== 2) return;
 
           assert.strictEqual(fragments[0][0] & 0x40, 0x40);
-          assert.strictEqual(fragments[0].length, 16);
+          assert.strictEqual(fragments[0].length, 11);
           assert.strictEqual(fragments[1][0] & 0x40, 0x00);
-          assert.strictEqual(fragments[1].length, 11);
+          assert.strictEqual(fragments[1].length, 6);
           done();
         }
       }, {
@@ -135,7 +135,7 @@ describe('Sender', function () {
           assert.strictEqual(fragments[0][0] & 0x40, 0x40);
           assert.strictEqual(fragments[0].length, 3);
           assert.strictEqual(fragments[1][0] & 0x40, 0x00);
-          assert.strictEqual(fragments[1].length, 13);
+          assert.strictEqual(fragments[1].length, 8);
           done();
         }
       }, {
@@ -159,7 +159,7 @@ describe('Sender', function () {
           assert.strictEqual(fragments[0][0] & 0x40, 0x40);
           assert.strictEqual(fragments[0].length, 3);
           assert.strictEqual(fragments[1][0] & 0x40, 0x00);
-          assert.strictEqual(fragments[1].length, 13);
+          assert.strictEqual(fragments[1].length, 8);
           done();
         }
       }, {
@@ -181,7 +181,7 @@ describe('Sender', function () {
           if (fragments.length !== 2) return;
 
           assert.strictEqual(fragments[0][0] & 0x40, 0x40);
-          assert.strictEqual(fragments[0].length, 17);
+          assert.strictEqual(fragments[0].length, 12);
           assert.strictEqual(fragments[1][0] & 0x40, 0x00);
           assert.strictEqual(fragments[1].length, 3);
           done();
@@ -205,7 +205,7 @@ describe('Sender', function () {
           if (fragments.length !== 2) return;
 
           assert.strictEqual(fragments[0][0] & 0x40, 0x40);
-          assert.strictEqual(fragments[0].length, 17);
+          assert.strictEqual(fragments[0].length, 12);
           assert.strictEqual(fragments[1][0] & 0x40, 0x00);
           assert.strictEqual(fragments[1].length, 3);
           done();


### PR DESCRIPTION
I started wondering why very similar packets didn't compress better. Turns out the Node.js API for `zlib` is a tad bit misleading: the kind of flush needs to be specified when calling `flush` even if it's been specified in the options (see https://nodejs.org/api/zlib.html#zlib_zlib_flush_kind_callback). 

This pull requests calls `flush` with the correct level and adds a test that checks that the compression actually makes similar packets smaller.

Note: I gave this only a very preliminary testing. Please do testing across more browsers before even considering merging.
