### PR TITLE
Allow socket to be passed through options.

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -581,7 +581,7 @@ function initAsClient (address, protocols, options) {
     checkServerIdentity: null,
     perMessageDeflate: true,
     localAddress: null,
-    socket: null,
+    socket: null
   }, options);
 
   if (options.protocolVersion !== 8 && options.protocolVersion !== 13) {

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -580,7 +580,8 @@ function initAsClient (address, protocols, options) {
     rejectUnauthorized: null,
     checkServerIdentity: null,
     perMessageDeflate: true,
-    localAddress: null
+    localAddress: null,
+    socket: null,
   }, options);
 
   if (options.protocolVersion !== 8 && options.protocolVersion !== 13) {
@@ -625,6 +626,7 @@ function initAsClient (address, protocols, options) {
     port: port,
     host: serverUrl.hostname,
     path: '/',
+    socket: options.socket,
     headers: {
       'Connection': 'Upgrade',
       'Upgrade': 'websocket',


### PR DESCRIPTION
This will allow http proxy support via establishing connection upfront.

This is revived version of PR #514. Example of usage:

``` js
connectViaProxy(endpoint) {
        return new Promise((resolve, reject) => {
            const proxyUrl = url.parse(process.env.http_proxy);
            const endpointUrl = url.parse(endpoint);

            var options = {
                port: parseInt(proxyUrl.port),
                hostname: proxyUrl.hostname,
                method: "CONNECT",
                path: endpointUrl.hostname + ":" + (endpointUrl.port || 443),
            };

            this.logger.debug(`Proxy options ${util.inspect(options)}`);

            var req = http.request(options);

            req.on("connect", (res, socket, head) => {
                console.log("Connected via proxy");
                resolve(socket);
            });

            req.on("error", err => {
                console.error("Error connecting to proxy",  {err});
                reject(err);
            });

            req.end();
}

connectViaProxy(endpoint).then(socket => {
     new WebSocket(endpoint, {socket: socket});
});
```
