### PR TITLE
Remove Sender inheritance from EventEmitter

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -6,7 +6,6 @@
 
 'use strict';
 
-const EventEmitter = require('events');
 const ErrorCodes = require('./ErrorCodes');
 const bufferUtil = require('./BufferUtil').BufferUtil;
 const PerMessageDeflate = require('./PerMessageDeflate');
@@ -14,16 +13,15 @@ const PerMessageDeflate = require('./PerMessageDeflate');
 /**
  * HyBi Sender implementation, Inherits from EventEmitter.
  */
-class Sender extends EventEmitter {
+class Sender {
   constructor (socket, extensions) {
-    super();
-
     this._socket = socket;
     this.extensions = extensions || {};
     this.firstFragment = true;
     this.compress = false;
     this.messageHandlers = [];
     this.processing = false;
+    this.onerror = null;
   }
 
   /**
@@ -32,9 +30,8 @@ class Sender extends EventEmitter {
    * @api public
    */
   close (code, data, mask, cb) {
-    if (typeof code !== 'undefined') {
-      if (typeof code !== 'number' ||
-        !ErrorCodes.isValidErrorCode(code)) throw new Error('first argument must be a valid error code number');
+    if (code !== undefined && (typeof code !== 'number' || !ErrorCodes.isValidErrorCode(code))) {
+      throw new Error('first argument must be a valid error code number');
     }
     code = code || 1000;
     var dataBuffer = new Buffer(2 + (data ? Buffer.byteLength(data) : 0));
@@ -148,7 +145,7 @@ class Sender extends EventEmitter {
     this.applyExtensions(data, finalFragment, this.compress, (err, data) => {
       if (err) {
         if (cb) cb(err);
-        else this.emit('error', err);
+        else this.onerror(err);
         return;
       }
       this.frameAndSend(opcode, data, finalFragment, mask, compress, cb);
@@ -167,7 +164,7 @@ class Sender extends EventEmitter {
     if (!data) {
       var buff = [opcode | (finalFragment ? 0x80 : 0), 0 | (maskData ? 0x80 : 0)]
         .concat(maskData ? [0, 0, 0, 0] : []);
-      sendFramedData.call(this, new Buffer(buff), null, cb);
+      sendFramedData(this, new Buffer(buff), null, cb);
       return;
     }
 
@@ -233,7 +230,7 @@ class Sender extends EventEmitter {
         data.copy(outputBuffer, dataOffset);
       }
     }
-    sendFramedData.call(this, outputBuffer, mergeBuffers ? null : data, cb);
+    sendFramedData(this, outputBuffer, mergeBuffers ? null : data, cb);
   }
 
   /**
@@ -307,16 +304,16 @@ function getRandomMask () {
   ]);
 }
 
-function sendFramedData (outputBuffer, data, cb) {
+function sendFramedData (sender, outputBuffer, data, cb) {
   try {
     if (data) {
-      this._socket.write(outputBuffer, 'binary');
-      this._socket.write(data, 'binary', cb);
+      sender._socket.write(outputBuffer, 'binary');
+      sender._socket.write(data, 'binary', cb);
     } else {
-      this._socket.write(outputBuffer, 'binary', cb);
+      sender._socket.write(outputBuffer, 'binary', cb);
     }
   } catch (e) {
     if (cb) cb(e);
-    else this.emit('error', e);
+    else sender.onerror(e);
   }
 }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -850,10 +850,10 @@ function establishConnection (ReceiverClass, SenderClass, socket, upgradeHead) {
 
   // finalize the client
   this._sender = new SenderClass(socket, this.extensions);
-  this._sender.on('error', (error) => {
+  this._sender.onerror = (error) => {
     this.close(1002, '');
     this.emit('error', error);
-  });
+  };
 
   this.readyState = WebSocket.OPEN;
   this.emit('open');
@@ -939,8 +939,7 @@ function cleanupWebsocketResources (error) {
   }
 
   if (this._sender) {
-    this._sender.removeAllListeners();
-    this._sender = null;
+    this._sender = this._sender.onerror = null;
   }
 
   if (this._receiver) {


### PR DESCRIPTION
The only event emitted by `Sender` is `error` so I think it makes sense to not make it inherit from `EventEmitter` and only use an `onerror` function instead.

This is also consistent with the `Receiver` class.