### PR TITLE
Wait for receiver to finish processing frames before closing. 

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -63,6 +63,7 @@ class Receiver {
     this.expectHeader(2, this.processPacket);
     this.dead = false;
     this.processing = false;
+    this.pendingCleanup = null;
 
     this.onerror = function() {};
     this.ontext = function() {};
@@ -106,22 +107,27 @@ class Receiver {
    * @api public
    */
 
-  cleanup() {
-    this.dead = true;
-    this.overflow = null;
-    this.headerBuffer = null;
-    this.expectBuffer = null;
-    this.expectHandler = null;
-    this.unfragmentedBufferPool = null;
-    this.fragmentedBufferPool = null;
-    this.state = null;
-    this.currentMessage = null;
-    this.onerror = null;
-    this.ontext = null;
-    this.onbinary = null;
-    this.onclose = null;
-    this.onping = null;
-    this.onpong = null;
+  cleanup(cb) {
+    if (this.processing) {
+      this.pendingCleanup = cb || function() {};
+    } else {
+      this.dead = true;
+      this.overflow = null;
+      this.headerBuffer = null;
+      this.expectBuffer = null;
+      this.expectHandler = null;
+      this.unfragmentedBufferPool = null;
+      this.fragmentedBufferPool = null;
+      this.state = null;
+      this.currentMessage = null;
+      this.onerror = null;
+      this.ontext = null;
+      this.onbinary = null;
+      this.onclose = null;
+      this.onping = null;
+      this.onpong = null;
+      if (cb) cb();
+    }
   }
 
   /**
@@ -328,7 +334,11 @@ class Receiver {
     if (this.processing || this.dead) return;
 
     var handler = this.messageHandlers.shift();
-    if (!handler) return;
+
+    if (!handler) {
+      if (this.pendingCleanup) this.cleanup(this.pendingCleanup);
+      return;
+    }
 
     this.processing = true;
 
@@ -636,27 +646,28 @@ var opcodes = {
       data = self.unmask(mask, data, true);
 
       var state = clone(this.state);
-      this.messageHandlers.push(function() {
+      this.messageHandlers.push(function(callback) {
         if (data && data.length == 1) {
           self.error('close packets with data must be at least two bytes long', 1002);
-          return;
+          return callback();
         }
         var code = data && data.length > 1 ? readUInt16BE.call(data, 0) : 1000;
         if (!ErrorCodes.isValidErrorCode(code)) {
           self.error('invalid error code', 1002);
-          return;
+          return callback();
         }
         var message = '';
         if (data && data.length > 2) {
           var messageBuffer = data.slice(2);
           if (!Validation.isValidUTF8(messageBuffer)) {
             self.error('invalid utf8 sequence', 1007);
-            return;
+            return callback();
           }
           message = messageBuffer.toString('utf8');
         }
         self.onclose(code, message, {masked: state.masked});
         self.reset();
+        callback();
       });
       this.flush();
     }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -940,18 +940,12 @@ function sendStream(instance, stream, options, cb) {
 function cleanupWebsocketResources(error) {
   if (this.readyState === WebSocket.CLOSED) return;
 
-  this.readyState = WebSocket.CLOSED;
-
-  clearTimeout(this._closeTimer);
-  this._closeTimer = null;
-
   // If the connection was closed abnormally (with an error), or if
   // the close control frame was not received then the close code
   // must default to 1006.
   if (error || !this._closeReceived) {
     this._closeCode = 1006;
   }
-  this.emit('close', this._closeCode || 1000, this._closeMessage || '');
 
   if (this._socket) {
     if (this._ultron) this._ultron.destroy();
@@ -975,9 +969,21 @@ function cleanupWebsocketResources(error) {
   }
 
   if (this._receiver) {
-    this._receiver.cleanup();
+    this._receiver.cleanup(finalClose.bind(this));
     this._receiver = null;
+  } else {
+    finalClose.call(this);
   }
+}
+
+function finalClose()
+{
+  this.readyState = WebSocket.CLOSED;
+
+  clearTimeout(this._closeTimer);
+  this._closeTimer = null;
+
+  this.emit('close', this._closeCode || 1000, this._closeMessage || '');
 
   if (this.extensions[PerMessageDeflate.extensionName]) {
     this.extensions[PerMessageDeflate.extensionName].cleanup();

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1533,6 +1533,20 @@ describe('WebSocket', function() {
         });
       });
     });
+
+    it('consumes all data when the server tcp socket closed', function(done) {
+      var wss = new WebSocketServer({port: ++port}, function() {
+        wss.on('connection', function(conn) {
+          conn.send('foo', function() {
+            conn._socket.destroy();
+          });
+        });
+        var ws = new WebSocket('ws://localhost:' + port);
+        ws.on('message', function (message) {
+            done();
+        });
+      });
+    });
   });
 
   describe('W3C API emulation', function() {


### PR DESCRIPTION
The socket close handler is now aware that frames can be processed asynchronously and will wait for the receiver to finish before emitting the close event.

Fixes #799.
