### PR TITLE
Fix and clean up parser and sender benchmarks

### DIFF
--- a/bench/parser.benchmark.js
+++ b/bench/parser.benchmark.js
@@ -6,112 +6,50 @@
 
 'use strict';
 
-/**
- * Benchmark dependencies.
- */
+const benchmark = require('benchmark')
 
-var benchmark = require('benchmark')
-  , Receiver = require('../').Receiver
-  , suite = new benchmark.Suite('Receiver');
-require('tinycolor');
-require('./util');
+const Receiver = require('../').Receiver
+const util = require('./util');
 
-/**
- * Setup receiver.
- */
+function createBinaryPacket(length) {
+  const message = Buffer.alloc(length);
 
-suite.on('start', function () {
-  receiver = new Receiver();
-});
+  for (var i = 0; i < length; ++i) message[i] = i % 10;
 
-suite.on('cycle', function () {
-  receiver = new Receiver();
-});
+  return Buffer.from('82' + util.getHybiLengthAsHexString(length, true) + '3483a868' +
+    util.mask(message, '3483a868').toString('hex'), 'hex');
+}
 
-/**
- * Benchmarks.
- */
+const pingMessage = 'Hello'
+const pingPacket1 = Buffer.from('89' + util.pack(2, 0x80 | pingMessage.length) +
+  '3483a868' + util.mask(pingMessage, '3483a868').toString('hex'), 'hex');
+const pingPacket2 = Buffer.from('8900', 'hex');
+const closePacket = Buffer.from('8800', 'hex');
+const maskedTextPacket = Buffer.from('81933483a86801b992524fa1c60959e68a5216e6cb005ba1d5', 'hex');
+const binaryDataPacket = createBinaryPacket(125);
+const binaryDataPacket2 = createBinaryPacket(65535);
+const binaryDataPacket3 = createBinaryPacket(200 * 1024)
 
-var pingMessage = 'Hello'
-  , pingPacket1 = getBufferFromHexString('89 ' + (pack(2, 0x80 | pingMessage.length)) +
-                                         ' 34 83 a8 68 '+ getHexStringFromBuffer(mask(pingMessage, '34 83 a8 68')));
-suite.add('ping message', function () {
-  receiver.add(pingPacket1);
-});
+var receiver = new Receiver({}, Infinity);
+const suite = new benchmark.Suite();
 
-var pingPacket2 = getBufferFromHexString('89 00')
-suite.add('ping with no data', function () {
-  receiver.add(pingPacket2);
-});
-
-var closePacket = getBufferFromHexString('88 00');
-suite.add('close message', function () {
+suite.add('ping message', () => receiver.add(pingPacket1));
+suite.add('ping with no data', () => receiver.add(pingPacket2));
+suite.add('close message', () => {
   receiver.add(closePacket);
   receiver.endPacket();
+})
+suite.add('masked text message', () => receiver.add(maskedTextPacket));
+suite.add('binary data (125 bytes)', () => receiver.add(binaryDataPacket));
+suite.add('binary data (65535 bytes)', () => receiver.add(binaryDataPacket2));
+suite.add('binary data (200 kB)', () => receiver.add(binaryDataPacket3));
+suite.on('cycle', (e) => {
+  console.log(e.target.toString());
+  receiver = new Receiver();
 });
 
-var maskedTextPacket = getBufferFromHexString('81 93 34 83 a8 68 01 b9 92 52 4f a1 c6 09 59 e6 8a 52 16 e6 cb 00 5b a1 d5');
-suite.add('masked text message', function () {
-  receiver.add(maskedTextPacket);
-});
-
-binaryDataPacket = (function() {
-  var length = 125
-    , message = new Buffer(length)
-  for (var i = 0; i < length; ++i) message[i] = i % 10;
-  return getBufferFromHexString('82 ' + getHybiLengthAsHexString(length, true) + ' 34 83 a8 68 '
-       + getHexStringFromBuffer(mask(message), '34 83 a8 68'));
-})();
-suite.add('binary data (125 bytes)', function () {
-  try {
-    receiver.add(binaryDataPacket);
-
-  }
-  catch(e) {console.log(e)}
-});
-
-binaryDataPacket2 = (function() {
-  var length = 65535
-    , message = new Buffer(length)
-  for (var i = 0; i < length; ++i) message[i] = i % 10;
-  return getBufferFromHexString('82 ' + getHybiLengthAsHexString(length, true) + ' 34 83 a8 68 '
-       + getHexStringFromBuffer(mask(message), '34 83 a8 68'));
-})();
-suite.add('binary data (65535 bytes)', function () {
-  receiver.add(binaryDataPacket2);
-});
-
-binaryDataPacket3 = (function() {
-  var length = 200*1024
-    , message = new Buffer(length)
-  for (var i = 0; i < length; ++i) message[i] = i % 10;
-  return getBufferFromHexString('82 ' + getHybiLengthAsHexString(length, true) + ' 34 83 a8 68 '
-       + getHexStringFromBuffer(mask(message), '34 83 a8 68'));
-})();
-suite.add('binary data (200 kB)', function () {
-  receiver.add(binaryDataPacket3);
-});
-
-/**
- * Output progress.
- */
-
-suite.on('cycle', function (bench, details) {
-  console.log('\n  ' + suite.name.grey, details.name.white.bold);
-  console.log('  ' + [
-      details.hz.toFixed(2).cyan + ' ops/sec'.grey
-    , details.count.toString().white + ' times executed'.grey
-    , 'benchmark took '.grey + details.times.elapsed.toString().white + ' sec.'.grey
-    ,
-  ].join(', '.grey));
-});
-
-/**
- * Run/export benchmarks.
- */
-
-if (!module.parent) {
-  suite.run();
+if (require.main === module) {
+  suite.run({ async: true });
 } else {
   module.exports = suite;
 }

--- a/bench/util.js
+++ b/bench/util.js
@@ -7,101 +7,51 @@
 'use strict';
 
 /**
- * Returns a Buffer from a "ff 00 ff"-type hex string.
- */
-
-global.getBufferFromHexString = function(byteStr) {
-  var bytes = byteStr.split(' ');
-  var buf = new Buffer(bytes.length);
-  for (var i = 0; i < bytes.length; ++i) {
-    buf[i] = parseInt(bytes[i], 16);
-  }
-  return buf;
-}
-
-/**
- * Returns a hex string from a Buffer.
- */
-
-global.getHexStringFromBuffer = function(data) {
-  var s = '';
-  for (var i = 0; i < data.length; ++i) {
-    s += padl(data[i].toString(16), 2, '0') + ' ';
-  }
-  return s.trim();
-}
-
-/**
- * Splits a buffer in two parts.
- */
-
-global.splitBuffer = function(buffer) {
-  var b1 = new Buffer(Math.ceil(buffer.length / 2));
-  buffer.copy(b1, 0, 0, b1.length);
-  var b2 = new Buffer(Math.floor(buffer.length / 2));
-  buffer.copy(b2, 0, b1.length, b1.length + b2.length);
-  return [b1, b2];
-}
-
-/**
  * Performs hybi07+ type masking on a hex string or buffer.
  */
+function mask(buf, maskString) {
+  const _mask = Buffer.from(maskString || '3483a868', 'hex');
 
-global.mask = function(buf, maskString) {
-  if (typeof buf == 'string') buf = new Buffer(buf);
-  var mask = getBufferFromHexString(maskString || '34 83 a8 68');
+  if (typeof buf === 'string') buf = Buffer.from(buf);
+
   for (var i = 0; i < buf.length; ++i) {
-    buf[i] ^= mask[i % 4];
+    buf[i] ^= _mask[i % 4];
   }
+
   return buf;
 }
 
 /**
- * Returns a hex string representing the length of a message
+ * Left pads the string `s` to a total length of `n` with char `c`.
  */
+function padl(s, n, c) {
+  return c.repeat(n - s.length) + s;
+}
 
-global.getHybiLengthAsHexString = function(len, masked) {
+/**
+ * Returns a hex string, representing a specific byte count `length`, from a number.
+ */
+function pack(length, number) {
+  return padl(number.toString(16), length, '0');
+}
+
+/**
+ * Returns a hex string representing the length of a message.
+ */
+function getHybiLengthAsHexString(len, masked) {
+  var s;
+
+  masked = masked ? 0x80 : 0;
+
   if (len < 126) {
-    var buf = new Buffer(1);
-    buf[0] = (masked ? 0x80 : 0) | len;
+    s = pack(2, masked | len);
+  } else if (len < 65536) {
+    s = pack(2, masked | 126) + pack(4, len);
+  } else {
+    s = pack(2, masked | 127) + pack(16, len);
   }
-  else if (len < 65536) {
-    var buf = new Buffer(3);
-    buf[0] = (masked ? 0x80 : 0) | 126;
-    getBufferFromHexString(pack(4, len)).copy(buf, 1);
-  }
-  else {
-    var buf = new Buffer(9);
-    buf[0] = (masked ? 0x80 : 0) | 127;
-    getBufferFromHexString(pack(16, len)).copy(buf, 1);
-  }
-  return getHexStringFromBuffer(buf);
+
+  return s;
 }
 
-/**
- * Unpacks a Buffer into a number.
- */
-
-global.unpack = function(buffer) {
-  var n = 0;
-  for (var i = 0; i < buffer.length; ++i) {
-    n = (i == 0) ? buffer[i] : (n * 256) + buffer[i];
-  }
-  return n;
-}
-
-/**
- * Returns a hex string, representing a specific byte count 'length', from a number.
- */
-
-global.pack = function(length, number) {
-  return padl(number.toString(16), length, '0').replace(/([0-9a-f][0-9a-f])/gi, '$1 ').trim();
-}
-
-/**
- * Left pads the string 's' to a total length of 'n' with char 'c'.
- */
-
-global.padl = function(s, n, c) {
-  return new Array(1 + n - s.length).join(c) + s;
-}
+module.exports = { getHybiLengthAsHexString, mask, pack };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "ansi": "0.3.x",
-    "benchmark": "0.3.x",
+    "benchmark": "2.1.x",
     "bufferutil": "1.2.x",
     "eslint": "^2.12.0",
     "expect.js": "0.3.x",


### PR DESCRIPTION
- Avoid using global variables.
- Remove unused functions from `bench/util.js`.
- Fix issues with strict mode and global variables.