### PR TITLE
fix PerMessageDeflate options pass issue

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -606,7 +606,7 @@ function initAsClient(address, protocols, options) {
   var extensionsOffer = {};
   var perMessageDeflate;
   if (options.value.perMessageDeflate) {
-    perMessageDeflate = new PerMessageDeflate(typeof options.value.perMessageDeflate !== true ? options.value.perMessageDeflate : {}, false);
+    perMessageDeflate = new PerMessageDeflate(options.value.perMessageDeflate !== true ? options.value.perMessageDeflate : {}, false);
     extensionsOffer[PerMessageDeflate.extensionName] = perMessageDeflate.offer();
   }
 


### PR DESCRIPTION
The `typeof options.value.perMessageDeflate !== true` always `false`.