### PR TITLE
Avoiding memory leaks

### DIFF
--- a/lib/BufferPool.js
+++ b/lib/BufferPool.js
@@ -6,6 +6,12 @@
 
 var util = require('util');
 
+function noop () {}
+
+function defaultGrowStrategy (db, size) {
+  return db.used + size;
+}
+
 function BufferPool(initialSize, growStrategy, shrinkStrategy) {
   if (this instanceof BufferPool === false) {
     throw new TypeError("Classes can't be function-called");
@@ -19,9 +25,7 @@ function BufferPool(initialSize, growStrategy, shrinkStrategy) {
   else if (typeof initialSize === 'undefined') {
     initialSize = 0;
   }
-  this._growStrategy = (growStrategy || function(db, size) {
-    return db.used + size;
-  }).bind(null, this);
+  this._growStrategy = (growStrategy || defaultGrowStrategy).bind(null, this);
   this._shrinkStrategy = (shrinkStrategy || function(db) {
     return initialSize;
   }).bind(null, this);
@@ -36,6 +40,17 @@ function BufferPool(initialSize, growStrategy, shrinkStrategy) {
     return this._used;
   });
 }
+
+BufferPool.prototype.destroy = function () {
+  this.__defineGetter__('size', noop);
+  this.__defineGetter__('used', noop);
+  this._changeFactor = null;
+  this._used = null;
+  this._offset = null;
+  this._buffer = null;
+  this._shrinkStrategy = null;
+  this._growStrategy = null;
+};
 
 BufferPool.prototype.get = function(length) {
   if (this._buffer == null || this._offset + length > this._buffer.length) {

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -123,7 +123,6 @@ ZProcess.prototype.fire = function (job) {
   }
   this.job = job;
   job.go(this.z);
-  console.log(++flushcnt, 'flushes');
   this.z.flush(this.onDone.bind(this));
 };
 ZProcess.prototype.checkJob = function () {

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -1,11 +1,249 @@
-
-var zlib = require('zlib');
+var zlib = require('zlib'),
+  util = require('util');
 
 var AVAILABLE_WINDOW_BITS = [8, 9, 10, 11, 12, 13, 14, 15];
 var DEFAULT_WINDOW_BITS = 15;
 var DEFAULT_MEM_LEVEL = 8;
 
+var flushcnt = 0;
+
 PerMessageDeflate.extensionName = 'permessage-deflate';
+
+function ZJob (data, fin, cb) {
+  this.data = data;
+  this.fin = fin;
+  this.cb = cb;
+  this.buffers = [];
+}
+ZJob.prototype.destroy = function () {
+  this.buffers = null;
+  this.cb = null;
+  this.fin = null;
+  this.data = null;
+};
+ZJob.prototype.push = function (buffer) {
+  this.buffers.push(buffer);
+};
+ZJob.prototype.abort = function (error) {
+  this.cb(error);
+  this.destroy();
+};
+
+function CompressJob (data, fin, cb) {
+  ZJob.call(this, data, fin, cb);
+}
+util.inherits(CompressJob, ZJob);
+CompressJob.prototype.go = function (z) {
+  z.write(this.data);
+};
+CompressJob.prototype.finish = function () {
+  var data = Buffer.concat(this.buffers);
+  if (this.fin) {
+    data = data.slice(0, data.length - 4);
+  }
+  this.cb(null, data);
+  this.destroy();
+};
+
+function DecompressJob (data, fin, cb) {
+  ZJob.call(this, data, fin, cb);
+}
+util.inherits(DecompressJob, ZJob);
+DecompressJob.prototype.go = function (z) {
+  z.write(this.data);
+  if (this.fin) {
+    z.write(new Buffer([0x00, 0x00, 0xff, 0xff]));
+  }
+};
+DecompressJob.prototype.finish = function () {
+  this.cb(null, Buffer.concat(this.buffers));
+  this.destroy();
+};
+
+
+function ZProcess (permessagedeflate) {
+  var endpoint = permessagedeflate._isServer ? 'server' : 'client';
+  var maxWindowBits = permessagedeflate.params[endpoint + '_max_window_bits'];
+  this.endpoint = endpoint;
+  this.pendingClose = false;
+  this.job = null;
+  this.jobs = [];
+  this.permessagedeflate = permessagedeflate;
+  this.z = null;
+  this.createZ(maxWindowBits, permessagedeflate._options.memLevel);
+  this.handler = this.onData.bind(this);
+  this.errorer = this.onError.bind(this);
+  this.doner = this.onDone.bind(this);
+  this.z.on('error', this.errorer).on('data', this.handler);
+}
+ZProcess.prototype.destroy = function () {
+  if (this.z) {
+    this.z.removeListener('data', this.handler);
+    this.z.removeListener('error', this.errorer);
+    this.z.close();
+  }
+  this.z = null;
+  this.doner = null;
+  this.errorer = null;
+  this.handler = null;
+  this.permessagedeflate = null;
+  this.jobs = null;
+  this.job = null; //clear it
+  this.pendingClose = null;
+  this.endpoint = null;
+};
+ZProcess.prototype.inProgress = function () {
+  return this.job || (this.jobs && this.jobs.length);
+};
+ZProcess.prototype.maybeDestroy = function () {
+  if (this.inProgress()) {
+    this.pendingClose = true;
+    return false;
+  }
+  return true;
+};
+ZProcess.prototype.write = function (data, fin, callback) {
+  var job;
+  if (!this.z) {
+    callback(Error('Already destroyed'));
+    return;
+  }
+  job = new this.JobCtor(data, fin, callback);
+  if (this.job) {
+    this.jobs.push(job);
+    return;
+  }
+  this.fire(job);
+};
+ZProcess.prototype.fire = function (job) {
+  if (!this.z) {
+    console.trace();
+    console.error('No Z object on', this);
+    throw Error('No Z object');
+  }
+  this.job = job;
+  job.go(this.z);
+  console.log(++flushcnt, 'flushes');
+  this.z.flush(this.onDone.bind(this));
+};
+ZProcess.prototype.checkJob = function () {
+  if (!this.job) {
+    console.trace();
+    console.error('no job on', this);
+    throw Error('No ZJob to end');
+  }
+};
+ZProcess.prototype.onData = function (buffer) {
+  this.checkJob();
+  this.job.push(buffer);
+};
+ZProcess.prototype.onError = function (err) {
+  this.cb(err);
+  this.destroy();
+};
+ZProcess.prototype.onDone = function () {
+  var job = this.job;
+  this.checkJob();
+  this.job = null;
+  job.finish();
+  if (!this.jobs) {
+    return;
+    console.trace();
+    console.error('already destroyed', this);
+    throw Error('Already destroyed');
+  } else if (this.jobs.length) {
+    this.fire(this.jobs.shift());
+  } else if (this.pendingClose) {
+    this.destroy();
+  } 
+};
+
+function CompressProcess (permessagedeflate) {
+  ZProcess.call(this, permessagedeflate);
+}
+util.inherits(CompressProcess, ZProcess);
+CompressProcess.prototype.destroy = function () {
+  if (!this.permessagedeflate) {
+    return;
+  }
+  if (!ZProcess.prototype.maybeDestroy.call(this)) {
+    return;
+  }
+  /*
+  if (!((this.fin && this.permessagedeflate.params[this.endpoint + '_no_context_takeover']) || this.deflate.pendingClose)) {
+    return;
+  }
+  */
+  this.permessagedeflate._deflate = null;
+  ZProcess.prototype.destroy.call(this);
+};
+CompressProcess.prototype.createZ = function (maxWindowBits, memlevel) {
+  this.z = zlib.createDeflateRaw({
+    flush: zlib.Z_SYNC_FLUSH,
+    windowBits: 'number' === typeof maxWindowBits ? maxWindowBits : DEFAULT_WINDOW_BITS,
+    memLevel: memlevel || DEFAULT_MEM_LEVEL
+  });
+
+};
+CompressProcess.prototype.JobCtor = CompressJob;
+
+function DecompressProcess(permessagedeflate) {
+  ZProcess.call(this, permessagedeflate);
+  this.maxPayload = 
+    ( permessagedeflate._maxPayload!==undefined &&
+      permessagedeflate._maxPayload!==null &&
+      permessagedeflate._maxPayload>0 ) ? permessagedeflate._maxPayload : 0;
+  this.cumulativeBufferLength = 0;
+}
+util.inherits(DecompressProcess, ZProcess);
+DecompressProcess.prototype.destroy = function () {
+  if (!this.permessagedeflate) {
+    return;
+  }
+  if (!ZProcess.prototype.maybeDestroy.call(this)) {
+    return;
+  }
+  /*
+  if (!((this.fin && this.permessagedeflate.params[this.endpoint + '_no_context_takeover']) || this.inflate.pendingClose)) {
+    return;
+  }
+  */
+  this.cumulativeBufferLength = null;
+  this.maxPayload = null;
+  this.permessagedeflate._inflate = null;
+  ZProcess.prototype.destroy.call(this);
+};
+DecompressProcess.prototype.createZ = function (maxWindowBits, memlevel) {
+  this.z = zlib.createInflateRaw({
+    windowBits: 'number' === typeof maxWindowBits ? maxWindowBits : DEFAULT_WINDOW_BITS
+  });
+};
+DecompressProcess.prototype.onError = function (err) {
+  if (this.job) {
+    this.job.abort(err);
+  }
+  this.job = null;
+  if (this.jobs && this.jobs.length) {
+    while(this.jobs.length) {
+      this.jobs.pop().abort(err);
+    }
+  }
+  this.destroy();
+};
+DecompressProcess.prototype.onData = function (buffer) {
+  if(this.maxPayload) {
+      this.cumulativeBufferLength+=buffer.length;
+      if(this.cumulativeBufferLength>this._maxPayload){
+        console.trace();
+        console.error('AAAAAAAAAa');
+        this.cb({type:1009});
+        this.destroy();
+        return;
+      }
+  }
+  ZProcess.prototype.onData.call(this, buffer);
+};
+DecompressProcess.prototype.JobCtor = DecompressJob;
 
 /**
  * Per-message Compression Extensions implementation
@@ -77,20 +315,12 @@ PerMessageDeflate.prototype.accept = function(paramsList) {
 
 PerMessageDeflate.prototype.cleanup = function() {
   if (this._inflate) {
-    if (this._inflate.writeInProgress) {
-      this._inflate.pendingClose = true;
-    } else {
-      if (this._inflate.close) this._inflate.close();
-      this._inflate = null;
-    }
+    this._inflate.destroy();
+    this._inflate = null;
   }
   if (this._deflate) {
-    if (this._deflate.writeInProgress) {
-      this._deflate.pendingClose = true;
-    } else {
-      if (this._deflate.close) this._deflate.close();
-      this._deflate = null;
-    }
+    this._deflate.destroy();
+    this._deflate = null;
   }
 };
 
@@ -151,7 +381,7 @@ PerMessageDeflate.prototype.acceptAsServer = function(paramsList) {
 /**
  * Accept extension response from server
  *
- * @api privaye
+ * @api private
  */
 
 PerMessageDeflate.prototype.acceptAsClient = function(paramsList) {
@@ -224,60 +454,12 @@ PerMessageDeflate.prototype.normalizeParams = function(paramsList) {
  * @api public
  */
 
+
 PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
-  var endpoint = this._isServer ? 'client' : 'server';
-
   if (!this._inflate) {
-    var maxWindowBits = this.params[endpoint + '_max_window_bits'];
-    this._inflate = zlib.createInflateRaw({
-      windowBits: 'number' === typeof maxWindowBits ? maxWindowBits : DEFAULT_WINDOW_BITS
-    });
+    this._inflate = new DecompressProcess(this);
   }
-  this._inflate.writeInProgress = true;
-
-  var self = this;
-  var buffers = [];
-  var cumulativeBufferLength=0;
-
-  this._inflate.on('error', onError).on('data', onData);
-  this._inflate.write(data);
-  if (fin) {
-    this._inflate.write(new Buffer([0x00, 0x00, 0xff, 0xff]));
-  }
-  this._inflate.flush(function() {
-    cleanup();
-    callback(null, Buffer.concat(buffers));
-  });
-
-  function onError(err) {
-    cleanup();
-    callback(err);
-  }
-
-  function onData(data) {
-      if(self._maxPayload!==undefined && self._maxPayload!==null && self._maxPayload>0){
-          cumulativeBufferLength+=data.length;
-          if(cumulativeBufferLength>self._maxPayload){
-            buffers=[];
-            cleanup();
-            var err={type:1009};
-            callback(err);
-            return;
-          }
-      }
-      buffers.push(data);
-  }
-
-  function cleanup() {
-    if (!self._inflate) return;
-    self._inflate.removeListener('error', onError);
-    self._inflate.removeListener('data', onData);
-    self._inflate.writeInProgress = false;
-    if ((fin && self.params[endpoint + '_no_context_takeover']) || self._inflate.pendingClose) {
-      if (self._inflate.close) self._inflate.close();
-      self._inflate = null;
-    }
-  }
+  this._inflate.write(data, fin, callback);
 };
 
 /**
@@ -287,51 +469,10 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
  */
 
 PerMessageDeflate.prototype.compress = function (data, fin, callback) {
-  var endpoint = this._isServer ? 'server' : 'client';
-
   if (!this._deflate) {
-    var maxWindowBits = this.params[endpoint + '_max_window_bits'];
-    this._deflate = zlib.createDeflateRaw({
-      flush: zlib.Z_SYNC_FLUSH,
-      windowBits: 'number' === typeof maxWindowBits ? maxWindowBits : DEFAULT_WINDOW_BITS,
-      memLevel: this._options.memLevel || DEFAULT_MEM_LEVEL
-    });
+    this._deflate = new CompressProcess(this);
   }
-  this._deflate.writeInProgress = true;
-
-  var self = this;
-  var buffers = [];
-
-  this._deflate.on('error', onError).on('data', onData);
-  this._deflate.write(data);
-  this._deflate.flush(function() {
-    cleanup();
-    var data = Buffer.concat(buffers);
-    if (fin) {
-      data = data.slice(0, data.length - 4);
-    }
-    callback(null, data);
-  });
-
-  function onError(err) {
-    cleanup();
-    callback(err);
-  }
-
-  function onData(data) {
-    buffers.push(data);
-  }
-
-  function cleanup() {
-    if (!self._deflate) return;
-    self._deflate.removeListener('error', onError);
-    self._deflate.removeListener('data', onData);
-    self._deflate.writeInProgress = false;
-    if ((fin && self.params[endpoint + '_no_context_takeover']) || self._deflate.pendingClose) {
-      if (self._deflate.close) self._deflate.close();
-      self._deflate = null;
-    }
-  }
+  this._deflate.write(data, fin, callback);
 };
 
 module.exports = PerMessageDeflate;

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -15,6 +15,11 @@ var util = require('util')
  * HyBi Receiver implementation
  */
 
+function growStrategy (db, length) {
+  return db.used + length;
+}
+function fragmentedShrinkStrategy (db, length) {
+}
 function Receiver (extensions,maxPayload) {
   if (this instanceof Receiver === false) {
     throw new TypeError("Classes can't be function-called");
@@ -27,9 +32,7 @@ function Receiver (extensions,maxPayload) {
 
   // memory pool for fragmented messages
   var fragmentedPoolPrevUsed = -1;
-  this.fragmentedBufferPool = new BufferPool(1024, function(db, length) {
-    return db.used + length;
-  }, function(db) {
+  this.fragmentedBufferPool = new BufferPool(1024, growStrategy, function(db) {
     return fragmentedPoolPrevUsed = fragmentedPoolPrevUsed >= 0 ?
       Math.ceil((fragmentedPoolPrevUsed + db.used) / 2) :
       db.used;
@@ -37,9 +40,7 @@ function Receiver (extensions,maxPayload) {
 
   // memory pool for unfragmented messages
   var unfragmentedPoolPrevUsed = -1;
-  this.unfragmentedBufferPool = new BufferPool(1024, function(db, length) {
-    return db.used + length;
-  }, function(db) {
+  this.unfragmentedBufferPool = new BufferPool(1024, growStrategy, function(db) {
     return unfragmentedPoolPrevUsed = unfragmentedPoolPrevUsed >= 0 ?
       Math.ceil((unfragmentedPoolPrevUsed + db.used) / 2) :
       db.used;
@@ -116,7 +117,13 @@ Receiver.prototype.cleanup = function() {
   this.headerBuffer = null;
   this.expectBuffer = null;
   this.expectHandler = null;
+  if (this.unfragmentedBufferPool) {
+    this.unfragmentedBufferPool.destroy();
+  }
   this.unfragmentedBufferPool = null;
+  if (this.fragmentedBufferPool) {
+    this.fragmentedBufferPool.destroy();
+  }
   this.fragmentedBufferPool = null;
   this.state = null;
   this.currentMessage = null;
@@ -342,13 +349,14 @@ Receiver.prototype.flush = function() {
   if (!handler) return;
 
   this.processing = true;
-  var self = this;
 
-  handler(function() {
-    self.processing = false;
-    self.flush();
-  });
+  handler(flusher.bind(this));
 };
+
+function flusher () {
+  this.processing = false;
+  this.flush();
+}
 
 /**
  * Apply extensions to message
@@ -357,20 +365,21 @@ Receiver.prototype.flush = function() {
  */
 
 Receiver.prototype.applyExtensions = function(messageBuffer, fin, compressed, callback) {
-  var self = this;
   if (compressed) {
-    this.extensions[PerMessageDeflate.extensionName].decompress(messageBuffer, fin, function(err, buffer) {
-      if (self.dead) return;
-      if (err) {
-        callback(new Error('invalid compressed data'));
-        return;
-      }
-      callback(null, buffer);
-    });
+    this.extensions[PerMessageDeflate.extensionName].decompress(messageBuffer, fin, onExtensionApplied.bind(this, callback));
   } else {
     callback(null, messageBuffer);
   }
 };
+
+function onExtensionApplied (callback, err, buffer) {
+  if (this.dead) return;
+  if (err) {
+    callback(new Error('invalid compressed data'));
+    return;
+  }
+  callback(null, buffer);
+}
 
 /**
 * Checks payload size, disconnects socket when it exceeds maxPayload
@@ -448,344 +457,352 @@ function clone(obj) {
 var opcodes = {
   // text
   '1': {
+    onHeader2: function(data) {
+      var length = readUInt16BE.call(data, 0);
+      if (this.maxPayloadExceeded(length)){
+        this.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+        return;
+      }
+      opcodes['1'].getData.call(this, length);
+    },
+    onHeader8: function(data) {
+      if (readUInt32BE.call(data, 0) != 0) {
+        this.error('packets with length spanning more than 32 bit is currently not supported', 1008);
+        return;
+      }
+      var length = readUInt32BE.call(data, 4);
+      if (this.maxPayloadExceeded(length)){
+        this.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+        return;
+      }
+      opcodes['1'].getData.call(this, readUInt32BE.call(data, 4));
+    },
+    onHeader4: function(length, data) {
+      this.expectData(length, opcodes['1'].onDataFromHeader4.bind(this, data));
+    },
+    onDataFromHeader4: function(mask, data) {
+      opcodes['1'].finish.call(this, mask, data);
+    },
+    onData: function(data) {
+      opcodes['1'].finish.call(this, null, data);
+    },
+    messageHandler: function(packet, state, callback) {
+      this.applyExtensions(packet, state.lastFragment, state.compressed, opcodes['1'].onExtensions.bind(this, state, callback));
+    },
+    onExtensions: function(state, callback, err, buffer) {
+      if (err) {
+        if(err.type===1009){
+            return this.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+        }
+        return this.error(err.message, 1007);
+      }
+      if (buffer != null) {
+        if( this.maxPayload==0 || (this.maxPayload > 0 && (this.currentMessageLength + buffer.length) < this.maxPayload) ){
+          this.currentMessage.push(buffer);
+        }
+        else{
+            this.currentMessage=null;
+            this.currentMessage = [];
+            this.currentMessageLength = 0;
+            this.error(new Error('Maximum payload exceeded. maxPayload: '+this.maxPayload), 1009);
+            return;
+        }
+        this.currentMessageLength += buffer.length;
+      }
+      if (state.lastFragment) {
+        var messageBuffer = Buffer.concat(this.currentMessage);
+        this.currentMessage = [];
+        this.currentMessageLength = 0;
+        if (!Validation.isValidUTF8(messageBuffer)) {
+          this.error('invalid utf8 sequence', 1007);
+          return;
+        }
+        this.ontext(messageBuffer.toString('utf8'), {masked: state.masked, buffer: messageBuffer});
+      }
+      callback();
+    },
     start: function(data) {
-      var self = this;
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        if (self.maxPayloadExceeded(firstLength)){
-          self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
+        if (this.maxPayloadExceeded(firstLength)){
+          this.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
           return;
         }
-        opcodes['1'].getData.call(self, firstLength);
+        opcodes['1'].getData.call(this, firstLength);
       }
       else if (firstLength == 126) {
-        self.expectHeader(2, function(data) {
-          var length = readUInt16BE.call(data, 0);
-          if (self.maxPayloadExceeded(length)){
-            self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
-            return;
-          }
-          opcodes['1'].getData.call(self, length);
-        });
+        this.expectHeader(2, opcodes['1'].onHeader2.bind(this));
       }
       else if (firstLength == 127) {
-        self.expectHeader(8, function(data) {
-          if (readUInt32BE.call(data, 0) != 0) {
-            self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
-            return;
-          }
-          var length = readUInt32BE.call(data, 4);
-          if (self.maxPayloadExceeded(length)){
-            self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
-            return;
-          }
-          opcodes['1'].getData.call(self, readUInt32BE.call(data, 4));
-        });
+        this.expectHeader(8, opcodes['1'].onHeader8.bind(this));
       }
     },
     getData: function(length) {
-      var self = this;
-      if (self.state.masked) {
-        self.expectHeader(4, function(data) {
-          var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['1'].finish.call(self, mask, data);
-          });
-        });
+      if (this.state.masked) {
+        this.expectHeader(4, opcodes['1'].onHeader4.bind(this, length));
       }
       else {
-        self.expectData(length, function(data) {
-          opcodes['1'].finish.call(self, null, data);
-        });
+        this.expectData(length, opcodes['1'].onData.bind(this));
       }
     },
     finish: function(mask, data) {
-      var self = this;
       var packet = this.unmask(mask, data, true) || new Buffer(0);
       var state = clone(this.state);
-      this.messageHandlers.push(function(callback) {
-        self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
-          if (err) {
-            if(err.type===1009){
-                return self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
-            }
-            return self.error(err.message, 1007);
-          }
-          if (buffer != null) {
-            if( self.maxPayload==0 || (self.maxPayload > 0 && (self.currentMessageLength + buffer.length) < self.maxPayload) ){
-              self.currentMessage.push(buffer);
-            }
-            else{
-                self.currentMessage=null;
-                self.currentMessage = [];
-                self.currentMessageLength = 0;
-                self.error(new Error('Maximum payload exceeded. maxPayload: '+self.maxPayload), 1009);
-                return;
-            }
-            self.currentMessageLength += buffer.length;
-          }
-          if (state.lastFragment) {
-            var messageBuffer = Buffer.concat(self.currentMessage);
-            self.currentMessage = [];
-            self.currentMessageLength = 0;
-            if (!Validation.isValidUTF8(messageBuffer)) {
-              self.error('invalid utf8 sequence', 1007);
-              return;
-            }
-            self.ontext(messageBuffer.toString('utf8'), {masked: state.masked, buffer: messageBuffer});
-          }
-          callback();
-        });
-      });
+      this.messageHandlers.push(opcodes['1'].messageHandler.bind(this, packet, state));
       this.flush();
       this.endPacket();
     }
   },
   // binary
   '2': {
+    onHeader2: function(data) {
+      var length = readUInt16BE.call(data, 0);
+      if (this.maxPayloadExceeded(length)){
+        this.error('Max payload exceeded in compressed text message. Aborting...', 1009);
+        return;
+      }
+      opcodes['2'].getData.call(this, length);
+    },
+    onHeader8: function(data) {
+      if (readUInt32BE.call(data, 0) != 0) {
+        this.error('packets with length spanning more than 32 bit is currently not supported', 1008);
+        return;
+      }
+      var length = readUInt32BE.call(data, 4, true);
+      if (this.maxPayloadExceeded(length)){
+        this.error('Max payload exceeded in compressed text message. Aborting...', 1009);
+        return;
+      }
+      opcodes['2'].getData.call(this, length);
+    },
+    onHeader4: function(length, data) {
+      this.expectData(length, opcodes['2'].onDataFromHeader4.bind(this, data));
+    },
+    onDataFromHeader4: function(mask, data) {
+      opcodes['2'].finish.call(this, mask, data);
+    },
+    onData: function(data) {
+      opcodes['2'].finish.call(this, null, data);
+    },
+    messageHandler: function(packet, state, callback) {
+      this.applyExtensions(packet, state.lastFragment, state.compressed, opcodes['2'].onExtensions.bind(this, state, callback));
+    },
+    onExtensions: function(state, callback, err, buffer) {
+      if (err) {
+        if(err.type===1009){
+            return this.error('Max payload exceeded in compressed binary message. Aborting...', 1009);
+        }
+        return this.error(err.message, 1007);
+      }
+      if (buffer != null) {
+        if( this.maxPayload==0 || (this.maxPayload > 0 && (this.currentMessageLength + buffer.length) < this.maxPayload) ){
+          this.currentMessage.push(buffer);
+        }
+        else{
+            this.currentMessage=null;
+            this.currentMessage = [];
+            this.currentMessageLength = 0;
+            this.error(new Error('Maximum payload exceeded'), 1009);
+            return;
+        }
+        this.currentMessageLength += buffer.length;
+      }
+      if (state.lastFragment) {
+        var messageBuffer = Buffer.concat(this.currentMessage);
+        this.currentMessage = [];
+        this.currentMessageLength = 0;
+        this.onbinary(messageBuffer, {masked: state.masked, buffer: messageBuffer});
+      }
+      callback();
+    },
     start: function(data) {
-      var self = this;
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-          if (self.maxPayloadExceeded(firstLength)){
-            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
+          if (this.maxPayloadExceeded(firstLength)){
+            this.error('Max payload exceeded in compressed text message. Aborting...', 1009);
             return;
           }
-        opcodes['2'].getData.call(self, firstLength);
+        opcodes['2'].getData.call(this, firstLength);
       }
       else if (firstLength == 126) {
-        self.expectHeader(2, function(data) {
-          var length = readUInt16BE.call(data, 0);
-          if (self.maxPayloadExceeded(length)){
-            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
-            return;
-          }
-          opcodes['2'].getData.call(self, length);
-        });
+        this.expectHeader(2, opcodes['2'].onHeader2.bind(this));
       }
       else if (firstLength == 127) {
-        self.expectHeader(8, function(data) {
-          if (readUInt32BE.call(data, 0) != 0) {
-            self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
-            return;
-          }
-          var length = readUInt32BE.call(data, 4, true);
-          if (self.maxPayloadExceeded(length)){
-            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
-            return;
-          }
-          opcodes['2'].getData.call(self, length);
-        });
+        this.expectHeader(8, opcodes['2'].onHeader8.bind(this));
       }
     },
     getData: function(length) {
-      var self = this;
-      if (self.state.masked) {
-        self.expectHeader(4, function(data) {
-          var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['2'].finish.call(self, mask, data);
-          });
-        });
+      if (this.state.masked) {
+        this.expectHeader(4, opcodes['2'].onHeader4.bind(this, length));
       }
       else {
-        self.expectData(length, function(data) {
-          opcodes['2'].finish.call(self, null, data);
-        });
+        this.expectData(length, opcodes['2'].onData.bind(this));
       }
     },
     finish: function(mask, data) {
-      var self = this;
       var packet = this.unmask(mask, data, true) || new Buffer(0);
       var state = clone(this.state);
-      this.messageHandlers.push(function(callback) {
-        self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
-          if (err) {
-            if(err.type===1009){
-                return self.error('Max payload exceeded in compressed binary message. Aborting...', 1009);
-            }
-            return self.error(err.message, 1007);
-          }
-          if (buffer != null) {
-            if( self.maxPayload==0 || (self.maxPayload > 0 && (self.currentMessageLength + buffer.length) < self.maxPayload) ){
-              self.currentMessage.push(buffer);
-            }
-            else{
-                self.currentMessage=null;
-                self.currentMessage = [];
-                self.currentMessageLength = 0;
-                self.error(new Error('Maximum payload exceeded'), 1009);
-                return;
-            }
-            self.currentMessageLength += buffer.length;
-          }
-          if (state.lastFragment) {
-            var messageBuffer = Buffer.concat(self.currentMessage);
-            self.currentMessage = [];
-            self.currentMessageLength = 0;
-            self.onbinary(messageBuffer, {masked: state.masked, buffer: messageBuffer});
-          }
-          callback();
-        });
-      });
+      this.messageHandlers.push(opcodes['2'].messageHandler.bind(this, packet, state));
       this.flush();
       this.endPacket();
     }
   },
   // close
   '8': {
+    onHeader4: function(length, data) {
+      this.expectData(length, opcodes['8'].onDataFromHeader4.bind(this, data));
+    },
+    onDataFromHeader4: function(mask, data) {
+      opcodes['8'].finish.call(this, mask, data);
+    },
+    onData: function(data) {
+      opcodes['8'].finish.call(this, null, data);
+    },
+    messageHandler: function(data, state) {
+      if (data && data.length == 1) {
+        this.error('close packets with data must be at least two bytes long', 1002);
+        return;
+      }
+      var code = data && data.length > 1 ? readUInt16BE.call(data, 0) : 1000;
+      if (!ErrorCodes.isValidErrorCode(code)) {
+        this.error('invalid error code', 1002);
+        return;
+      }
+      var message = '';
+      if (data && data.length > 2) {
+        var messageBuffer = data.slice(2);
+        if (!Validation.isValidUTF8(messageBuffer)) {
+          this.error('invalid utf8 sequence', 1007);
+          return;
+        }
+        message = messageBuffer.toString('utf8');
+      }
+      this.onclose(code, message, {masked: state.masked});
+      this.reset();
+    },
     start: function(data) {
-      var self = this;
-      if (self.state.lastFragment == false) {
-        self.error('fragmented close is not supported', 1002);
+      if (this.state.lastFragment == false) {
+        this.error('fragmented close is not supported', 1002);
         return;
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        opcodes['8'].getData.call(self, firstLength);
+        opcodes['8'].getData.call(this, firstLength);
       }
       else {
-        self.error('control frames cannot have more than 125 bytes of data', 1002);
+        this.error('control frames cannot have more than 125 bytes of data', 1002);
       }
     },
     getData: function(length) {
-      var self = this;
-      if (self.state.masked) {
-        self.expectHeader(4, function(data) {
-          var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['8'].finish.call(self, mask, data);
-          });
-        });
+      if (this.state.masked) {
+        this.expectHeader(4, opcodes['8'].onHeader4.bind(this, length));
       }
       else {
-        self.expectData(length, function(data) {
-          opcodes['8'].finish.call(self, null, data);
-        });
+        this.expectData(length, opcodes['8'].onData.bind(this));
       }
     },
     finish: function(mask, data) {
-      var self = this;
-      data = self.unmask(mask, data, true);
+      data = this.unmask(mask, data, true);
 
       var state = clone(this.state);
-      this.messageHandlers.push(function() {
-        if (data && data.length == 1) {
-          self.error('close packets with data must be at least two bytes long', 1002);
-          return;
-        }
-        var code = data && data.length > 1 ? readUInt16BE.call(data, 0) : 1000;
-        if (!ErrorCodes.isValidErrorCode(code)) {
-          self.error('invalid error code', 1002);
-          return;
-        }
-        var message = '';
-        if (data && data.length > 2) {
-          var messageBuffer = data.slice(2);
-          if (!Validation.isValidUTF8(messageBuffer)) {
-            self.error('invalid utf8 sequence', 1007);
-            return;
-          }
-          message = messageBuffer.toString('utf8');
-        }
-        self.onclose(code, message, {masked: state.masked});
-        self.reset();
-      });
+      this.messageHandlers.push(opcodes['8'].messageHandler.bind(this, data, state));
       this.flush();
     },
   },
   // ping
   '9': {
+    onHeader4: function(length, data) {
+      var mask = data;
+      this.expectData(length, opcodes['9'].onDataFromHeader4.bind(this, data));
+    },
+    onDataFromHeader4: function(mask, data) {
+      opcodes['9'].finish.call(this, mask, data);
+    },
+    onData: function(data) {
+      opcodes['9'].finish.call(this, null, data);
+    },
+    messageHandler: function(data, state, callback) {
+      this.onping(data, {masked: state.masked, binary: true});
+      callback();
+    },
     start: function(data) {
-      var self = this;
-      if (self.state.lastFragment == false) {
-        self.error('fragmented ping is not supported', 1002);
+      if (this.state.lastFragment == false) {
+        this.error('fragmented ping is not supported', 1002);
         return;
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        opcodes['9'].getData.call(self, firstLength);
+        opcodes['9'].getData.call(this, firstLength);
       }
       else {
-        self.error('control frames cannot have more than 125 bytes of data', 1002);
+        this.error('control frames cannot have more than 125 bytes of data', 1002);
       }
     },
     getData: function(length) {
-      var self = this;
-      if (self.state.masked) {
-        self.expectHeader(4, function(data) {
-          var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['9'].finish.call(self, mask, data);
-          });
-        });
+      if (this.state.masked) {
+        this.expectHeader(4, opcodes['9'].onHeader4.bind(this, length));
       }
       else {
-        self.expectData(length, function(data) {
-          opcodes['9'].finish.call(self, null, data);
-        });
+        this.expectData(length, opcodes['9'].onData.bind(this));
       }
     },
     finish: function(mask, data) {
-      var self = this;
       data = this.unmask(mask, data, true);
       var state = clone(this.state);
-      this.messageHandlers.push(function(callback) {
-        self.onping(data, {masked: state.masked, binary: true});
-        callback();
-      });
+      this.messageHandlers.push(opcodes['9'].messageHandler.bind(this, data, state));
       this.flush();
       this.endPacket();
     }
   },
   // pong
   '10': {
+    onHeader4: function(length, data) {
+      var mask = data;
+      this.expectData(length, opcodes['10'].onDataFromHeader4.bind(this, data));
+    },
+    onDataFromHeader4: function(mask, data) {
+      opcodes['10'].finish.call(this, mask, data);
+    },
+    onData: function(data) {
+      opcodes['10'].finish.call(this, null, data);
+    },
+    messageHandler: function(data, state, callback) {
+      this.onpong(data, {masked: state.masked, binary: true});
+      callback();
+    },
     start: function(data) {
-      var self = this;
-      if (self.state.lastFragment == false) {
-        self.error('fragmented pong is not supported', 1002);
+      if (this.state.lastFragment == false) {
+        this.error('fragmented pong is not supported', 1002);
         return;
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        opcodes['10'].getData.call(self, firstLength);
+        opcodes['10'].getData.call(this, firstLength);
       }
       else {
-        self.error('control frames cannot have more than 125 bytes of data', 1002);
+        this.error('control frames cannot have more than 125 bytes of data', 1002);
       }
     },
     getData: function(length) {
-      var self = this;
       if (this.state.masked) {
-        this.expectHeader(4, function(data) {
-          var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['10'].finish.call(self, mask, data);
-          });
-        });
+        this.expectHeader(4, opcodes['10'].onHeader4.bind(this, length));
       }
       else {
-        this.expectData(length, function(data) {
-          opcodes['10'].finish.call(self, null, data);
-        });
+        this.expectData(length, opcodes['10'].onData.bind(this));
       }
     },
     finish: function(mask, data) {
-      var self = this;
-      data = self.unmask(mask, data, true);
+      data = this.unmask(mask, data, true);
       var state = clone(this.state);
-      this.messageHandlers.push(function(callback) {
-        self.onpong(data, {masked: state.masked, binary: true});
-        callback();
-      });
+      this.messageHandlers.push(opcodes['10'].messageHandler.bind(this, data, state));
       this.flush();
       this.endPacket();
     }

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -36,6 +36,12 @@ function Sender(socket, extensions) {
 
 util.inherits(Sender, events.EventEmitter);
 
+function closer (mask, databuffer, cb, callback) {
+  this.frameAndSend(0x8, databuffer, true, mask);
+  callback();
+  if (typeof cb == 'function') cb();
+}
+
 /**
  * Sends a close instruction to the remote party.
  *
@@ -52,14 +58,14 @@ Sender.prototype.close = function(code, data, mask, cb) {
   writeUInt16BE.call(dataBuffer, code, 0);
   if (dataBuffer.length > 2) dataBuffer.write(data, 2);
 
-  var self = this;
-  this.messageHandlers.push(function(callback) {
-    self.frameAndSend(0x8, dataBuffer, true, mask);
-    callback();
-    if (typeof cb == 'function') cb();
-  });
+  this.messageHandlers.push(closer.bind(this, mask, dataBuffer, cb));
   this.flush();
 };
+
+function pinger (mask, data, callback) {
+  this.frameAndSend(0x9, data || '', true, mask);
+  callback();
+}
 
 /**
  * Sends a ping message to the remote party.
@@ -68,14 +74,14 @@ Sender.prototype.close = function(code, data, mask, cb) {
  */
 
 Sender.prototype.ping = function(data, options) {
-  var mask = options && options.mask;
-  var self = this;
-  this.messageHandlers.push(function(callback) {
-    self.frameAndSend(0x9, data || '', true, mask);
-    callback();
-  });
+  this.messageHandlers.push(pinger.bind(this, options && options.mask, data));
   this.flush();
 };
+
+function ponger (mask, data, callback) {
+  this.frameAndSend(0xa, data || '', true, mask);
+  callback();
+}
 
 /**
  * Sends a pong message to the remote party.
@@ -84,14 +90,29 @@ Sender.prototype.ping = function(data, options) {
  */
 
 Sender.prototype.pong = function(data, options) {
-  var mask = options && options.mask;
-  var self = this;
-  this.messageHandlers.push(function(callback) {
-    self.frameAndSend(0xa, data || '', true, mask);
-    callback();
-  });
+  this.messageHandlers.push(ponger.bind(this, options && options.mask, data));
   this.flush();
 };
+
+function onExtensionsAppliedForSend (opcode, finalFragment, mask, compress, cb, callback, err, data) {
+  if (err) {
+    if (typeof cb == 'function') cb(err);
+    else this.emit('error', err);
+    return;
+  }
+  this.frameAndSend(opcode, data, finalFragment, mask, compress, cb);
+  callback();
+}
+
+function sender (data, finalFragment, compressFragment, opcode, mask, compress, cb, callback) {
+  try {
+  this.applyExtensions(data, finalFragment, compressFragment, onExtensionsAppliedForSend.bind(this, opcode, finalFragment, mask, compress, cb, callback ));
+  } catch(e) {
+    console.error(e.stack);
+    console.error(e);
+    process.exit(0);
+  }
+}
 
 /**
  * Sends text or binary data to the remote party.
@@ -111,22 +132,11 @@ Sender.prototype.send = function(data, options, cb) {
     this.firstFragment = false;
     this.compress = compress;
   }
-  if (finalFragment) this.firstFragment = true
+  if (finalFragment) this.firstFragment = true;
 
   var compressFragment = this.compress;
 
-  var self = this;
-  this.messageHandlers.push(function(callback) {
-    self.applyExtensions(data, finalFragment, compressFragment, function(err, data) {
-      if (err) {
-        if (typeof cb == 'function') cb(err);
-        else self.emit('error', err);
-        return;
-      }
-      self.frameAndSend(opcode, data, finalFragment, mask, compress, cb);
-      callback();
-    });
-  });
+  this.messageHandlers.push(sender.bind(this, data, finalFragment, compressFragment, opcode, mask, compress, cb));
   this.flush();
 };
 
@@ -249,6 +259,12 @@ Sender.prototype.frameAndSend = function(opcode, data, finalFragment, maskData, 
   }
 };
 
+
+function flusher() {
+  this.processing = false;
+  this.flush();
+}
+
 /**
  * Execute message handler buffers
  *
@@ -263,12 +279,7 @@ Sender.prototype.flush = function() {
 
   this.processing = true;
 
-  var self = this;
-
-  handler(function() {
-    self.processing = false;
-    self.flush();
-  });
+  handler(flusher.bind(this));
 };
 
 /**

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -72,6 +72,7 @@ function WebSocket(address, protocols, options) {
   this.supports = {};
   this.extensions = {};
   this._binaryType = 'nodebuffer';
+  this._queue = null;
 
   if (Array.isArray(address)) {
     initAsServerClient.apply(this, address.concat(options));
@@ -103,6 +104,7 @@ WebSocket.prototype.close = function close(code, data) {
 
   if (this.readyState === WebSocket.CONNECTING) {
     this.readyState = WebSocket.CLOSED;
+    this.removeAllListeners();
     return;
   }
 
@@ -113,27 +115,28 @@ WebSocket.prototype.close = function close(code, data) {
     return;
   }
 
-  var self = this;
   try {
     this.readyState = WebSocket.CLOSING;
     this._closeCode = code;
     this._closeMessage = data;
     var mask = !this._isServer;
-    this._sender.close(code, data, mask, function(err) {
-      if (err) self.emit('error', err);
-
-      if (self._closeReceived && self._isServer) {
-        self.terminate();
-      } else {
-        // ensure that the connection is cleaned up even when no response of closing handshake.
-        clearTimeout(self._closeTimer);
-        self._closeTimer = setTimeout(cleanupWebsocketResources.bind(self, true), closeTimeout);
-      }
-    });
+    this._sender.close(code, data, mask, onSenderClosed.bind(this));
   } catch (e) {
     this.emit('error', e);
   }
 };
+
+function onSenderClosed(err) {
+  if (err) this.emit('error', err);
+
+  if (this._closeReceived && this._isServer) {
+    this.terminate();
+  } else {
+    // ensure that the connection is cleaned up even when no response of closing handshake.
+    clearTimeout(this._closeTimer);
+    this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
+  }
+}
 
 /**
  * Pause the client stream
@@ -222,8 +225,7 @@ WebSocket.prototype.send = function send(data, options, cb) {
 
   if (!data) data = '';
   if (this._queue) {
-    var self = this;
-    this._queue.push(function() { self.send(data, options, cb); });
+    this._queue.push(this.send.bind(this, data, options, cb));
     return;
   }
 
@@ -254,19 +256,18 @@ WebSocket.prototype.send = function send(data, options, cb) {
 
   if (data instanceof readable) {
     startQueue(this);
-    var self = this;
 
-    sendStream(this, data, options, function send(error) {
-      process.nextTick(function tock() {
-        executeQueueSends(self);
-      });
-
-      if (typeof cb === 'function') cb(error);
-    });
+    sendStream(this, data, options, onStreamSent.bind(this, cb));
   } else {
     this._sender.send(data, options, cb);
   }
 };
+
+function onStreamSent (cb, error) {
+  process.nextTick(executeQueueSends.bind(null, this));
+
+  if (typeof cb === 'function') cb(error);
+}
 
 /**
  * Streams data through calls to a user supplied function
@@ -281,8 +282,6 @@ WebSocket.prototype.stream = function stream(options, cb) {
     options = {};
   }
 
-  var self = this;
-
   if (typeof cb !== 'function') throw new Error('callback must be provided');
 
   if (this.readyState !== WebSocket.OPEN) {
@@ -292,7 +291,7 @@ WebSocket.prototype.stream = function stream(options, cb) {
   }
 
   if (this._queue) {
-    this._queue.push(function () { self.stream(options, cb); });
+    this._queue.push(this.stream.bind(this, options, cb));
     return;
   }
 
@@ -306,24 +305,28 @@ WebSocket.prototype.stream = function stream(options, cb) {
 
   startQueue(this);
 
-  function send(data, final) {
-    try {
-      if (self.readyState !== WebSocket.OPEN) throw new Error('not opened');
-      options.fin = final === true;
-      self._sender.send(data, options);
-      if (!final) process.nextTick(cb.bind(null, null, send));
-      else executeQueueSends(self);
-    } catch (e) {
-      if (typeof cb === 'function') cb(e);
-      else {
-        delete self._queue;
-        self.emit('error', e);
-      }
+  process.nextTick(cb.bind(null, null, streamSend.bind(null, this, options, cb)));
+};
+
+function streamSend(instance, options, cb, data, final) {
+  try {
+    if (instance.readyState !== WebSocket.OPEN) throw new Error('not opened');
+    options.fin = final === true;
+    instance._sender.send(data, options);
+    if (!final) process.nextTick(cb.bind(null, null, streamSend.bind(null, instance, options, cb)));
+    else executeQueueSends(instance);
+  } catch (e) {
+    if (typeof cb === 'function') cb(e);
+    else {
+      instance._queue = null;
+      instance.emit('error', e);
     }
   }
+  instance = null;
+  options = null;
+  cb = null;
+}
 
-  process.nextTick(cb.bind(null, null, send));
-};
 
 /**
  * Immediately shuts down the connection
@@ -566,6 +569,7 @@ function initAsServerClient(req, socket, upgradeHead, options) {
   } else {
     establishConnection.call(this, Receiver, Sender, socket, upgradeHead);
   }
+  options.destroy();
 }
 
 function initAsClient(address, protocols, options) {
@@ -704,188 +708,213 @@ function initAsClient(address, protocols, options) {
     else requestOptions.headers.Origin = options.value.origin;
   }
 
-  var self = this;
   var req = httpObj.request(requestOptions);
 
-  req.on('error', function onerror(error) {
-    self.emit('error', error);
-    cleanupWebsocketResources.call(self, error);
-  });
+  req.on('error', onRequestError.bind(this));
 
-  req.once('response', function response(res) {
-    var error;
+  req.once('response', onRequestResponseOnce.bind(this, req));
 
-    if (!self.emit('unexpected-response', req, res)) {
-      error = new Error('unexpected server response (' + res.statusCode + ')');
-      req.abort();
-      self.emit('error', error);
-    }
-
-    cleanupWebsocketResources.call(self, error);
-  });
-
-  req.once('upgrade', function upgrade(res, socket, upgradeHead) {
-    if (self.readyState === WebSocket.CLOSED) {
-      // client closed before server accepted connection
-      self.emit('close');
-      self.removeAllListeners();
-      socket.end();
-      return;
-    }
-
-    var serverKey = res.headers['sec-websocket-accept'];
-    if (typeof serverKey === 'undefined' || serverKey !== expectedServerKey) {
-      self.emit('error', 'invalid server key');
-      self.removeAllListeners();
-      socket.end();
-      return;
-    }
-
-    var serverProt = res.headers['sec-websocket-protocol'];
-    var protList = (options.value.protocol || "").split(/, */);
-    var protError = null;
-
-    if (!options.value.protocol && serverProt) {
-      protError = 'server sent a subprotocol even though none requested';
-    } else if (options.value.protocol && !serverProt) {
-      protError = 'server sent no subprotocol even though requested';
-    } else if (serverProt && protList.indexOf(serverProt) === -1) {
-      protError = 'server responded with an invalid protocol';
-    }
-
-    if (protError) {
-      self.emit('error', protError);
-      self.removeAllListeners();
-      socket.end();
-      return;
-    } else if (serverProt) {
-      self.protocol = serverProt;
-    }
-
-    var serverExtensions = Extensions.parse(res.headers['sec-websocket-extensions']);
-    if (perMessageDeflate && serverExtensions[PerMessageDeflate.extensionName]) {
-      try {
-        perMessageDeflate.accept(serverExtensions[PerMessageDeflate.extensionName]);
-      } catch (err) {
-        self.emit('error', 'invalid extension parameter');
-        self.removeAllListeners();
-        socket.end();
-        return;
-      }
-      self.extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
-    }
-
-    establishConnection.call(self, Receiver, Sender, socket, upgradeHead);
-
-    // perform cleanup on http resources
-    req.removeAllListeners();
-    req = null;
-    agent = null;
-  });
+  req.once('upgrade', onRequestUpgradeOnce.bind(this, expectedServerKey, options, perMessageDeflate, agent, req));
 
   req.end();
   this.readyState = WebSocket.CONNECTING;
 }
 
-function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
-  var ultron = this._ultron = new Ultron(socket)
-    , called = false
-    , self = this;
+function onRequestError(error) {
+  this.emit('error', error);
+  cleanupWebsocketResources.call(this, error);
+}
 
+function onRequestResponseOnce(req, res) {
+  var error;
+
+  if (!this.emit('unexpected-response', req, res)) {
+    error = new Error('unexpected server response (' + res.statusCode + ')');
+    req.abort();
+    this.emit('error', error);
+  }
+
+  cleanupWebsocketResources.call(this, error);
+  req = null;
+}
+
+function onRequestUpgradeOnce (expectedServerKey, options, perMessageDeflate, agent, req, res, socket, upgradeHead) {
+  if (this.readyState === WebSocket.CLOSED) {
+    // client closed before server accepted connection
+    this.emit('close');
+    this.removeAllListeners();
+    socket.end();
+    return;
+  }
+
+  var serverKey = res.headers['sec-websocket-accept'];
+  if (typeof serverKey === 'undefined' || serverKey !== expectedServerKey) {
+    this.emit('error', 'invalid server key');
+    this.removeAllListeners();
+    socket.end();
+    return;
+  }
+
+  var serverProt = res.headers['sec-websocket-protocol'];
+  var protList = (options.value.protocol || "").split(/, */);
+  var protError = null;
+
+  if (!options.value.protocol && serverProt) {
+    protError = 'server sent a subprotocol even though none requested';
+  } else if (options.value.protocol && !serverProt) {
+    protError = 'server sent no subprotocol even though requested';
+  } else if (serverProt && protList.indexOf(serverProt) === -1) {
+    protError = 'server responded with an invalid protocol';
+  }
+
+  if (protError) {
+    this.emit('error', protError);
+    this.removeAllListeners();
+    socket.end();
+    return;
+  } else if (serverProt) {
+    this.protocol = serverProt;
+  }
+
+  var serverExtensions = Extensions.parse(res.headers['sec-websocket-extensions']);
+  if (perMessageDeflate && serverExtensions[PerMessageDeflate.extensionName]) {
+    try {
+      perMessageDeflate.accept(serverExtensions[PerMessageDeflate.extensionName]);
+    } catch (err) {
+      this.emit('error', 'invalid extension parameter');
+      this.removeAllListeners();
+      socket.end();
+      return;
+    }
+    this.extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
+  }
+
+  establishConnection.call(this, Receiver, Sender, socket, upgradeHead);
+
+  // perform cleanup on http resources
+  req.removeAllListeners();
+  req = null;
+  agent = null;
+}
+
+function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
+  var handlerobj = {called: false, handler: null}
+    , fhb = firstHandler.bind(this, handlerobj, socket, upgradeHead, realHandler.bind(this));
+
+  handlerobj.handler = fhb;
   socket.setTimeout(0);
   socket.setNoDelay(true);
-
+  if (this._ultron) {
+    this._ultron.destroy();
+  }
+  this._ultron = new Ultron(socket);
   this._receiver = new ReceiverClass(this.extensions,this.maxPayload);
   this._socket = socket;
 
   // socket cleanup handlers
-  ultron.on('end', cleanupWebsocketResources.bind(this));
-  ultron.on('close', cleanupWebsocketResources.bind(this));
-  ultron.on('error', cleanupWebsocketResources.bind(this));
+  this._ultron.on('end', cleanupWebsocketResources.bind(this));
+  this._ultron.on('close', cleanupWebsocketResources.bind(this));
+  this._ultron.on('error', cleanupWebsocketResources.bind(this));
 
-  // ensure that the upgradeHead is added to the receiver
-  function firstHandler(data) {
-    if (called || self.readyState === WebSocket.CLOSED) return;
-
-    called = true;
-    socket.removeListener('data', firstHandler);
-    ultron.on('data', realHandler);
-
-    if (upgradeHead && upgradeHead.length > 0) {
-      realHandler(upgradeHead);
-      upgradeHead = null;
-    }
-
-    if (data) realHandler(data);
-  }
-
-  // subsequent packets are pushed straight to the receiver
-  function realHandler(data) {
-    self.bytesReceived += data.length;
-    self._receiver.add(data);
-  }
-
-  ultron.on('data', firstHandler);
+  this._ultron.on('data', fhb);
 
   // if data was passed along with the http upgrade,
   // this will schedule a push of that on to the receiver.
   // this has to be done on next tick, since the caller
   // hasn't had a chance to set event handlers on this client
   // object yet.
-  process.nextTick(firstHandler);
+  process.nextTick(fhb);
 
   // receiver event handlers
-  self._receiver.ontext = function ontext(data, flags) {
-    flags = flags || {};
+  this._receiver.ontext = onTextReceived.bind(this);
 
-    self.emit('message', data, flags);
-  };
+  this._receiver.onbinary = onBinaryReceived.bind(this);
 
-  self._receiver.onbinary = function onbinary(data, flags) {
-    flags = flags || {};
+  this._receiver.onping = onPingReceived.bind(this);
 
-    flags.binary = true;
-    self.emit('message', data, flags);
-  };
+  this._receiver.onpong = onPongReceived.bind(this);
 
-  self._receiver.onping = function onping(data, flags) {
-    flags = flags || {};
+  this._receiver.onclose = onClose.bind(this);
 
-    self.pong(data, {
-      mask: !self._isServer,
-      binary: flags.binary === true
-    }, true);
-
-    self.emit('ping', data, flags);
-  };
-
-  self._receiver.onpong = function onpong(data, flags) {
-    self.emit('pong', data, flags || {});
-  };
-
-  self._receiver.onclose = function onclose(code, data, flags) {
-    flags = flags || {};
-
-    self._closeReceived = true;
-    self.close(code, data);
-  };
-
-  self._receiver.onerror = function onerror(reason, errorCode) {
-    // close the connection when the receiver reports a HyBi error code
-    self.close(typeof errorCode !== 'undefined' ? errorCode : 1002, '');
-    self.emit('error', (reason instanceof Error) ? reason : (new Error(reason)));
-  };
+  this._receiver.onerror = onError.bind(this);
 
   // finalize the client
   this._sender = new SenderClass(socket, this.extensions);
-  this._sender.on('error', function onerror(error) {
-    self.close(1002, '');
-    self.emit('error', error);
-  });
+  this._sender.on('error', onSenderError.bind(this));
 
   this.readyState = WebSocket.OPEN;
   this.emit('open');
 }
+
+// subsequent packets are pushed straight to the receiver
+function realHandler(data) {
+  this.bytesReceived += data.length;
+  this._receiver.add(data);
+}
+
+function onTextReceived(data, flags) {
+  flags = flags || {};
+
+  this.emit('message', data, flags);
+}
+
+function onBinaryReceived(data, flags) {
+  flags = flags || {};
+
+  flags.binary = true;
+  this.emit('message', data, flags);
+}
+
+function onPingReceived(data, flags) {
+  flags = flags || {};
+
+  this.pong(data, {
+    mask: !this._isServer,
+    binary: flags.binary === true
+  }, true);
+
+  this.emit('ping', data, flags);
+}
+
+function onPongReceived(data, flags) {
+  this.emit('pong', data, flags || {});
+}
+
+function onClose(code, data, flags) {
+  flags = flags || {};
+
+  this._closeReceived = true;
+  this.close(code, data);
+}
+
+function onError(reason, errorCode) {
+  // close the connection when the receiver reports a HyBi error code
+  this.close(typeof errorCode !== 'undefined' ? errorCode : 1002, '');
+  this.emit('error', (reason instanceof Error) ? reason : (new Error(reason)));
+}
+
+
+function onSenderError(error) {
+  this.close(1002, '');
+  this.emit('error', error);
+}
+
+// ensure that the upgradeHead is added to the receiver
+function firstHandler(handlerobj, socket, upgradeHead, _realHandler, data) {
+  if (handlerobj.called || this.readyState === WebSocket.CLOSED) return;
+
+  handlerobj.called = true;
+  socket.removeListener('data', handlerobj.handler);
+  this._ultron.on('data', _realHandler);
+
+  if (upgradeHead && upgradeHead.length > 0) {
+    _realHandler(upgradeHead);
+    upgradeHead = null;
+  }
+
+  if (data) _realHandler(data);
+}
+
 
 function startQueue(instance) {
   instance._queue = instance._queue || [];
@@ -893,9 +922,9 @@ function startQueue(instance) {
 
 function executeQueueSends(instance) {
   var queue = instance._queue;
-  if (typeof queue === 'undefined') return;
+  if (!queue) return;
 
-  delete instance._queue;
+  instance._queue = null;
   for (var i = 0, l = queue.length; i < l; ++i) {
     queue[i]();
   }
@@ -906,7 +935,7 @@ function sendStream(instance, stream, options, cb) {
     if (instance.readyState !== WebSocket.OPEN) {
       if (typeof cb === 'function') cb(new Error('not opened'));
       else {
-        delete instance._queue;
+        instance._queue = null;
         instance.emit('error', new Error('not opened'));
       }
       return;
@@ -920,7 +949,7 @@ function sendStream(instance, stream, options, cb) {
     if (instance.readyState !== WebSocket.OPEN) {
       if (typeof cb === 'function') cb(new Error('not opened'));
       else {
-        delete instance._queue;
+        instance._queue = null;
         instance.emit('error', new Error('not opened'));
       }
       return;
@@ -931,6 +960,11 @@ function sendStream(instance, stream, options, cb) {
 
     if (typeof cb === 'function') cb(null);
   });
+}
+
+function onSocketErrorFinal () {
+  try { this.destroy(); }
+  catch (e) {}
 }
 
 function cleanupWebsocketResources(error) {
@@ -951,10 +985,7 @@ function cleanupWebsocketResources(error) {
 
   if (this._socket) {
     if (this._ultron) this._ultron.destroy();
-    this._socket.on('error', function onerror() {
-      try { this.destroy(); }
-      catch (e) {}
-    });
+    this._socket.on('error', onSocketErrorFinal.bind(this));
 
     try {
       if (!error) this._socket.end();
@@ -983,5 +1014,5 @@ function cleanupWebsocketResources(error) {
 
   this.removeAllListeners();
   this.on('error', function onerror() {}); // catch all errors after this
-  delete this._queue;
+  this._queue = null;
 }

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -4,6 +4,8 @@
  * MIT Licensed
  */
 
+'use strict';
+
 var util = require('util')
   , events = require('events')
   , http = require('http')
@@ -38,13 +40,16 @@ function WebSocketServer(options, callback) {
     clientTracking: true,
     perMessageDeflate: true,
     maxPayload: null
-  }).merge(options);
+  },'_destroy').merge(options);
 
   if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {
     throw new TypeError('`port` or a `server` must be provided');
   }
 
-  var self = this;
+  this._closeServer = null;
+  this._onceServerListening = null;
+  this._onServerError = null;
+  this._onServerUpgrade = null;
 
   if (options.isDefinedAndNonNull('port')) {
     this._server = http.createServer(function (req, res) {
@@ -57,7 +62,7 @@ function WebSocketServer(options, callback) {
     });
     this._server.allowHalfOpen = false;
     this._server.listen(options.value.port, options.value.host, callback);
-    this._closeServer = function() { if (self._server) self._server.close(); };
+    this._closeServer = doCloseServer.bind(this);
   }
   else if (options.value.server) {
     this._server = options.value.server;
@@ -74,23 +79,11 @@ function WebSocketServer(options, callback) {
     }
   }
   if (this._server) {
-    this._onceServerListening = function() { self.emit('listening'); };
+    this._onceServerListening = doEmitListening.bind(this);
     this._server.once('listening', this._onceServerListening);
-  }
-
-  if (typeof this._server != 'undefined') {
-    this._onServerError = function(error) { self.emit('error', error) };
+    this._onServerError = doEmitError.bind(this);
     this._server.on('error', this._onServerError);
-    this._onServerUpgrade = function(req, socket, upgradeHead) {
-      //copy upgradeHead to avoid retention of large slab buffers used in node core
-      var head = new Buffer(upgradeHead.length);
-      upgradeHead.copy(head);
-
-      self.handleUpgrade(req, socket, head, function(client) {
-        self.emit('connection'+req.url, client);
-        self.emit('connection', client);
-      });
-    };
+    this._onServerUpgrade = doServerUpgrade.bind(this);
     this._server.on('upgrade', this._onServerUpgrade);
   }
 
@@ -127,14 +120,15 @@ WebSocketServer.prototype.close = function(callback) {
   if (this.path && this._server._webSocketPaths) {
     delete this._server._webSocketPaths[this.path];
     if (Object.keys(this._server._webSocketPaths).length == 0) {
-      delete this._server._webSocketPaths;
+      this._server._webSocketPaths = null;
     }
   }
 
   // close the http server if it was internally created
   try {
-    if (typeof this._closeServer !== 'undefined') {
+    if (typeof this._closeServer === 'function') {
       this._closeServer();
+      this._closeServer = null;
     }
   }
   finally {
@@ -143,12 +137,154 @@ WebSocketServer.prototype.close = function(callback) {
       this._server.removeListener('error', this._onServerError);
       this._server.removeListener('upgrade', this._onServerUpgrade);
     }
-    delete this._server;
+    if (this.options) {
+      this.options._destroy();
+      this.options =null;
+    }
+    this._onceServerListening = null;
+    this._onServerError = null;
+    this._onServerUpgrade = null;
+    this._server = null;
   }
   if(callback)
     callback(error);
   else if(error)
     throw error;
+};
+
+function doCloseServer () {
+  if (this._server) this._server.close();
+}
+
+function doEmitListening () {
+  this.emit('listening');
+}
+
+function doEmitError (error) {
+  this.emit('error', error);
+}
+
+function doServerUpgrade (req, socket, upgradeHead) {
+  //copy upgradeHead to avoid retention of large slab buffers used in node core
+  var head = new Buffer(upgradeHead.length);
+  upgradeHead.copy(head);
+
+  this.handleUpgrade(req, socket, head, doEmitConnectionWithReq.bind(this, req));
+}
+
+function doEmitConnectionWithReq (req, client) {
+  this.emit('connection'+req.url, client);
+  this.emit('connection', client);
+}
+
+function onClientVerifiedForHybiUpgrade (protocols, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket, result, code, name) {
+  if (typeof code === 'undefined') code = 401;
+  if (typeof name === 'undefined') name = http.STATUS_CODES[code];
+
+  if (!result) abortConnection(socket, code, name);
+  else doCompleteHybiUpgrade1.call(this, protocols, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket);
+}
+
+function doCompleteHybiUpgrade1 (protocols, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket) {
+  // choose from the sub-protocols
+  if (typeof this.options.handleProtocols == 'function') {
+      var protList = (protocols || "").split(/, */), 
+        callbackCalledObj = {callbackCalled: false};
+      var res = this.options.handleProtocols(protList, protocolHandlerForHybiUpgrade.bind(this, callbackCalledObj, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket));
+      if (!callbackCalledObj.callbackCalled) {
+          // the handleProtocols handler never called our callback
+          abortConnection(socket, 501, 'Could not process protocols');
+      }
+      return;
+  } else {
+      if (typeof protocols !== 'undefined') {
+        doCompleteHybiUpgrade2.call(this, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket, protocols.split(/, */)[0]);
+      }
+      else {
+        doCompleteHybiUpgrade2.call(this, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket);
+      }
+  }
+}
+
+function protocolHandlerForHybiUpgrade (callbackCalledObj, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket, result, protocol) {
+    callbackCalledObj.callbackCalled = true;
+    if (!result) abortConnection(socket, 401, 'Unauthorized');
+    else doCompleteHybiUpgrade2.call(this, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket, protocol);
+  }
+
+function doCompleteHybiUpgrade2 (version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket, protocol) {
+  // calc key
+  var key = req.headers['sec-websocket-key'];
+  var shasum = crypto.createHash('sha1');
+  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+  key = shasum.digest('base64');
+
+  var headers = [
+      'HTTP/1.1 101 Switching Protocols'
+    , 'Upgrade: websocket'
+    , 'Connection: Upgrade'
+    , 'Sec-WebSocket-Accept: ' + key
+  ];
+
+  if (typeof protocol != 'undefined') {
+    headers.push('Sec-WebSocket-Protocol: ' + protocol);
+  }
+
+  var extensions = {};
+  try {
+    extensions = acceptExtensions.call(this, extensionsOffer);
+  } catch (err) {
+    abortConnection(socket, 400, 'Bad Request');
+    return;
+  }
+
+  if (Object.keys(extensions).length) {
+    var serverExtensions = {};
+    Object.keys(extensions).forEach(function(token) {
+      serverExtensions[token] = [extensions[token].params]
+    });
+    headers.push('Sec-WebSocket-Extensions: ' + Extensions.format(serverExtensions));
+    serverExtensions = null;
+  }
+
+  // allows external modification/inspection of handshake headers
+  this.emit('headers', headers);
+
+  socket.setTimeout(0);
+  socket.setNoDelay(true);
+  try {
+    socket.write(headers.concat('', '').join('\r\n'));
+  }
+  catch (e) {
+    // if the upgrade write fails, shut the connection down hard
+    try { socket.destroy(); } catch (e) {}
+    return;
+  }
+
+  var client = new WebSocket([req, socket, upgradeHead], {
+    protocolVersion: version,
+    protocol: protocol,
+    extensions: extensions,
+    maxPayload: this.options.maxPayload
+  });
+  extensions = null;
+
+  if (this.options.clientTracking) {
+    this.clients.push(client);
+    client.on('close', onClientClosedFromHybiUpgrade.bind(this, client));
+  }
+
+  // signal upgrade complete
+  socket.removeListener('error', errorHandler);
+  cb(client);
+}
+
+function onClientClosedFromHybiUpgrade (client) {
+  var index = this.clients.indexOf(client);
+  if (index != -1) {
+    this.clients.splice(index, 1);
+  }
+  client = null;
 }
 
 /**
@@ -180,11 +316,22 @@ module.exports = WebSocketServer;
  * which may or may not be bound to a sepcific WebSocket instance.
  */
 
+function socketDestroyer (socket) {
+  var _s = socket;
+  return function () {
+    try {
+      _s.destroy();
+      _s = null;
+    } catch(e) {
+      console.error(e.stack);
+      console.error(e);
+    }
+  };
+}
+
 function handleHybiUpgrade(req, socket, upgradeHead, cb) {
   // handle premature socket errors
-  var errorHandler = function() {
-    try { socket.destroy(); } catch (e) {}
-  }
+  var errorHandler = socketDestroyer(socket);
   socket.on('error', errorHandler);
 
   // verify key presence
@@ -211,106 +358,6 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
   // handle extensions offer
   var extensionsOffer = Extensions.parse(req.headers['sec-websocket-extensions']);
 
-  // handler to call when the connection sequence completes
-  var self = this;
-  var completeHybiUpgrade2 = function(protocol) {
-
-    // calc key
-    var key = req.headers['sec-websocket-key'];
-    var shasum = crypto.createHash('sha1');
-    shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
-    key = shasum.digest('base64');
-
-    var headers = [
-        'HTTP/1.1 101 Switching Protocols'
-      , 'Upgrade: websocket'
-      , 'Connection: Upgrade'
-      , 'Sec-WebSocket-Accept: ' + key
-    ];
-
-    if (typeof protocol != 'undefined') {
-      headers.push('Sec-WebSocket-Protocol: ' + protocol);
-    }
-
-    var extensions = {};
-    try {
-      extensions = acceptExtensions.call(self, extensionsOffer);
-    } catch (err) {
-      abortConnection(socket, 400, 'Bad Request');
-      return;
-    }
-
-    if (Object.keys(extensions).length) {
-      var serverExtensions = {};
-      Object.keys(extensions).forEach(function(token) {
-        serverExtensions[token] = [extensions[token].params]
-      });
-      headers.push('Sec-WebSocket-Extensions: ' + Extensions.format(serverExtensions));
-    }
-
-    // allows external modification/inspection of handshake headers
-    self.emit('headers', headers);
-
-    socket.setTimeout(0);
-    socket.setNoDelay(true);
-    try {
-      socket.write(headers.concat('', '').join('\r\n'));
-    }
-    catch (e) {
-      // if the upgrade write fails, shut the connection down hard
-      try { socket.destroy(); } catch (e) {}
-      return;
-    }
-
-    var client = new WebSocket([req, socket, upgradeHead], {
-      protocolVersion: version,
-      protocol: protocol,
-      extensions: extensions,
-      maxPayload: self.options.maxPayload
-    });
-
-    if (self.options.clientTracking) {
-      self.clients.push(client);
-      client.on('close', function() {
-        var index = self.clients.indexOf(client);
-        if (index != -1) {
-          self.clients.splice(index, 1);
-        }
-      });
-    }
-
-    // signal upgrade complete
-    socket.removeListener('error', errorHandler);
-    cb(client);
-  }
-
-  // optionally call external protocol selection handler before
-  // calling completeHybiUpgrade2
-  var completeHybiUpgrade1 = function() {
-    // choose from the sub-protocols
-    if (typeof self.options.handleProtocols == 'function') {
-        var protList = (protocols || "").split(/, */);
-        var callbackCalled = false;
-        var res = self.options.handleProtocols(protList, function(result, protocol) {
-          callbackCalled = true;
-          if (!result) abortConnection(socket, 401, 'Unauthorized');
-          else completeHybiUpgrade2(protocol);
-        });
-        if (!callbackCalled) {
-            // the handleProtocols handler never called our callback
-            abortConnection(socket, 501, 'Could not process protocols');
-        }
-        return;
-    } else {
-        if (typeof protocols !== 'undefined') {
-            completeHybiUpgrade2(protocols.split(/, */)[0]);
-        }
-        else {
-            completeHybiUpgrade2();
-        }
-    }
-  }
-
   // optionally call external client verification handler
   if (typeof this.options.verifyClient == 'function') {
     var info = {
@@ -319,13 +366,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
       req: req
     };
     if (this.options.verifyClient.length == 2) {
-      this.options.verifyClient(info, function(result, code, name) {
-        if (typeof code === 'undefined') code = 401;
-        if (typeof name === 'undefined') name = http.STATUS_CODES[code];
-
-        if (!result) abortConnection(socket, code, name);
-        else completeHybiUpgrade1();
-      });
+      this.options.verifyClient(info, onClientVerifiedForHybiUpgrade.bind(this, protocols, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket));
       return;
     }
     else if (!this.options.verifyClient(info)) {
@@ -334,7 +375,178 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     }
   }
 
-  completeHybiUpgrade1();
+  doCompleteHybiUpgrade1.call(this, protocols, version, upgradeHead, extensionsOffer, errorHandler, cb, req, socket);
+}
+
+function onClientVerifiedForHixieUpgradeFromOptions (upgradeHead, errorHandler, cb, req, socket, result, code, name) {
+  if (typeof code === 'undefined') code = 401;
+  if (typeof name === 'undefined') name = http.STATUS_CODES[code];
+
+  if (!result) abortConnection(socket, code, name);
+  else onClientVerifiedForHixieUpgrade.call(this, upgradeHead, errorHandler, cb, req, socket);
+}
+
+// build the response header and return a Buffer
+function buildResponseHeaderForHixieUpgrade (protocol, origin, location) {
+  var headers = [
+      'HTTP/1.1 101 Switching Protocols'
+    , 'Upgrade: WebSocket'
+    , 'Connection: Upgrade'
+    , 'Sec-WebSocket-Location: ' + location
+  ];
+  if (typeof protocol != 'undefined') headers.push('Sec-WebSocket-Protocol: ' + protocol);
+  if (typeof origin != 'undefined') headers.push('Sec-WebSocket-Origin: ' + origin);
+
+  return new Buffer(headers.concat('', '').join('\r\n'));
+}
+
+// setup handshake completion to run after client has been verified
+function onClientVerifiedForHixieUpgrade (upgradeHead, errorHandler, cb, req, socket) {
+  var wshost;
+  if (!req.headers['x-forwarded-host'])
+      wshost = req.headers.host;
+  else
+      wshost = req.headers['x-forwarded-host'];
+  var location = ((req.headers['x-forwarded-proto'] === 'https' || socket.encrypted) ? 'wss' : 'ws') + '://' + wshost + req.url
+    , protocol = req.headers['sec-websocket-protocol'];
+
+  // send handshake response before receiving the nonce
+  var handshakeResponse = function() {
+
+    socket.setTimeout(0);
+    socket.setNoDelay(true);
+
+    var headerBuffer = buildResponseHeaderForHixieUpgrade(protocol, req.headers['origin'], location);
+
+    try {
+      socket.write(headerBuffer, 'binary', function(err) {
+        // remove listener if there was an error
+        if (err) socket.removeListener('data', handler);
+        return;
+      });
+    } catch (e) {
+      try { socket.destroy(); } catch (e) {}
+      return;
+    };
+  };
+
+  // retrieve nonce
+  var nonceLength = 8;
+  if (upgradeHead && upgradeHead.length >= nonceLength) {
+    var nonce = upgradeHead.slice(0, nonceLength);
+    var rest = upgradeHead.length > nonceLength ? upgradeHead.slice(nonceLength) : null;
+
+    handshakeCompleterForHixieUpgrade.call(this, protocol, req, socket, errorHandler, cb, nonce, rest, buildResponseHeaderForHixieUpgrade(protocol, req.headers['origin'], location));
+  }
+  else {
+    // nonce not present in upgradeHead
+    var nonce = new Buffer(nonceLength);
+    upgradeHead.copy(nonce, 0);
+    var handlerobj = {
+      nonce: nonce,
+      received: upgradeHead.length,
+      handler: null
+    };
+    var handler = handshakeDataHandlerForHixieUpgrade.bind(this, nonceLength, handlerobj);
+    handlerobj.handler = handler;
+
+    // handle additional data as we receive it
+    socket.on('data', handler);
+
+    // send header response before we have the nonce to fix haproxy buffering
+    handshakeResponse();
+  }
+}
+
+function handshakeDataHandlerForHixieUpgrade (nonceLength, handlerobj, data) {
+  var toRead = Math.min(data.length, nonceLength - handlerobj.received), rest;
+  if (toRead === 0) return;
+  data.copy(handlerobj.nonce, handlerobj.received, 0, toRead);
+  handlerobj.received += toRead;
+  if (received == nonceLength) {
+    socket.removeListener('data', handler);
+    if (toRead < data.length)
+      rest = data.slice(toRead);
+    else
+      rest = null;
+
+    // complete the handshake but send empty buffer for headers since they have already been sent
+    handshakeCompleterForHixieUpgrade.call(this, protocol, req, socket, errorHandler, cb, handlerobj.nonce, rest, new Buffer(0));
+    handlerobj.received = null;
+    handlerobj.handler = null;
+    handlerobj.nonce = null;
+    handlerobj = null;
+  }
+}
+
+function binaryHandshakeCompleterForHixieUpgrade (protocol, req, socket, errorHandler, rest, cb, err) {
+  if (err) return; // do not create client if an error happens
+  var client = new WebSocket([req, socket, rest], {
+    protocolVersion: 'hixie-76',
+    protocol: protocol
+  });
+  if (this.options.clientTracking) {
+    this.clients.push(client);
+    client.on('close', onClientClosedFromHixie.bind(this, client));
+  }
+
+  // signal upgrade complete
+  socket.removeListener('error', errorHandler);
+  cb(client);
+  protocol = null;
+  req = null;
+  socket = null;
+  errorHandler = null;
+  rest = null;
+  cb = null;
+}
+
+function onClientClosedFromHixie (client) {
+  var index = this.clients.indexOf(client);
+  if (index != -1) {
+    this.clients.splice(index, 1);
+  }
+}
+
+  // handshake completion code to run once nonce has been successfully retrieved
+function handshakeCompleterForHixieUpgrade (protocol, req, socket, errorHandler, cb, nonce, rest, headerBuffer) {
+  // calculate key
+  var k1 = req.headers['sec-websocket-key1']
+    , k2 = req.headers['sec-websocket-key2']
+    , md5 = crypto.createHash('md5');
+
+  [k1, k2].forEach(function (k) {
+    var n = parseInt(k.replace(/[^\d]/g, ''))
+      , spaces = k.replace(/[^ ]/g, '').length;
+    if (spaces === 0 || n % spaces !== 0){
+      abortConnection(socket, 400, 'Bad Request');
+      return;
+    }
+    n /= spaces;
+    md5.update(String.fromCharCode(
+      n >> 24 & 0xFF,
+      n >> 16 & 0xFF,
+      n >> 8  & 0xFF,
+      n       & 0xFF));
+  });
+  md5.update(nonce.toString('binary'));
+
+  socket.setTimeout(0);
+  socket.setNoDelay(true);
+
+  try {
+    var hashBuffer = new Buffer(md5.digest('binary'), 'binary');
+    var handshakeBuffer = new Buffer(headerBuffer.length + hashBuffer.length);
+    headerBuffer.copy(handshakeBuffer, 0);
+    hashBuffer.copy(handshakeBuffer, headerBuffer.length);
+
+    // do a single write, which - upon success - causes a new client websocket to be setup
+    socket.write(handshakeBuffer, 'binary', binaryHandshakeCompleterForHixieUpgrade.bind(this, protocol, req, socket, errorHandler, rest, cb));
+  }
+  catch (e) {
+    try { socket.destroy(); } catch (e) {}
+    return;
+  }
 }
 
 function handleHixieUpgrade(req, socket, upgradeHead, cb) {
@@ -356,164 +568,15 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
     return;
   }
 
-  var origin = req.headers['origin']
-    , self = this;
-
-  // setup handshake completion to run after client has been verified
-  var onClientVerified = function() {
-    var wshost;
-    if (!req.headers['x-forwarded-host'])
-        wshost = req.headers.host;
-    else
-        wshost = req.headers['x-forwarded-host'];
-    var location = ((req.headers['x-forwarded-proto'] === 'https' || socket.encrypted) ? 'wss' : 'ws') + '://' + wshost + req.url
-      , protocol = req.headers['sec-websocket-protocol'];
-
-    // build the response header and return a Buffer
-    var buildResponseHeader = function() {
-      var headers = [
-          'HTTP/1.1 101 Switching Protocols'
-        , 'Upgrade: WebSocket'
-        , 'Connection: Upgrade'
-        , 'Sec-WebSocket-Location: ' + location
-      ];
-      if (typeof protocol != 'undefined') headers.push('Sec-WebSocket-Protocol: ' + protocol);
-      if (typeof origin != 'undefined') headers.push('Sec-WebSocket-Origin: ' + origin);
-
-      return new Buffer(headers.concat('', '').join('\r\n'));
-    };
-
-    // send handshake response before receiving the nonce
-    var handshakeResponse = function() {
-
-      socket.setTimeout(0);
-      socket.setNoDelay(true);
-
-      var headerBuffer = buildResponseHeader();
-
-      try {
-        socket.write(headerBuffer, 'binary', function(err) {
-          // remove listener if there was an error
-          if (err) socket.removeListener('data', handler);
-          return;
-        });
-      } catch (e) {
-        try { socket.destroy(); } catch (e) {}
-        return;
-      };
-    };
-
-    // handshake completion code to run once nonce has been successfully retrieved
-    var completeHandshake = function(nonce, rest, headerBuffer) {
-      // calculate key
-      var k1 = req.headers['sec-websocket-key1']
-        , k2 = req.headers['sec-websocket-key2']
-        , md5 = crypto.createHash('md5');
-
-      [k1, k2].forEach(function (k) {
-        var n = parseInt(k.replace(/[^\d]/g, ''))
-          , spaces = k.replace(/[^ ]/g, '').length;
-        if (spaces === 0 || n % spaces !== 0){
-          abortConnection(socket, 400, 'Bad Request');
-          return;
-        }
-        n /= spaces;
-        md5.update(String.fromCharCode(
-          n >> 24 & 0xFF,
-          n >> 16 & 0xFF,
-          n >> 8  & 0xFF,
-          n       & 0xFF));
-      });
-      md5.update(nonce.toString('binary'));
-
-      socket.setTimeout(0);
-      socket.setNoDelay(true);
-
-      try {
-        var hashBuffer = new Buffer(md5.digest('binary'), 'binary');
-        var handshakeBuffer = new Buffer(headerBuffer.length + hashBuffer.length);
-        headerBuffer.copy(handshakeBuffer, 0);
-        hashBuffer.copy(handshakeBuffer, headerBuffer.length);
-
-        // do a single write, which - upon success - causes a new client websocket to be setup
-        socket.write(handshakeBuffer, 'binary', function(err) {
-          if (err) return; // do not create client if an error happens
-          var client = new WebSocket([req, socket, rest], {
-            protocolVersion: 'hixie-76',
-            protocol: protocol
-          });
-          if (self.options.clientTracking) {
-            self.clients.push(client);
-            client.on('close', function() {
-              var index = self.clients.indexOf(client);
-              if (index != -1) {
-                self.clients.splice(index, 1);
-              }
-            });
-          }
-
-          // signal upgrade complete
-          socket.removeListener('error', errorHandler);
-          cb(client);
-        });
-      }
-      catch (e) {
-        try { socket.destroy(); } catch (e) {}
-        return;
-      }
-    }
-
-    // retrieve nonce
-    var nonceLength = 8;
-    if (upgradeHead && upgradeHead.length >= nonceLength) {
-      var nonce = upgradeHead.slice(0, nonceLength);
-      var rest = upgradeHead.length > nonceLength ? upgradeHead.slice(nonceLength) : null;
-      completeHandshake.call(self, nonce, rest, buildResponseHeader());
-    }
-    else {
-      // nonce not present in upgradeHead
-      var nonce = new Buffer(nonceLength);
-      upgradeHead.copy(nonce, 0);
-      var received = upgradeHead.length;
-      var rest = null;
-      var handler = function (data) {
-        var toRead = Math.min(data.length, nonceLength - received);
-        if (toRead === 0) return;
-        data.copy(nonce, received, 0, toRead);
-        received += toRead;
-        if (received == nonceLength) {
-          socket.removeListener('data', handler);
-          if (toRead < data.length) rest = data.slice(toRead);
-
-          // complete the handshake but send empty buffer for headers since they have already been sent
-          completeHandshake.call(self, nonce, rest, new Buffer(0));
-        }
-      }
-
-      // handle additional data as we receive it
-      socket.on('data', handler);
-
-      // send header response before we have the nonce to fix haproxy buffering
-      handshakeResponse();
-    }
-  }
-
   // verify client
   if (typeof this.options.verifyClient == 'function') {
     var info = {
-      origin: origin,
+      origin: req.headers['origin'],
       secure: typeof req.connection.authorized !== 'undefined' || typeof req.connection.encrypted !== 'undefined',
       req: req
     };
     if (this.options.verifyClient.length == 2) {
-      var self = this;
-      this.options.verifyClient(info, function(result, code, name) {
-        if (typeof code === 'undefined') code = 401;
-        if (typeof name === 'undefined') name = http.STATUS_CODES[code];
-
-        if (!result) abortConnection(socket, code, name);
-        else onClientVerified.apply(self);
-      });
+      this.options.verifyClient(info, onClientVerifiedForHixieUpgradeFromOptions.bind(this, upgradeHead, errorHandler, cb, req, socket));
       return;
     }
     else if (!this.options.verifyClient(info)) {
@@ -523,7 +586,7 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
   }
 
   // no client verification required
-  onClientVerified();
+  onClientVerifiedForHixieUpgrade.call(this, upgradeHead, errorHandler, cb, req, socket);
 }
 
 function acceptExtensions(offer) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "options": ">=0.0.5",
+    "options": "https://git@github.com/andrija-hers/options.js",
     "ultron": "1.0.x"
   },
   "devDependencies": {

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -269,7 +269,7 @@ describe('WebSocketServer', function() {
         wss1.close();
         Object.keys(srv._webSocketPaths).length.should.eql(1);
         wss2.close();
-        (typeof srv._webSocketPaths).should.eql('undefined');
+        should.equal(srv._webSocketPaths, null);
         srv.close();
         done();
       });


### PR DESCRIPTION
Here is a massive refactor that minimizes memory leaks.

There are 2 important notes here:
1. This PR will not work until https://github.com/einaros/options.js/pull/14 is accepted (the `options` module leaks memory massively)
2. One of the test still fails - just like the original code does (due to timeout of 5000 ms)

I hope that @einaros will take care of the `options` repo so that this PR may be accepted.

The code changes are pretty much self explanatory, but I'll just note that almost all the work is based on removing the notorious `var self = this` paradigm, that _always_ leads to memory leaks (via closures that never get collected as garbage).
