### PR TITLE
Added method removeEventListener to WebSocket interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 coverage
 
 builderror.log
+
+*.iml
+.idea

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -481,6 +481,25 @@ WebSocket.prototype.addEventListener = function(method, listener) {
   }
 };
 
+WebSocket.prototype.removeEventListener = function(method, listener) {
+  var listeners = this.listeners(method);
+  for(var i = 0; i < listeners.length; i++) {
+    if(listeners[i]._listener === listener) {
+      this.removeListener(method, listeners[i]);
+    }
+  }
+};
+
+WebSocket.prototype.hasEventListener = function(method, listener) {
+  var listeners = this.listeners(method);
+  for(var i = 0; i < listeners.length; i++) {
+    if(listeners[i]._listener === listener) {
+      return true;
+    }
+  }
+  return false;
+};
+
 module.exports = WebSocket;
 module.exports.buildHostHeader = buildHostHeader
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -483,8 +483,8 @@ WebSocket.prototype.addEventListener = function(method, listener) {
 
 WebSocket.prototype.removeEventListener = function(method, listener) {
   var listeners = this.listeners(method);
-  for(var i = 0; i < listeners.length; i++) {
-    if(listeners[i]._listener === listener) {
+  for (var i = 0; i < listeners.length; i++) {
+    if (listeners[i]._listener === listener) {
       this.removeListener(method, listeners[i]);
     }
   }
@@ -492,8 +492,8 @@ WebSocket.prototype.removeEventListener = function(method, listener) {
 
 WebSocket.prototype.hasEventListener = function(method, listener) {
   var listeners = this.listeners(method);
-  for(var i = 0; i < listeners.length; i++) {
-    if(listeners[i]._listener === listener) {
+  for (var i = 0; i < listeners.length; i++) {
+    if (listeners[i]._listener === listener) {
       return true;
     }
   }

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1616,6 +1616,24 @@ describe('WebSocket', function() {
       });
     });
 
+    it('should remove added event listener', function(done) {
+      this.timeout(4000);
+      server.createServer(++port, function(srv) {
+        var ws = new WebSocket('ws://localhost:' + port);
+        function openListener() {}
+        function messageListener() {}
+        ws.addEventListener('open', openListener);
+        ws.addEventListener('message', messageListener);
+        assert.equal(ws.hasEventListener('open', openListener), true);
+        assert.equal(ws.hasEventListener('message', messageListener), true);
+        ws.removeEventListener('open', openListener);
+        ws.removeEventListener('message', messageListener);
+        assert.equal(ws.hasEventListener('open', openListener), false);
+        assert.equal(ws.hasEventListener('message', messageListener), false);
+        done();
+      });
+    });
+
     it('should receive valid CloseEvent when server closes with code 1000', function(done) {
       var wss = new WebSocketServer({port: ++port}, function() {
         var ws = new WebSocket('ws://localhost:' + port);


### PR DESCRIPTION
Hey Guys,

added a new method "removeEventListener" to the WebSocket interface, because I think it's common to have the counterpart to addEventListener.
