### PR TITLE
Avoid using Buffer.concat() on single part messages and provide length otherwise

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -502,7 +502,9 @@ var opcodes = {
             this.currentMessageLength += buffer.length;
           }
           if (state.lastFragment) {
-            var messageBuffer = Buffer.concat(this.currentMessage);
+            var messageBuffer = this.currentMessage.length === 1 ?
+              this.currentMessage[0] :
+              Buffer.concat(this.currentMessage, this.currentMessageLength);
             this.currentMessage = [];
             this.currentMessageLength = 0;
             if (!Validation.isValidUTF8(messageBuffer)) {
@@ -585,7 +587,9 @@ var opcodes = {
             this.currentMessageLength += buffer.length;
           }
           if (state.lastFragment) {
-            var messageBuffer = Buffer.concat(this.currentMessage);
+            var messageBuffer = this.currentMessage.length === 1 ?
+              this.currentMessage[0] :
+              Buffer.concat(this.currentMessage, this.currentMessageLength);
             this.currentMessage = [];
             this.currentMessageLength = 0;
             this.onbinary(messageBuffer, {masked: state.masked, buffer: messageBuffer});


### PR DESCRIPTION
Avoiding a copy means improved performance, especially with large messages.