### PR TITLE
specify data encoding type 'binary' at hash#update

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -619,7 +619,7 @@ function initAsClient(address, protocols, options) {
   // begin handshake
   var key = new Buffer(options.value.protocolVersion + '-' + Date.now()).toString('base64');
   var shasum = crypto.createHash('sha1');
-  shasum.update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11');
+  shasum.update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', 'binary');
   var expectedServerKey = shasum.digest('base64');
 
   var agent = options.value.agent;

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -218,7 +218,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     // calc key
     var key = req.headers['sec-websocket-key'];
     var shasum = crypto.createHash('sha1');
-    shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", 'binary');
     key = shasum.digest('base64');
 
     var headers = [
@@ -422,9 +422,9 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
           n >> 24 & 0xFF,
           n >> 16 & 0xFF,
           n >> 8  & 0xFF,
-          n       & 0xFF));
+          n       & 0xFF), 'binary');
       });
-      md5.update(nonce.toString('binary'));
+      md5.update(nonce.toString('binary'), 'binary');
 
       socket.setTimeout(0);
       socket.setNoDelay(true);

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -49,7 +49,7 @@ function validServer(server, req, socket) {
   // calc key
   var key = req.headers['sec-websocket-key'];
   var shasum = crypto.createHash('sha1');
-  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", 'binary');
   key = shasum.digest('base64');
 
   var headers = [
@@ -113,7 +113,7 @@ function invalidRequestHandler(server, req, socket) {
   // calc key
   var key = req.headers['sec-websocket-key'];
   var shasum = crypto.createHash('sha1');
-  shasum.update(key + "bogus");
+  shasum.update(key + "bogus", 'binary');
   key = shasum.digest('base64');
 
   var headers = [
@@ -142,7 +142,7 @@ function closeAfterConnectHandler(server, req, socket) {
   // calc key
   var key = req.headers['sec-websocket-key'];
   var shasum = crypto.createHash('sha1');
-  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+  shasum.update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11", 'binary');
   key = shasum.digest('base64');
 
   var headers = [


### PR DESCRIPTION
Solves https://github.com/websockets/ws/issues/716, which originated in Node v6 due to [this breaking change](https://github.com/nodejs/node/pull/5522#discussion_r54774150).