### PR TITLE
Remove unnecessary assignment

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -368,10 +368,11 @@ class Receiver {
   }
 
   /**
-  * Checks payload size, disconnects socket when it exceeds maxPayload
-  *
-  * @api private
-  */
+   * Checks payload size, disconnects socket when it exceeds maxPayload
+   *
+   * @api private
+   */
+
   maxPayloadExceeded(length) {
     if (this.maxPayload === undefined || this.maxPayload === null || this.maxPayload < 1) {
       return false;
@@ -382,7 +383,6 @@ class Receiver {
       return false;
     }
     this.error('payload cannot exceed ' + this.maxPayload + ' bytes', 1009);
-    this.messageBuffer = [];
     this.cleanup();
 
     return true;


### PR DESCRIPTION
The `messageBuffer` property is not used anywhere, so this patch removes the whole assignment.