### PR TITLE
Avoid using `Function.prototype.call()`

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -80,20 +80,20 @@ class Receiver {
 
   add(data) {
     if (this.dead) return;
-    var dataLength = data.length;
+    const dataLength = data.length;
     if (dataLength == 0) return;
     if (this.expectBuffer == null) {
       this.overflow.push(data);
       return;
     }
-    var toRead = Math.min(dataLength, this.expectBuffer.length - this.expectOffset);
+    const toRead = Math.min(dataLength, this.expectBuffer.length - this.expectOffset);
     fastCopy(toRead, data, this.expectBuffer, this.expectOffset);
     this.expectOffset += toRead;
     if (toRead < dataLength) {
       this.overflow.push(data.slice(toRead));
     }
     while (this.expectBuffer && this.expectOffset == this.expectBuffer.length) {
-      var bufferForHandler = this.expectBuffer;
+      const bufferForHandler = this.expectBuffer;
       this.expectBuffer = null;
       this.expectOffset = 0;
       this.expectHandler(bufferForHandler);
@@ -140,8 +140,8 @@ class Receiver {
     var toRead = length;
     while (toRead > 0 && this.overflow.length > 0) {
       var fromOverflow = this.overflow.pop();
-      if (toRead < fromOverflow.length) this.overflow.push(fromOverflow.slice(toRead));
       var read = Math.min(fromOverflow.length, toRead);
+      if (toRead < fromOverflow.length) this.overflow.push(fromOverflow.slice(toRead));
       fastCopy(read, fromOverflow, this.expectBuffer, this.expectOffset);
       this.expectOffset += read;
       toRead -= read;
@@ -164,8 +164,8 @@ class Receiver {
     var toRead = length;
     while (toRead > 0 && this.overflow.length > 0) {
       var fromOverflow = this.overflow.pop();
-      if (toRead < fromOverflow.length) this.overflow.push(fromOverflow.slice(toRead));
       var read = Math.min(fromOverflow.length, toRead);
+      if (toRead < fromOverflow.length) this.overflow.push(fromOverflow.slice(toRead));
       fastCopy(read, fromOverflow, this.expectBuffer, this.expectOffset);
       this.expectOffset += read;
       toRead -= read;
@@ -202,8 +202,8 @@ class Receiver {
     }
     this.state.lastFragment = (data[0] & 0x80) == 0x80;
     this.state.masked = (data[1] & 0x80) == 0x80;
-    var compressed = (data[0] & 0x40) == 0x40;
-    var opcode = data[0] & 0xf;
+    const compressed = (data[0] & 0x40) == 0x40;
+    const opcode = data[0] & 0xf;
     if (opcode === 0) {
       if (compressed) {
         this.error(new Error('continuation frame cannot have the Per-message Compressed bits'), 1002);
@@ -216,8 +216,7 @@ class Receiver {
         this.error(new Error('continuation frame cannot follow current opcode'), 1002);
         return;
       }
-    }
-    else {
+    } else {
       if (opcode < 3 && this.state.activeFragmentedOperation != null) {
         this.error(new Error('data frames after the initial data frame must have opcode 0'), 1002);
         return;
@@ -231,14 +230,14 @@ class Receiver {
       if (this.state.lastFragment === false) {
         this.state.fragmentedOperation = true;
         this.state.activeFragmentedOperation = opcode;
+      } else {
+        this.state.fragmentedOperation = false;
       }
-      else this.state.fragmentedOperation = false;
     }
-    var handler = opcodes[this.state.opcode];
+    const handler = opcodes[this.state.opcode];
     if (typeof handler == 'undefined') {
       this.error(new Error(`no handler for opcode ${this.state.opcode}`), 1002);
-    }
-    else {
+    } else {
       handler.start(this, data);
     }
   }
@@ -345,7 +344,7 @@ class Receiver {
 
   applyExtensions(messageBuffer, fin, compressed, callback) {
     if (compressed) {
-      var extension = this.extensions[PerMessageDeflate.extensionName];
+      const extension = this.extensions[PerMessageDeflate.extensionName];
       extension.decompress(messageBuffer, fin, (err, buffer) => {
         if (this.dead) return;
         if (err) {
@@ -369,7 +368,7 @@ class Receiver {
     if (this.maxPayload === undefined || this.maxPayload === null || this.maxPayload < 1) {
       return false;
     }
-    var fullLength = this.currentPayloadLength + length;
+    const fullLength = this.currentPayloadLength + length;
     if (fullLength < this.maxPayload) {
       this.currentPayloadLength = fullLength;
       return false;
@@ -382,8 +381,6 @@ class Receiver {
 }
 
 module.exports = Receiver;
-
-
 
 /**
  * Buffer utilities
@@ -421,18 +418,18 @@ function clone(obj) {
  * Opcode handlers
  */
 
-var opcodes = {
+const opcodes = {
   // text
   '1': {
     start: (receiver, data) => {
       // decode length
-      var firstLength = data[1] & 0x7f;
+      const firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
         if (receiver.maxPayloadExceeded(firstLength)) return;
         opcodes['1'].getData(receiver, firstLength);
       } else if (firstLength == 126) {
         receiver.expectHeader(2, (data) => {
-          var length = data.readUInt16BE(0, true);
+          const length = data.readUInt16BE(0, true);
           if (receiver.maxPayloadExceeded(length)) return;
           opcodes['1'].getData(receiver, length);
         });
@@ -442,7 +439,7 @@ var opcodes = {
             receiver.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
             return;
           }
-          var length = data.readUInt32BE(4, true);
+          const length = data.readUInt32BE(4, true);
           if (receiver.maxPayloadExceeded(length)) return;
           opcodes['1'].getData(receiver, length);
         });
@@ -450,8 +447,7 @@ var opcodes = {
     },
     getData: (receiver, length) => {
       if (receiver.state.masked) {
-        receiver.expectHeader(4, (data) => {
-          var mask = data;
+        receiver.expectHeader(4, (mask) => {
           receiver.expectData(length, (data) => opcodes['1'].finish(receiver, mask, data));
         });
       } else {
@@ -459,8 +455,8 @@ var opcodes = {
       }
     },
     finish: (receiver, mask, data) => {
-      var packet = receiver.unmask(mask, data) || new Buffer(0);
-      var state = clone(receiver.state);
+      const packet = receiver.unmask(mask, data) || new Buffer(0);
+      const state = clone(receiver.state);
       receiver.messageHandlers.push((callback) => {
         receiver.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
           if (err) {
@@ -481,7 +477,7 @@ var opcodes = {
             receiver.currentMessageLength += buffer.length;
           }
           if (state.lastFragment) {
-            var messageBuffer = receiver.currentMessage.length === 1 ?
+            const messageBuffer = receiver.currentMessage.length === 1 ?
               receiver.currentMessage[0] :
               Buffer.concat(receiver.currentMessage, receiver.currentMessageLength);
             receiver.currentMessage = [];
@@ -506,13 +502,13 @@ var opcodes = {
   '2': {
     start: (receiver, data) => {
       // decode length
-      var firstLength = data[1] & 0x7f;
+      const firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
         if (receiver.maxPayloadExceeded(firstLength)) return;
         opcodes['2'].getData(receiver, firstLength);
       } else if (firstLength == 126) {
         receiver.expectHeader(2, (data) => {
-          var length = data.readUInt16BE(0, true);
+          const length = data.readUInt16BE(0, true);
           if (receiver.maxPayloadExceeded(length)) return;
           opcodes['2'].getData(receiver, length);
         });
@@ -522,7 +518,7 @@ var opcodes = {
             receiver.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
             return;
           }
-          var length = data.readUInt32BE(4, true);
+          const length = data.readUInt32BE(4, true);
           if (receiver.maxPayloadExceeded(length)) return;
           opcodes['2'].getData(receiver, length);
         });
@@ -530,8 +526,7 @@ var opcodes = {
     },
     getData: (receiver, length) => {
       if (receiver.state.masked) {
-        receiver.expectHeader(4, (data) => {
-          var mask = data;
+        receiver.expectHeader(4, (mask) => {
           receiver.expectData(length, (data) => opcodes['2'].finish(receiver, mask, data));
         });
       } else {
@@ -539,8 +534,8 @@ var opcodes = {
       }
     },
     finish: (receiver, mask, data) => {
-      var packet = receiver.unmask(mask, data) || new Buffer(0);
-      var state = clone(receiver.state);
+      const packet = receiver.unmask(mask, data) || new Buffer(0);
+      const state = clone(receiver.state);
       receiver.messageHandlers.push((callback) => {
         receiver.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
           if (err) {
@@ -561,7 +556,7 @@ var opcodes = {
             receiver.currentMessageLength += buffer.length;
           }
           if (state.lastFragment) {
-            var messageBuffer = receiver.currentMessage.length === 1 ?
+            const messageBuffer = receiver.currentMessage.length === 1 ?
               receiver.currentMessage[0] :
               Buffer.concat(receiver.currentMessage, receiver.currentMessageLength);
             receiver.currentMessage = [];
@@ -587,7 +582,7 @@ var opcodes = {
       }
 
       // decode length
-      var firstLength = data[1] & 0x7f;
+      const firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
         opcodes['8'].getData(receiver, firstLength);
       } else {
@@ -596,33 +591,29 @@ var opcodes = {
     },
     getData: (receiver, length) => {
       if (receiver.state.masked) {
-        receiver.expectHeader(4, (data) => {
-          var mask = data;
-          receiver.expectData(length, (data) => {
-            opcodes['8'].finish(receiver, mask, data);
-          });
+        receiver.expectHeader(4, (mask) => {
+          receiver.expectData(length, (data) => opcodes['8'].finish(receiver, mask, data));
         });
       } else {
         receiver.expectData(length, (data) => opcodes['8'].finish(receiver, null, data));
       }
     },
     finish: (receiver, mask, data) => {
-      data = receiver.unmask(mask, data);
-
-      var state = clone(receiver.state);
+      const packet = receiver.unmask(mask, data);
+      const state = clone(receiver.state);
       receiver.messageHandlers.push(() => {
-        if (data && data.length == 1) {
+        if (packet && packet.length == 1) {
           receiver.error('close packets with data must be at least two bytes long', 1002);
           return;
         }
-        var code = data && data.length > 1 ? data.readUInt16BE(0, true) : 1000;
+        const code = packet && packet.length > 1 ? packet.readUInt16BE(0, true) : 1000;
         if (!ErrorCodes.isValidErrorCode(code)) {
           receiver.error('invalid error code', 1002);
           return;
         }
         var message = '';
-        if (data && data.length > 2) {
-          var messageBuffer = data.slice(2);
+        if (packet && packet.length > 2) {
+          const messageBuffer = packet.slice(2);
           if (!Validation.isValidUTF8(messageBuffer)) {
             receiver.error('invalid utf8 sequence', 1007);
             return;
@@ -644,7 +635,7 @@ var opcodes = {
       }
 
       // decode length
-      var firstLength = data[1] & 0x7f;
+      const firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
         opcodes['9'].getData(receiver, firstLength);
       } else {
@@ -653,8 +644,7 @@ var opcodes = {
     },
     getData: (receiver, length) => {
       if (receiver.state.masked) {
-        receiver.expectHeader(4, (data) => {
-          var mask = data;
+        receiver.expectHeader(4, (mask) => {
           receiver.expectData(length, (data) => opcodes['9'].finish(receiver, mask, data));
         });
       } else {
@@ -662,10 +652,10 @@ var opcodes = {
       }
     },
     finish: (receiver, mask, data) => {
-      data = receiver.unmask(mask, data);
-      var state = clone(receiver.state);
+      const packet = receiver.unmask(mask, data);
+      const state = clone(receiver.state);
       receiver.messageHandlers.push((callback) => {
-        receiver.onping(data, { masked: state.masked, binary: true });
+        receiver.onping(packet, { masked: state.masked, binary: true });
         callback();
       });
       receiver.flush();
@@ -681,7 +671,7 @@ var opcodes = {
       }
 
       // decode length
-      var firstLength = data[1] & 0x7f;
+      const firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
         opcodes['10'].getData(receiver, firstLength);
       } else {
@@ -690,8 +680,7 @@ var opcodes = {
     },
     getData: (receiver, length) => {
       if (receiver.state.masked) {
-        receiver.expectHeader(4, (data) => {
-          var mask = data;
+        receiver.expectHeader(4, (mask) => {
           receiver.expectData(length, (data) => opcodes['10'].finish(receiver, mask, data));
         });
       } else {
@@ -699,10 +688,10 @@ var opcodes = {
       }
     },
     finish: (receiver, mask, data) => {
-      data = receiver.unmask(mask, data);
-      var state = clone(receiver.state);
+      const packet = receiver.unmask(mask, data);
+      const state = clone(receiver.state);
       receiver.messageHandlers.push((callback) => {
-        receiver.onpong(data, { masked: state.masked, binary: true });
+        receiver.onpong(packet, { masked: state.masked, binary: true });
         callback();
       });
       receiver.flush();

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -96,7 +96,7 @@ class Receiver {
       var bufferForHandler = this.expectBuffer;
       this.expectBuffer = null;
       this.expectOffset = 0;
-      this.expectHandler.call(this, bufferForHandler);
+      this.expectHandler(bufferForHandler);
     }
   }
 
@@ -188,7 +188,7 @@ class Receiver {
    * @api private
    */
 
-  processPacket (data) {
+  processPacket(data) {
     if (this.extensions[PerMessageDeflate.extensionName]) {
       if ((data[0] & 0x30) != 0) {
         this.error(new Error('reserved fields (2, 3) must be empty'), 1002);
@@ -239,7 +239,7 @@ class Receiver {
       this.error(new Error(`no handler for opcode ${this.state.opcode}`), 1002);
     }
     else {
-      handler.start.call(this, data);
+      handler.start(this, data);
     }
   }
 
@@ -424,322 +424,289 @@ function clone(obj) {
 var opcodes = {
   // text
   '1': {
-    start: function(data) {
+    start: (receiver, data) => {
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        if (this.maxPayloadExceeded(firstLength)) return;
-        opcodes['1'].getData.call(this, firstLength);
-      }
-      else if (firstLength == 126) {
-        this.expectHeader(2, (data) => {
+        if (receiver.maxPayloadExceeded(firstLength)) return;
+        opcodes['1'].getData(receiver, firstLength);
+      } else if (firstLength == 126) {
+        receiver.expectHeader(2, (data) => {
           var length = data.readUInt16BE(0, true);
-          if (this.maxPayloadExceeded(length)) return;
-          opcodes['1'].getData.call(this, length);
+          if (receiver.maxPayloadExceeded(length)) return;
+          opcodes['1'].getData(receiver, length);
         });
-      }
-      else if (firstLength == 127) {
-        this.expectHeader(8, (data) => {
+      } else if (firstLength == 127) {
+        receiver.expectHeader(8, (data) => {
           if (data.readUInt32BE(0, true) != 0) {
-            this.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
+            receiver.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
             return;
           }
           var length = data.readUInt32BE(4, true);
-          if (this.maxPayloadExceeded(length)) return;
-          opcodes['1'].getData.call(this, length);
+          if (receiver.maxPayloadExceeded(length)) return;
+          opcodes['1'].getData(receiver, length);
         });
       }
     },
-    getData: function(length) {
-      if (this.state.masked) {
-        this.expectHeader(4, (data) => {
+    getData: (receiver, length) => {
+      if (receiver.state.masked) {
+        receiver.expectHeader(4, (data) => {
           var mask = data;
-          this.expectData(length, (data) => {
-            opcodes['1'].finish.call(this, mask, data);
-          });
+          receiver.expectData(length, (data) => opcodes['1'].finish(receiver, mask, data));
         });
-      }
-      else {
-        this.expectData(length, (data) => {
-          opcodes['1'].finish.call(this, null, data);
-        });
+      } else {
+        receiver.expectData(length, (data) => opcodes['1'].finish(receiver, null, data));
       }
     },
-    finish: function(mask, data) {
-      var packet = this.unmask(mask, data) || new Buffer(0);
-      var state = clone(this.state);
-      this.messageHandlers.push((callback) => {
-        this.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
+    finish: (receiver, mask, data) => {
+      var packet = receiver.unmask(mask, data) || new Buffer(0);
+      var state = clone(receiver.state);
+      receiver.messageHandlers.push((callback) => {
+        receiver.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
           if (err) {
-            this.error(err, err.closeCode === 1009 ? 1009 : 1007);
+            receiver.error(err, err.closeCode === 1009 ? 1009 : 1007);
             return;
           }
 
           if (buffer != null) {
-            if (this.maxPayload == 0 || (this.maxPayload > 0 &&
-              (this.currentMessageLength + buffer.length) < this.maxPayload)) {
-              this.currentMessage.push(buffer);
-            }
-            else {
-              this.currentMessage = [];
-              this.currentMessageLength = 0;
-              this.error(new Error(`payload cannot exceed ${this.maxPayload} bytes`), 1009);
+            if (receiver.maxPayload == 0 || (receiver.maxPayload > 0 &&
+              (receiver.currentMessageLength + buffer.length) < receiver.maxPayload)) {
+              receiver.currentMessage.push(buffer);
+            } else {
+              receiver.currentMessage = [];
+              receiver.currentMessageLength = 0;
+              receiver.error(new Error(`payload cannot exceed ${receiver.maxPayload} bytes`), 1009);
               return;
             }
-            this.currentMessageLength += buffer.length;
+            receiver.currentMessageLength += buffer.length;
           }
           if (state.lastFragment) {
-            var messageBuffer = this.currentMessage.length === 1 ?
-              this.currentMessage[0] :
-              Buffer.concat(this.currentMessage, this.currentMessageLength);
-            this.currentMessage = [];
-            this.currentMessageLength = 0;
+            var messageBuffer = receiver.currentMessage.length === 1 ?
+              receiver.currentMessage[0] :
+              Buffer.concat(receiver.currentMessage, receiver.currentMessageLength);
+            receiver.currentMessage = [];
+            receiver.currentMessageLength = 0;
             if (!Validation.isValidUTF8(messageBuffer)) {
-              this.error(new Error('invalid utf8 sequence'), 1007);
+              receiver.error(new Error('invalid utf8 sequence'), 1007);
               return;
             }
-            this.ontext(messageBuffer.toString('utf8'), {masked: state.masked, buffer: messageBuffer});
+            receiver.ontext(messageBuffer.toString('utf8'), {
+              masked: state.masked,
+              buffer: messageBuffer
+            });
           }
           callback();
         });
       });
-      this.flush();
-      this.endPacket();
+      receiver.flush();
+      receiver.endPacket();
     }
   },
   // binary
   '2': {
-    start: function(data) {
+    start: (receiver, data) => {
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        if (this.maxPayloadExceeded(firstLength)) return;
-        opcodes['2'].getData.call(this, firstLength);
-      }
-      else if (firstLength == 126) {
-        this.expectHeader(2, (data) => {
+        if (receiver.maxPayloadExceeded(firstLength)) return;
+        opcodes['2'].getData(receiver, firstLength);
+      } else if (firstLength == 126) {
+        receiver.expectHeader(2, (data) => {
           var length = data.readUInt16BE(0, true);
-          if (this.maxPayloadExceeded(length)) return;
-          opcodes['2'].getData.call(this, length);
+          if (receiver.maxPayloadExceeded(length)) return;
+          opcodes['2'].getData(receiver, length);
         });
-      }
-      else if (firstLength == 127) {
-        this.expectHeader(8, (data) => {
+      } else if (firstLength == 127) {
+        receiver.expectHeader(8, (data) => {
           if (data.readUInt32BE(0, true) != 0) {
-            this.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
+            receiver.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
             return;
           }
           var length = data.readUInt32BE(4, true);
-          if (this.maxPayloadExceeded(length)) return;
-          opcodes['2'].getData.call(this, length);
+          if (receiver.maxPayloadExceeded(length)) return;
+          opcodes['2'].getData(receiver, length);
         });
       }
     },
-    getData: function(length) {
-      if (this.state.masked) {
-        this.expectHeader(4, (data) => {
+    getData: (receiver, length) => {
+      if (receiver.state.masked) {
+        receiver.expectHeader(4, (data) => {
           var mask = data;
-          this.expectData(length, (data) => {
-            opcodes['2'].finish.call(this, mask, data);
-          });
+          receiver.expectData(length, (data) => opcodes['2'].finish(receiver, mask, data));
         });
-      }
-      else {
-        this.expectData(length, (data) => {
-          opcodes['2'].finish.call(this, null, data);
-        });
+      } else {
+        receiver.expectData(length, (data) => opcodes['2'].finish(receiver, null, data));
       }
     },
-    finish: function(mask, data) {
-      var packet = this.unmask(mask, data) || new Buffer(0);
-      var state = clone(this.state);
-      this.messageHandlers.push((callback) => {
-        this.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
+    finish: (receiver, mask, data) => {
+      var packet = receiver.unmask(mask, data) || new Buffer(0);
+      var state = clone(receiver.state);
+      receiver.messageHandlers.push((callback) => {
+        receiver.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
           if (err) {
-            this.error(err, err.closeCode === 1009 ? 1009 : 1007);
+            receiver.error(err, err.closeCode === 1009 ? 1009 : 1007);
             return;
           }
 
           if (buffer != null) {
-            if (this.maxPayload == 0 || (this.maxPayload > 0 &&
-              (this.currentMessageLength + buffer.length) < this.maxPayload)) {
-              this.currentMessage.push(buffer);
-            }
-            else {
-              this.currentMessage = [];
-              this.currentMessageLength = 0;
-              this.error(new Error(`payload cannot exceed ${this.maxPayload} bytes`), 1009);
+            if (receiver.maxPayload == 0 || (receiver.maxPayload > 0 &&
+              (receiver.currentMessageLength + buffer.length) < receiver.maxPayload)) {
+              receiver.currentMessage.push(buffer);
+            } else {
+              receiver.currentMessage = [];
+              receiver.currentMessageLength = 0;
+              receiver.error(new Error(`payload cannot exceed ${receiver.maxPayload} bytes`), 1009);
               return;
             }
-            this.currentMessageLength += buffer.length;
+            receiver.currentMessageLength += buffer.length;
           }
           if (state.lastFragment) {
-            var messageBuffer = this.currentMessage.length === 1 ?
-              this.currentMessage[0] :
-              Buffer.concat(this.currentMessage, this.currentMessageLength);
-            this.currentMessage = [];
-            this.currentMessageLength = 0;
-            this.onbinary(messageBuffer, {masked: state.masked, buffer: messageBuffer});
+            var messageBuffer = receiver.currentMessage.length === 1 ?
+              receiver.currentMessage[0] :
+              Buffer.concat(receiver.currentMessage, receiver.currentMessageLength);
+            receiver.currentMessage = [];
+            receiver.currentMessageLength = 0;
+            receiver.onbinary(messageBuffer, {
+              masked: state.masked,
+              buffer: messageBuffer
+            });
           }
           callback();
         });
       });
-      this.flush();
-      this.endPacket();
+      receiver.flush();
+      receiver.endPacket();
     }
   },
   // close
   '8': {
-    start: function(data) {
-      var self = this;
-      if (self.state.lastFragment == false) {
-        self.error('fragmented close is not supported', 1002);
+    start: (receiver, data) => {
+      if (receiver.state.lastFragment == false) {
+        receiver.error('fragmented close is not supported', 1002);
         return;
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        opcodes['8'].getData.call(self, firstLength);
-      }
-      else {
-        self.error('control frames cannot have more than 125 bytes of data', 1002);
+        opcodes['8'].getData(receiver, firstLength);
+      } else {
+        receiver.error('control frames cannot have more than 125 bytes of data', 1002);
       }
     },
-    getData: function(length) {
-      var self = this;
-      if (self.state.masked) {
-        self.expectHeader(4, function(data) {
+    getData: (receiver, length) => {
+      if (receiver.state.masked) {
+        receiver.expectHeader(4, (data) => {
           var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['8'].finish.call(self, mask, data);
+          receiver.expectData(length, (data) => {
+            opcodes['8'].finish(receiver, mask, data);
           });
         });
-      }
-      else {
-        self.expectData(length, function(data) {
-          opcodes['8'].finish.call(self, null, data);
-        });
+      } else {
+        receiver.expectData(length, (data) => opcodes['8'].finish(receiver, null, data));
       }
     },
-    finish: function(mask, data) {
-      var self = this;
-      data = self.unmask(mask, data);
+    finish: (receiver, mask, data) => {
+      data = receiver.unmask(mask, data);
 
-      var state = clone(this.state);
-      this.messageHandlers.push(function() {
+      var state = clone(receiver.state);
+      receiver.messageHandlers.push(() => {
         if (data && data.length == 1) {
-          self.error('close packets with data must be at least two bytes long', 1002);
+          receiver.error('close packets with data must be at least two bytes long', 1002);
           return;
         }
         var code = data && data.length > 1 ? data.readUInt16BE(0, true) : 1000;
         if (!ErrorCodes.isValidErrorCode(code)) {
-          self.error('invalid error code', 1002);
+          receiver.error('invalid error code', 1002);
           return;
         }
         var message = '';
         if (data && data.length > 2) {
           var messageBuffer = data.slice(2);
           if (!Validation.isValidUTF8(messageBuffer)) {
-            self.error('invalid utf8 sequence', 1007);
+            receiver.error('invalid utf8 sequence', 1007);
             return;
           }
           message = messageBuffer.toString('utf8');
         }
-        self.onclose(code, message, {masked: state.masked});
-        self.reset();
+        receiver.onclose(code, message, { masked: state.masked });
+        receiver.reset();
       });
-      this.flush();
+      receiver.flush();
     }
   },
   // ping
   '9': {
-    start: function(data) {
-      var self = this;
-      if (self.state.lastFragment == false) {
-        self.error('fragmented ping is not supported', 1002);
+    start: (receiver, data) => {
+      if (receiver.state.lastFragment == false) {
+        receiver.error('fragmented ping is not supported', 1002);
         return;
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        opcodes['9'].getData.call(self, firstLength);
-      }
-      else {
-        self.error('control frames cannot have more than 125 bytes of data', 1002);
+        opcodes['9'].getData(receiver, firstLength);
+      } else {
+        receiver.error('control frames cannot have more than 125 bytes of data', 1002);
       }
     },
-    getData: function(length) {
-      var self = this;
-      if (self.state.masked) {
-        self.expectHeader(4, function(data) {
+    getData: (receiver, length) => {
+      if (receiver.state.masked) {
+        receiver.expectHeader(4, (data) => {
           var mask = data;
-          self.expectData(length, function(data) {
-            opcodes['9'].finish.call(self, mask, data);
-          });
+          receiver.expectData(length, (data) => opcodes['9'].finish(receiver, mask, data));
         });
-      }
-      else {
-        self.expectData(length, function(data) {
-          opcodes['9'].finish.call(self, null, data);
-        });
+      } else {
+        receiver.expectData(length, (data) => opcodes['9'].finish(receiver, null, data));
       }
     },
-    finish: function(mask, data) {
-      var self = this;
-      data = this.unmask(mask, data);
-      var state = clone(this.state);
-      this.messageHandlers.push(function(callback) {
-        self.onping(data, {masked: state.masked, binary: true});
+    finish: (receiver, mask, data) => {
+      data = receiver.unmask(mask, data);
+      var state = clone(receiver.state);
+      receiver.messageHandlers.push((callback) => {
+        receiver.onping(data, { masked: state.masked, binary: true });
         callback();
       });
-      this.flush();
-      this.endPacket();
+      receiver.flush();
+      receiver.endPacket();
     }
   },
   // pong
   '10': {
-    start: function(data) {
-      var self = this;
-      if (self.state.lastFragment == false) {
-        self.error('fragmented pong is not supported', 1002);
+    start: (receiver, data) => {
+      if (receiver.state.lastFragment == false) {
+        receiver.error('fragmented pong is not supported', 1002);
         return;
       }
 
       // decode length
       var firstLength = data[1] & 0x7f;
       if (firstLength < 126) {
-        opcodes['10'].getData.call(self, firstLength);
-      }
-      else {
-        self.error('control frames cannot have more than 125 bytes of data', 1002);
+        opcodes['10'].getData(receiver, firstLength);
+      } else {
+        receiver.error('control frames cannot have more than 125 bytes of data', 1002);
       }
     },
-    getData: function(length) {
-      if (this.state.masked) {
-        this.expectHeader(4, (data) => {
+    getData: (receiver, length) => {
+      if (receiver.state.masked) {
+        receiver.expectHeader(4, (data) => {
           var mask = data;
-          this.expectData(length, (data) => {
-            opcodes['10'].finish.call(this, mask, data);
-          });
+          receiver.expectData(length, (data) => opcodes['10'].finish(receiver, mask, data));
         });
-      }
-      else {
-        this.expectData(length, (data) => {
-          opcodes['10'].finish.call(this, null, data);
-        });
+      } else {
+        receiver.expectData(length, (data) => opcodes['10'].finish(receiver, null, data));
       }
     },
-    finish: function(mask, data) {
-      data = this.unmask(mask, data);
-      var state = clone(this.state);
-      this.messageHandlers.push((callback) => {
-        this.onpong(data, {masked: state.masked, binary: true});
+    finish: (receiver, mask, data) => {
+      data = receiver.unmask(mask, data);
+      var state = clone(receiver.state);
+      receiver.messageHandlers.push((callback) => {
+        receiver.onpong(data, { masked: state.masked, binary: true });
         callback();
       });
-      this.flush();
-      this.endPacket();
+      receiver.flush();
+      receiver.endPacket();
     }
   }
 }


### PR DESCRIPTION
- First commit removes all occurrences of `Function.prototype.call()` in favor of direct function invocation.
- Second commit applies some style changes.