### PR TITLE
Add headers as option to verifyClient

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -36,7 +36,7 @@ Either `port` or `server` must be provided, otherwise you might enable
   * `result` Boolean: Whether the user accepts or not the handshake.
   * `code` Number: If `result` is `false` this field determines the HTTP error status code to be sent to the client.
   * `name` String: If `result` is `false` this field determines the HTTP reason phrase.
-  * `headers` Array: If `result` is `false` these are returned in the headers seperated by new lines. i.e. `["retry-after: 2"]` to ask the client to retry after 2 seconds (for a 503 response).
+  * `headers` Object: If `result` is `false` these can be returned as addional headers to the client. i.e. `{"retry-after": 2}` to ask the client to retry after 2 seconds (for a 503 response). If left blank, no extra headers will be sent.
 
 If `verifyClient` is provided with a single argument then that is:
 * `info` Object: Same as above.

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -36,6 +36,7 @@ Either `port` or `server` must be provided, otherwise you might enable
   * `result` Boolean: Whether the user accepts or not the handshake.
   * `code` Number: If `result` is `false` this field determines the HTTP error status code to be sent to the client.
   * `name` String: If `result` is `false` this field determines the HTTP reason phrase.
+  * `headers` Array: If `result` is `false` these are returned in the headers seperated by new lines. i.e. `["retry-after: 2"]` to ask the client to retry after 2 seconds (for a 503 response).
 
 If `verifyClient` is provided with a single argument then that is:
 * `info` Object: Same as above.

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -36,7 +36,7 @@ Either `port` or `server` must be provided, otherwise you might enable
   * `result` Boolean: Whether the user accepts or not the handshake.
   * `code` Number: If `result` is `false` this field determines the HTTP error status code to be sent to the client.
   * `name` String: If `result` is `false` this field determines the HTTP reason phrase.
-  * `headers` Object: If `result` is `false` these can be returned as addional headers to the client. i.e. `{"retry-after": 2}` to ask the client to retry after 2 seconds (for a 503 response). If left blank, no extra headers will be sent.
+  * `headers` Object: These can be returned as addional headers to the client. i.e. `{"retry-after": 2}` to ask the client to retry after 2 seconds (for a 503 response). If left blank, no extra headers will be sent.
 
 If `verifyClient` is provided with a single argument then that is:
 * `info` Object: Same as above.

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -332,11 +332,11 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
       req: req
     };
     if (this.options.verifyClient.length == 2) {
-      this.options.verifyClient(info, function(result, code, name) {
+      this.options.verifyClient(info, function(result, code, name, headers) {
         if (typeof code === 'undefined') code = 401;
         if (typeof name === 'undefined') name = http.STATUS_CODES[code];
 
-        if (!result) abortConnection(socket, code, name);
+        if (!result) abortConnection(socket, code, name, headers);
         else completeHybiUpgrade1();
       });
       return;
@@ -552,10 +552,11 @@ function acceptExtensions(offer) {
   return extensions;
 }
 
-function abortConnection(socket, code, name) {
+function abortConnection(socket, code, name, headers) {
   try {
     var response = `HTTP/1.1 ${code} ${name}\r\n` +
       `Content-type: text/html\r\n` +
+      (Array.isArray(headers) ? headers.join("\r\n") + "\r\n" : "") +
       `\r\n\r\n`;
     socket.write(response);
   }

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -226,7 +226,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
 
   // handler to call when the connection sequence completes
   var self = this;
-  var completeHybiUpgrade2 = function(protocol) {
+  var completeHybiUpgrade2 = function(protocol, extraHeaders) {
 
     // calc key
     var key = req.headers['sec-websocket-key'];
@@ -234,15 +234,18 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
     shasum.update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', 'binary');
     key = shasum.digest('base64');
 
-    var headers = [
-      'HTTP/1.1 101 Switching Protocols',
-      'Upgrade: websocket',
-      'Connection: Upgrade',
-      'Sec-WebSocket-Accept: ' + key
+    var rawHeaderRows = [
+      'HTTP/1.1 101 Switching Protocols'
     ];
 
+    var headers = {
+      'Upgrade': 'websocket',
+      'Connection': 'Upgrade',
+      'Sec-WebSocket-Accept': key
+    };
+
     if (typeof protocol != 'undefined') {
-      headers.push('Sec-WebSocket-Protocol: ' + protocol);
+      headers['Sec-WebSocket-Protocol'] = protocol;
     }
 
     var extensions = {};
@@ -258,16 +261,22 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
       Object.keys(extensions).forEach(function(token) {
         serverExtensions[token] = [extensions[token].params]
       });
-      headers.push('Sec-WebSocket-Extensions: ' + Extensions.format(serverExtensions));
+      headers['Sec-WebSocket-Extensions'] = Extensions.format(serverExtensions);
     }
 
+    if (typeof extraHeaders === 'object') {
+      Object.keys(extraHeaders).forEach(prop => { headers[prop] = extraHeaders[prop]; });
+    }
+
+    rawHeaderRows = rawHeaderRows.concat(Object.keys(headers).map(prop => `${prop}: ${headers[prop]}`));
+
     // allows external modification/inspection of handshake headers
-    self.emit('headers', headers);
+    self.emit('headers', rawHeaderRows);
 
     socket.setTimeout(0);
     socket.setNoDelay(true);
     try {
-      socket.write(headers.concat('', '').join('\r\n'));
+      socket.write(rawHeaderRows.concat('', '').join('\r\n'));
     }
     catch (e) {
       // if the upgrade write fails, shut the connection down hard
@@ -299,7 +308,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
 
   // optionally call external protocol selection handler before
   // calling completeHybiUpgrade2
-  var completeHybiUpgrade1 = function() {
+  var completeHybiUpgrade1 = function(headers) {
     // choose from the sub-protocols
     if (typeof self.options.handleProtocols == 'function') {
       var protList = (protocols || '').split(/, */);
@@ -307,7 +316,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
       self.options.handleProtocols(protList, function(result, protocol) {
         callbackCalled = true;
         if (!result) abortConnection(socket, 401, 'Unauthorized');
-        else completeHybiUpgrade2(protocol);
+        else completeHybiUpgrade2(protocol, headers);
       });
       if (!callbackCalled) {
             // the handleProtocols handler never called our callback
@@ -316,10 +325,10 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
       return;
     } else {
       if (typeof protocols !== 'undefined') {
-        completeHybiUpgrade2(protocols.split(/, */)[0]);
+        completeHybiUpgrade2(protocols.split(/, */)[0], headers);
       }
       else {
-        completeHybiUpgrade2();
+        completeHybiUpgrade2(undefined, headers);
       }
     }
   }
@@ -337,7 +346,7 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
         if (typeof name === 'undefined') name = http.STATUS_CODES[code];
 
         if (!result) abortConnection(socket, code, name, headers);
-        else completeHybiUpgrade1();
+        else completeHybiUpgrade1(headers);
       });
       return;
     }
@@ -555,7 +564,7 @@ function acceptExtensions(offer) {
 function abortConnection(socket, code, name, headers) {
   try {
     var originalHeaders = {
-      'content-type': 'text/html'
+      'Content-Type': 'text/html'
     };
     if (typeof headers === 'object') {
       Object.keys(headers).forEach((key) => {

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -557,7 +557,7 @@ function abortConnection(socket, code, name, headers) {
     var originalHeaders = {
       'content-type': 'text/html'
     };
-    if (typeof headers === "object") {
+    if (typeof headers === 'object') {
       Object.keys(headers).forEach((key) => {
         originalHeaders[key] = headers[key];
       });

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -554,10 +554,17 @@ function acceptExtensions(offer) {
 
 function abortConnection(socket, code, name, headers) {
   try {
+    var originalHeaders = {
+      'content-type': 'text/html'
+    };
+    if (typeof headers === "object") {
+      Object.keys(headers).forEach((key) => {
+        originalHeaders[key] = headers[key];
+      });
+    }
     var response = `HTTP/1.1 ${code} ${name}\r\n` +
-      `Content-type: text/html\r\n` +
-      (Array.isArray(headers) ? headers.join("\r\n") + "\r\n" : "") +
-      `\r\n\r\n`;
+      Object.keys(originalHeaders).map(key => `${key}: ${originalHeaders[key]}`).join(`\r\n`) +
+      `\r\n\r\n\r\n`;
     socket.write(response);
   }
   catch (e) { /* ignore errors - we've aborted this connection */ }

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -685,10 +685,10 @@ describe('WebSocketServer', function() {
         wss.on('error', function() {});
       });
 
-      it('client can be denied asynchronously with custom response code', function(done) {
+      it('client can be denied asynchronously with custom response code and headers', function(done) {
         var wss = new WebSocketServer({port: ++port, verifyClient: function(o, cb) {
           process.nextTick(function() {
-            cb(false, 404);
+            cb(false, 503, 'Service Unavailable', { 'retry-after': 2 });
           });
         }}, function() {
           var options = {
@@ -705,7 +705,9 @@ describe('WebSocketServer', function() {
           var req = http.request(options);
           req.end();
           req.on('response', function(res) {
-            res.statusCode.should.eql(404);
+            res.statusCode.should.eql(503);
+            res.headers['retry-after'].should.eql('2');
+            res.statusMessage.should.eql('Service Unavailable');
             process.nextTick(function() {
               wss.close();
               done();


### PR DESCRIPTION
This allows the verifyClient to be more flexible in what it returns to the client if there is a failure on authentication. i.e. a retry-after etc.

Happy to hear feedback :-)
