### PR TITLE
add another one emit event headers with path, like event connection

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -256,6 +256,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     }
 
     // allows external modification/inspection of handshake headers
+    self.emit('headers' + req.url, headers, req.headers);
     self.emit('headers', headers, req.headers);
 
     socket.setTimeout(0);

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -256,7 +256,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     }
 
     // allows external modification/inspection of handshake headers
-    self.emit('headers', headers);
+    self.emit('headers', headers, req.headers);
 
     socket.setTimeout(0);
     socket.setNoDelay(true);


### PR DESCRIPTION
I needed to share connections and i find it:

```
self.emit('connection' + req.url, client); 
self.emit('connection', client);
```

But i set cookie in 'headers' event and i needed same behavior with 'headers' event.
