### PR TITLE
Security: Use crypto.randomBytes, not Math.random

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -248,12 +248,7 @@ function getBufferFromNative(data) {
 }
 
 function getRandomMask() {
-  return new Buffer([
-    ~~(Math.random() * 255),
-    ~~(Math.random() * 255),
-    ~~(Math.random() * 255),
-    ~~(Math.random() * 255)
-  ]);
+  return require('crypto').randomBytes(4);
 }
 
 function sendFramedData(outputBuffer, data, cb) {


### PR DESCRIPTION
Depending on the JavaScript engine (node now runs on Chakra and V8) Math.random can be anywhere between [extremely insecure](https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d#.2h4wfgmoo) (v8's implementation has collisions at around 24,000 cycles) and cryptographically pseudo-random.

However, using crypto.randomBytes() directly ensures that the secure version is always used.
