### PR TITLE
Fix stack overflow crash

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -256,7 +256,9 @@ class Sender extends EventEmitter {
 
     handler(function() {
       self.processing = false;
-      self.flush();
+      process.nextTick(function() {
+        self.flush();
+      });
     });
   }
 

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -60,8 +60,26 @@ describe('Sender', function() {
       });
       sender.send('hi', { compress: true });
     });
-  });
+    
+    it('Should be able to handle many send calls while processing without crashing on flush', function(done) {
+      var messageCount = 0;
+      var maxMessages = 5000;
 
+      var sender = new Sender({
+        write: function(data) {
+          messageCount++;
+          if (messageCount > maxMessages) return done();
+        }
+      });
+      for (var i = 0; i < maxMessages; i++) {
+        sender.processing = true;
+        sender.send('hi', { compress: false, fin: true, binary: false, mask: false });
+      }
+      sender.processing = false;
+      sender.send('hi', { compress: false, fin: true, binary: false, mask: false });
+    });
+  });
+  
   describe('#close', function() {
     it('should consume all data before closing', function(done) {
       var perMessageDeflate = new PerMessageDeflate();


### PR DESCRIPTION
If a message has many messageHandlers it can trigger a stack overflow as it recursively calls flush on each one. This ensures that the stack is cleared before each recursive flush is called. 

Fixes #809