### PR TITLE
Add mocha env to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,13 +18,8 @@
   },
   "env": {
     "es6": true,
-    "node": true
-  },
-  "globals": {
-    "describe": true,
-    "it": true,
-    "before": true,
-    "after": true
+    "node": true,
+    "mocha": true
   },
   "extends": "eslint:recommended"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ansi": "0.3.x",
     "benchmark": "2.1.x",
     "bufferutil": "1.2.x",
-    "eslint": "^2.12.0",
+    "eslint": "3.7.x",
     "expect.js": "0.3.x",
     "istanbul": "^0.4.1",
     "mocha": "2.3.x",


### PR DESCRIPTION
- Use mocha env in eslint config instead of adding each mocha global manually.
- Update eslint to version 3.7.x.