### PR TITLE
increased performance of frameAndSend

### DIFF
--- a/bench/sender.benchmark.js
+++ b/bench/sender.benchmark.js
@@ -20,6 +20,7 @@ require('./util');
  * Setup sender.
  */
 
+var sender;
 suite.on('start', function () {
   sender = new Sender();
   sender._socket = { write: function() {} };
@@ -34,7 +35,7 @@ suite.on('cycle', function () {
  * Benchmarks
  */
 
-framePacket = new Buffer(200*1024);
+var framePacket = new Buffer(200*1024);
 framePacket.fill(99);
 suite.add('frameAndSend, unmasked (200 kB)', function () {
   sender.frameAndSend(0x2, framePacket, true, false);

--- a/bench/util.js
+++ b/bench/util.js
@@ -10,7 +10,7 @@
  * Returns a Buffer from a "ff 00 ff"-type hex string.
  */
 
-getBufferFromHexString = function(byteStr) {
+global.getBufferFromHexString = function(byteStr) {
   var bytes = byteStr.split(' ');
   var buf = new Buffer(bytes.length);
   for (var i = 0; i < bytes.length; ++i) {
@@ -23,7 +23,7 @@ getBufferFromHexString = function(byteStr) {
  * Returns a hex string from a Buffer.
  */
 
-getHexStringFromBuffer = function(data) {
+global.getHexStringFromBuffer = function(data) {
   var s = '';
   for (var i = 0; i < data.length; ++i) {
     s += padl(data[i].toString(16), 2, '0') + ' ';
@@ -35,7 +35,7 @@ getHexStringFromBuffer = function(data) {
  * Splits a buffer in two parts.
  */
 
-splitBuffer = function(buffer) {
+global.splitBuffer = function(buffer) {
   var b1 = new Buffer(Math.ceil(buffer.length / 2));
   buffer.copy(b1, 0, 0, b1.length);
   var b2 = new Buffer(Math.floor(buffer.length / 2));
@@ -47,7 +47,7 @@ splitBuffer = function(buffer) {
  * Performs hybi07+ type masking on a hex string or buffer.
  */
 
-mask = function(buf, maskString) {
+global.mask = function(buf, maskString) {
   if (typeof buf == 'string') buf = new Buffer(buf);
   var mask = getBufferFromHexString(maskString || '34 83 a8 68');
   for (var i = 0; i < buf.length; ++i) {
@@ -60,7 +60,7 @@ mask = function(buf, maskString) {
  * Returns a hex string representing the length of a message
  */
 
-getHybiLengthAsHexString = function(len, masked) {
+global.getHybiLengthAsHexString = function(len, masked) {
   if (len < 126) {
     var buf = new Buffer(1);
     buf[0] = (masked ? 0x80 : 0) | len;
@@ -82,7 +82,7 @@ getHybiLengthAsHexString = function(len, masked) {
  * Unpacks a Buffer into a number.
  */
 
-unpack = function(buffer) {
+global.unpack = function(buffer) {
   var n = 0;
   for (var i = 0; i < buffer.length; ++i) {
     n = (i == 0) ? buffer[i] : (n * 256) + buffer[i];
@@ -94,7 +94,7 @@ unpack = function(buffer) {
  * Returns a hex string, representing a specific byte count 'length', from a number.
  */
 
-pack = function(length, number) {
+global.pack = function(length, number) {
   return padl(number.toString(16), length, '0').replace(/([0-9a-f][0-9a-f])/gi, '$1 ').trim();
 }
 
@@ -102,6 +102,6 @@ pack = function(length, number) {
  * Left pads the string 's' to a total length of 'n' with char 'c'.
  */
 
-padl = function(s, n, c) {
+global.padl = function(s, n, c) {
   return new Array(1 + n - s.length).join(c) + s;
 }

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -142,8 +142,8 @@ class Sender extends EventEmitter {
 
     if (!Buffer.isBuffer(data)) {
       canModifyData = true;
-      if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
-        data = getArrayBuffer(data);
+      if (data && (data.buffer || data) instanceof ArrayBuffer) {
+        data = getBufferFromNative(data);
       } else {
         //
         // If people want to send a number, this would allocate the number in
@@ -268,7 +268,7 @@ class Sender extends EventEmitter {
   applyExtensions(data, fin, compress, callback) {
     if (compress && data) {
       if ((data.buffer || data) instanceof ArrayBuffer) {
-        data = getArrayBuffer(data);
+        data = getBufferFromNative(data);
       }
       this.extensions[PerMessageDeflate.extensionName].compress(data, fin, callback);
     } else {
@@ -279,16 +279,12 @@ class Sender extends EventEmitter {
 
 module.exports = Sender;
 
-function getArrayBuffer(data) {
+function getBufferFromNative(data) {
   // data is either an ArrayBuffer or ArrayBufferView.
-  var array = new Uint8Array(data.buffer || data),
-    l = data.byteLength || data.length,
-    o = data.byteOffset || 0,
-    buffer = new Buffer(l);
-  for (var i = 0; i < l; ++i) {
-    buffer[i] = array[o + i];
+  if (data.buffer) {
+    data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
   }
-  return buffer;
+  return new Buffer(data);
 }
 
 function getRandomMask() {

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -127,24 +127,17 @@ class Sender extends EventEmitter {
     var canModifyData = false;
 
     if (!data) {
-
-      try {
-        var buff = [opcode | (finalFragment ? 0x80 : 0), 0 | (maskData ? 0x80 : 0)]
-          .concat(maskData ? [0, 0, 0, 0] : []);
-        this._socket.write(new Buffer(buff), 'binary', cb);
-      }
-      catch (e) {
-        if (typeof cb == 'function') cb(e);
-        else this.emit('error', e);
-      }
+      var buff = [opcode | (finalFragment ? 0x80 : 0), 0 | (maskData ? 0x80 : 0)]
+        .concat(maskData ? [0, 0, 0, 0] : []);
+      sendFramedData.call(this, new Buffer(buff), null, cb);
       return;
     }
 
     if (!Buffer.isBuffer(data)) {
-      canModifyData = true;
       if (data && (data.buffer || data) instanceof ArrayBuffer) {
         data = getBufferFromNative(data);
       } else {
+        canModifyData = true;
         //
         // If people want to send a number, this would allocate the number in
         // bytes as memory size instead of storing the number as buffer value. So
@@ -194,49 +187,17 @@ class Sender extends EventEmitter {
       outputBuffer[dataOffset - 1] = mask[3];
       if (mergeBuffers) {
         bufferUtil.mask(data, mask, outputBuffer, dataOffset, dataLength);
-        try {
-          this._socket.write(outputBuffer, 'binary', cb);
-        }
-        catch (e) {
-          if (typeof cb == 'function') cb(e);
-          else this.emit('error', e);
-        }
-      }
-      else {
+      } else {
         bufferUtil.mask(data, mask, data, 0, dataLength);
-        try {
-          this._socket.write(outputBuffer, 'binary');
-          this._socket.write(data, 'binary', cb);
-        }
-        catch (e) {
-          if (typeof cb == 'function') cb(e);
-          else this.emit('error', e);
-        }
       }
     }
     else {
       outputBuffer[1] = secondByte;
       if (mergeBuffers) {
         data.copy(outputBuffer, dataOffset);
-        try {
-          this._socket.write(outputBuffer, 'binary', cb);
-        }
-        catch (e) {
-          if (typeof cb == 'function') cb(e);
-          else this.emit('error', e);
-        }
-      }
-      else {
-        try {
-          this._socket.write(outputBuffer, 'binary');
-          this._socket.write(data, 'binary', cb);
-        }
-        catch (e) {
-          if (typeof cb == 'function') cb(e);
-          else this.emit('error', e);
-        }
       }
     }
+    sendFramedData.call(this, outputBuffer, mergeBuffers ? null : data, cb);
   }
 
   /**
@@ -293,4 +254,19 @@ function getRandomMask() {
     ~~(Math.random() * 255),
     ~~(Math.random() * 255)
   ]);
+}
+
+function sendFramedData(outputBuffer, data, cb) {
+  try {
+    if (data) {
+      this._socket.write(outputBuffer, 'binary');
+      this._socket.write(data, 'binary', cb);
+    } else {
+      this._socket.write(outputBuffer, 'binary', cb);
+    }
+  }
+  catch (e) {
+    if (typeof cb == 'function') cb(e);
+    else this.emit('error', e);
+  }
 }

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -281,10 +281,9 @@ module.exports = Sender;
 
 function getBufferFromNative(data) {
   // data is either an ArrayBuffer or ArrayBufferView.
-  if (data.buffer) {
-    data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
-  }
-  return new Buffer(data);
+  return !data.buffer
+    ? new Buffer(data)
+    : new Buffer(data.buffer).slice(data.byteOffset, data.byteOffset + data.byteLength)
 }
 
 function getRandomMask() {

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -436,7 +436,7 @@ WebSocket.prototype.addEventListener = function(method, listener) {
 
   function onMessage (data, flags) {
     if (flags.binary && this.binaryType === 'arraybuffer')
-      data = new Uint8Array(data).buffer;
+      data = data.buffer.slice(data.byteOffset, data.byteOffset + data.length);
     listener.call(target, new MessageEvent(data, !!flags.binary, target));
   }
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -436,7 +436,7 @@ WebSocket.prototype.addEventListener = function(method, listener) {
 
   function onMessage (data, flags) {
     if (flags.binary && this.binaryType === 'arraybuffer')
-      data = data.buffer.slice(data.byteOffset, data.byteOffset + data.length);
+      data = new Uint8Array(data).buffer;
     listener.call(target, new MessageEvent(data, !!flags.binary, target));
   }
 


### PR DESCRIPTION
The V8 engine optimizes code on a per-function basis. But it can't optimize functions that have a `try {} catch {}` block in them. Because of this, `frameAndSend()` was not getting optimized. And I don't know about you, but I'd say that's a pretty important function for optimization.

To fix this, I moved the `try {} catch {}` block into a separate function.

Also, when converting from ArrayBuffers/TypedArrays to Buffers, the data was being copied in memory, which has a speed of _O(n)_. With this pull request, converting between the two will no longer copy the memory, which is much faster; _O(1)_.

Also, I renamed the function `getArrayBuffer ` to `getBufferFromNative ` to better describe what it actually does.