### PR TITLE
Remove messageHandler mechanism in Receiver

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -36,10 +36,8 @@ class Receiver {
     this.expectHandler = null;
     this.currentMessage = [];
     this.currentMessageLength = 0;
-    this.messageHandlers = [];
     this.expectData(2, this.processPacket);
     this.dead = false;
-    this.processing = false;
 
     this.onerror = function () {};
     this.ontext = function () {};
@@ -60,12 +58,21 @@ class Receiver {
 
   add (data) {
     if (this.dead) return;
-    if (!this.expectBytes) return;
 
     this.buffers.push(data);
     this.bufferedBytes += data.length;
 
-    while (this.expectBytes && this.expectBytes <= this.bufferedBytes) {
+    this.process();
+  }
+
+  /**
+   * Check buffer for data.
+   *
+   * @api private
+   */
+
+  process () {
+    if (this.expectBytes && this.expectBytes <= this.bufferedBytes) {
       var bufferForHandler = this.readBuffer(this.expectBytes);
       this.expectBytes = 0;
       this.expectHandler(bufferForHandler);
@@ -152,6 +159,8 @@ class Receiver {
     }
     this.expectBytes = length;
     this.expectHandler = handler;
+
+    this.process();
   }
 
   /**
@@ -256,7 +265,6 @@ class Receiver {
     this.bufferedBytes = 0;
     this.currentMessage = [];
     this.currentMessageLength = 0;
-    this.messageHandlers = [];
     this.currentPayloadLength = 0;
   }
 
@@ -284,45 +292,21 @@ class Receiver {
   }
 
   /**
-   * Execute message handler buffers
-   *
-   * @api private
-   */
-
-  flush () {
-    if (this.processing || this.dead) return;
-
-    var handler = this.messageHandlers.shift();
-    if (!handler) return;
-
-    this.processing = true;
-
-    handler(() => {
-      this.processing = false;
-      this.flush();
-    });
-  }
-
-  /**
    * Apply extensions to message
    *
    * @api private
    */
 
-  applyExtensions (messageBuffer, fin, compressed, callback) {
-    if (compressed) {
-      const extension = this.extensions[PerMessageDeflate.extensionName];
-      extension.decompress(messageBuffer, fin, (err, buffer) => {
-        if (this.dead) return;
-        if (err) {
-          callback(err.closeCode === 1009 ? err : new Error('invalid compressed data'));
-          return;
-        }
-        callback(null, buffer);
-      });
-    } else {
-      callback(null, messageBuffer);
-    }
+  applyExtensions (messageBuffer, fin, callback) {
+    const extension = this.extensions[PerMessageDeflate.extensionName];
+    extension.decompress(messageBuffer, fin, (err, buffer) => {
+      if (this.dead) return;
+      if (err) {
+        callback(err.closeCode === 1009 ? err : new Error('invalid compressed data'));
+        return;
+      }
+      callback(null, buffer);
+    });
   }
 
   /**
@@ -345,17 +329,69 @@ class Receiver {
 
     return true;
   }
+
+  /**
+   * Handles compressed data.
+   *
+   * @api private
+   */
+
+  handleDataCompressed (packet) {
+    this.applyExtensions(packet, this.state.lastFragment, (err, buffer) => {
+      if (err) {
+        this.error(err, err.closeCode === 1009 ? 1009 : 1007);
+        return;
+      }
+
+      this.handleData(buffer);
+      this.endPacket();
+    });
+  }
+
+  /**
+   * Handles uncompressed data.
+   *
+   * @api private
+   */
+
+  handleData (buffer) {
+    if (buffer != null) {
+      if (this.maxPayload === 0 || (this.maxPayload > 0 &&
+        (this.currentMessageLength + buffer.length) < this.maxPayload)) {
+        this.currentMessage.push(buffer);
+      } else {
+        this.currentMessage = [];
+        this.currentMessageLength = 0;
+        this.error(new Error(`payload cannot exceed ${this.maxPayload} bytes`), 1009);
+        return;
+      }
+      this.currentMessageLength += buffer.length;
+    }
+    if (this.state.lastFragment) {
+      const messageBuffer = this.currentMessage.length === 1
+        ? this.currentMessage[0]
+        : Buffer.concat(this.currentMessage, this.currentMessageLength);
+      this.currentMessage = [];
+      this.currentMessageLength = 0;
+
+      if (this.state.opcode === 2) {
+        this.onbinary(messageBuffer, {
+          masked: this.state.masked
+        });
+      } else {
+        if (!Validation.isValidUTF8(messageBuffer)) {
+          this.error(new Error('invalid utf8 sequence'), 1007);
+          return;
+        }
+        this.ontext(messageBuffer.toString('utf8'), {
+          masked: this.state.masked
+        });
+      }
+    }
+  }
 }
 
 module.exports = Receiver;
-
-/**
- * Buffer utilities
- */
-
-function clone (obj) {
-  return Object.assign({}, obj);
-}
 
 /**
  * Opcode handlers
@@ -399,46 +435,12 @@ const opcodes = {
     },
     finish: (receiver, mask, data) => {
       const packet = receiver.unmask(mask, data) || new Buffer(0);
-      const state = clone(receiver.state);
-      receiver.messageHandlers.push((callback) => {
-        receiver.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
-          if (err) {
-            receiver.error(err, err.closeCode === 1009 ? 1009 : 1007);
-            return;
-          }
-
-          if (buffer != null) {
-            if (receiver.maxPayload === 0 || (receiver.maxPayload > 0 &&
-              (receiver.currentMessageLength + buffer.length) < receiver.maxPayload)) {
-              receiver.currentMessage.push(buffer);
-            } else {
-              receiver.currentMessage = [];
-              receiver.currentMessageLength = 0;
-              receiver.error(new Error(`payload cannot exceed ${receiver.maxPayload} bytes`), 1009);
-              return;
-            }
-            receiver.currentMessageLength += buffer.length;
-          }
-          if (state.lastFragment) {
-            const messageBuffer = receiver.currentMessage.length === 1
-              ? receiver.currentMessage[0]
-              : Buffer.concat(receiver.currentMessage, receiver.currentMessageLength);
-            receiver.currentMessage = [];
-            receiver.currentMessageLength = 0;
-            if (!Validation.isValidUTF8(messageBuffer)) {
-              receiver.error(new Error('invalid utf8 sequence'), 1007);
-              return;
-            }
-            receiver.ontext(messageBuffer.toString('utf8'), {
-              masked: state.masked,
-              buffer: messageBuffer
-            });
-          }
-          callback();
-        });
-      });
-      receiver.flush();
-      receiver.endPacket();
+      if (receiver.state.compressed) {
+        receiver.handleDataCompressed(packet);
+      } else {
+        receiver.handleData(packet);
+        receiver.endPacket();
+      }
     }
   },
   // binary
@@ -478,42 +480,12 @@ const opcodes = {
     },
     finish: (receiver, mask, data) => {
       const packet = receiver.unmask(mask, data) || new Buffer(0);
-      const state = clone(receiver.state);
-      receiver.messageHandlers.push((callback) => {
-        receiver.applyExtensions(packet, state.lastFragment, state.compressed, (err, buffer) => {
-          if (err) {
-            receiver.error(err, err.closeCode === 1009 ? 1009 : 1007);
-            return;
-          }
-
-          if (buffer != null) {
-            if (receiver.maxPayload === 0 || (receiver.maxPayload > 0 &&
-              (receiver.currentMessageLength + buffer.length) < receiver.maxPayload)) {
-              receiver.currentMessage.push(buffer);
-            } else {
-              receiver.currentMessage = [];
-              receiver.currentMessageLength = 0;
-              receiver.error(new Error(`payload cannot exceed ${receiver.maxPayload} bytes`), 1009);
-              return;
-            }
-            receiver.currentMessageLength += buffer.length;
-          }
-          if (state.lastFragment) {
-            const messageBuffer = receiver.currentMessage.length === 1
-              ? receiver.currentMessage[0]
-              : Buffer.concat(receiver.currentMessage, receiver.currentMessageLength);
-            receiver.currentMessage = [];
-            receiver.currentMessageLength = 0;
-            receiver.onbinary(messageBuffer, {
-              masked: state.masked,
-              buffer: messageBuffer
-            });
-          }
-          callback();
-        });
-      });
-      receiver.flush();
-      receiver.endPacket();
+      if (receiver.state.compressed) {
+        receiver.handleDataCompressed(packet);
+      } else {
+        receiver.handleData(packet);
+        receiver.endPacket();
+      }
     }
   },
   // close
@@ -543,30 +515,26 @@ const opcodes = {
     },
     finish: (receiver, mask, data) => {
       const packet = receiver.unmask(mask, data);
-      const state = clone(receiver.state);
-      receiver.messageHandlers.push(() => {
-        if (packet && packet.length === 1) {
-          receiver.error('close packets with data must be at least two bytes long', 1002);
+      if (packet && packet.length === 1) {
+        receiver.error('close packets with data must be at least two bytes long', 1002);
+        return;
+      }
+      const code = packet && packet.length > 1 ? packet.readUInt16BE(0, true) : 1000;
+      if (!ErrorCodes.isValidErrorCode(code)) {
+        receiver.error('invalid error code', 1002);
+        return;
+      }
+      var message = '';
+      if (packet && packet.length > 2) {
+        const messageBuffer = packet.slice(2);
+        if (!Validation.isValidUTF8(messageBuffer)) {
+          receiver.error('invalid utf8 sequence', 1007);
           return;
         }
-        const code = packet && packet.length > 1 ? packet.readUInt16BE(0, true) : 1000;
-        if (!ErrorCodes.isValidErrorCode(code)) {
-          receiver.error('invalid error code', 1002);
-          return;
-        }
-        var message = '';
-        if (packet && packet.length > 2) {
-          const messageBuffer = packet.slice(2);
-          if (!Validation.isValidUTF8(messageBuffer)) {
-            receiver.error('invalid utf8 sequence', 1007);
-            return;
-          }
-          message = messageBuffer.toString('utf8');
-        }
-        receiver.onclose(code, message, { masked: state.masked });
-        receiver.reset();
-      });
-      receiver.flush();
+        message = messageBuffer.toString('utf8');
+      }
+      receiver.onclose(code, message, { masked: receiver.state.masked });
+      receiver.reset();
     }
   },
   // ping
@@ -596,12 +564,8 @@ const opcodes = {
     },
     finish: (receiver, mask, data) => {
       const packet = receiver.unmask(mask, data);
-      const state = clone(receiver.state);
-      receiver.messageHandlers.push((callback) => {
-        receiver.onping(packet, { masked: state.masked, binary: true });
-        callback();
-      });
-      receiver.flush();
+      const flags = { masked: receiver.state.masked, binary: true };
+      receiver.onping(packet, flags);
       receiver.endPacket();
     }
   },
@@ -632,12 +596,8 @@ const opcodes = {
     },
     finish: (receiver, mask, data) => {
       const packet = receiver.unmask(mask, data);
-      const state = clone(receiver.state);
-      receiver.messageHandlers.push((callback) => {
-        receiver.onpong(packet, { masked: state.masked, binary: true });
-        callback();
-      });
-      receiver.flush();
+      const flags = { masked: receiver.state.masked, binary: true };
+      receiver.onpong(packet, flags);
       receiver.endPacket();
     }
   }

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -11,6 +11,8 @@ const ErrorCodes = require('./ErrorCodes');
 const bufferUtil = require('./BufferUtil').BufferUtil;
 const PerMessageDeflate = require('./PerMessageDeflate');
 
+function noop () {}
+
 /**
  * HyBi Receiver implementation
  */
@@ -39,12 +41,12 @@ class Receiver {
     this.expectData(2, this.processPacket);
     this.dead = false;
 
-    this.onerror = function () {};
-    this.ontext = function () {};
-    this.onbinary = function () {};
-    this.onclose = function () {};
-    this.onping = function () {};
-    this.onpong = function () {};
+    this.onerror = noop;
+    this.ontext = noop;
+    this.onbinary = noop;
+    this.onclose = noop;
+    this.onping = noop;
+    this.onpong = noop;
 
     this.buffers = [];
     this.bufferedBytes = 0;

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -292,24 +292,6 @@ class Receiver {
   }
 
   /**
-   * Apply extensions to message
-   *
-   * @api private
-   */
-
-  applyExtensions (messageBuffer, fin, callback) {
-    const extension = this.extensions[PerMessageDeflate.extensionName];
-    extension.decompress(messageBuffer, fin, (err, buffer) => {
-      if (this.dead) return;
-      if (err) {
-        callback(err.closeCode === 1009 ? err : new Error('invalid compressed data'));
-        return;
-      }
-      callback(null, buffer);
-    });
-  }
-
-  /**
    * Checks payload size, disconnects socket when it exceeds maxPayload
    *
    * @api private
@@ -337,7 +319,9 @@ class Receiver {
    */
 
   handleDataCompressed (packet) {
-    this.applyExtensions(packet, this.state.lastFragment, (err, buffer) => {
+    const extension = this.extensions[PerMessageDeflate.extensionName];
+    extension.decompress(packet, this.state.lastFragment, (err, buffer) => {
+      if (this.dead) return;
       if (err) {
         this.error(err, err.closeCode === 1009 ? 1009 : 1007);
         return;


### PR DESCRIPTION
We don't need this at all - we can pull from the receiver's buffer when we are ready for the next frame.