### PR TITLE
Improve ping and pong performance

### DIFF
--- a/bench/sender.benchmark.js
+++ b/bench/sender.benchmark.js
@@ -16,6 +16,8 @@ const suite = new benchmark.Suite();
 var sender = new Sender();
 sender._socket = { write() {} };
 
+suite.add('ping message', () => sender.ping('Hello', { mask: true }));
+suite.add('ping with no data', () => sender.ping(null, { mask: true }));
 suite.add('frameAndSend, unmasked (200 kB)', () => sender.frameAndSend(0x2, framePacket, true, false));
 suite.add('frameAndSend, masked (200 kB)', () => sender.frameAndSend(0x2, framePacket, true, true));
 suite.on('cycle', (e) => {

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -11,6 +11,12 @@ const ErrorCodes = require('./ErrorCodes');
 const bufferUtil = require('./BufferUtil').BufferUtil;
 const PerMessageDeflate = require('./PerMessageDeflate');
 
+const emptyPing       = new Buffer([0x89, 0x00]);
+const emptyPingMasked = new Buffer([0x89, 0x80, 0x00, 0x00, 0x00, 0x00]);
+
+const emptyPong       = new Buffer([0x8a, 0x00]);
+const emptyPongMasked = new Buffer([0x8a, 0x80, 0x00, 0x00, 0x00, 0x00]);
+
 /**
  * HyBi Sender implementation, Inherits from EventEmitter.
  */
@@ -57,12 +63,11 @@ class Sender extends EventEmitter {
    */
   ping(data, options) {
     var mask = options && options.mask;
-    var self = this;
-    this.messageHandlers.push(function(callback) {
-      self.frameAndSend(0x9, data || '', true, mask);
-      callback();
-    });
-    this.flush();
+    if (data) {
+      this.frameAndSend(0x9, data, true, mask);
+    } else {
+      sendFramedData.call(this, mask ? emptyPingMasked : emptyPing);
+    }
   }
 
   /**
@@ -72,13 +77,11 @@ class Sender extends EventEmitter {
    */
   pong(data, options) {
     var mask = options && options.mask;
-    var self = this;
-    this.messageHandlers.push(function(callback) {
-      self.frameAndSend(0xa, data || '', true, mask);
-      callback();
-    });
-
-    this.flush();
+    if (data) {
+      this.frameAndSend(0xa, data, true, mask);
+    } else {
+      sendFramedData.call(this, mask ? emptyPongMasked : emptyPong);
+    }
   }
 
   /**


### PR DESCRIPTION
Skip messageHandler mechanism for ping/pong packets and use premade empty ping and pong frames.

Improves the included ping benchmark from

```
ping message x 432,273 ops/sec ±1.38% (86 runs sampled)
ping with no data x 706,276 ops/sec ±1.79% (85 runs sampled)
```

to

```
ping message x 662,729 ops/sec ±0.77% (87 runs sampled)
ping with no data x 18,062,074 ops/sec ±1.18% (85 runs sampled)
```