### PR TITLE
Remove unreachable code

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -131,10 +131,6 @@ class Receiver {
    */
 
   expectHeader(length, handler) {
-    if (length == 0) {
-      handler(null);
-      return;
-    }
     this.expectBuffer = this.headerBuffer.slice(this.expectOffset, this.expectOffset + length);
     this.expectHandler = handler;
     var toRead = length;


### PR DESCRIPTION
The `length` argument is always > 0.