### PR TITLE
Remove redundant check

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -134,7 +134,7 @@ class Sender extends EventEmitter {
     }
 
     if (!Buffer.isBuffer(data)) {
-      if (data && (data.buffer || data) instanceof ArrayBuffer) {
+      if ((data.buffer || data) instanceof ArrayBuffer) {
         data = getBufferFromNative(data);
       } else {
         canModifyData = true;


### PR DESCRIPTION
If `data` is falsy, the function exits [early](https://github.com/websockets/ws/blob/cad49db8a825d99c68a9330be86e0aa590ecf53e/lib/Sender.js#L129-L134).