### PR TITLE
Reset `currentPayloadLength` only on final frame

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -226,9 +226,12 @@ class Receiver {
       // end current fragmented operation
       this.state.activeFragmentedOperation = null;
     }
-    this.currentPayloadLength = 0;
+    if (this.state.activeFragmentedOperation !== null) {
+      this.state.opcode = this.state.activeFragmentedOperation;
+    } else {
+      this.currentPayloadLength = this.state.opcode = 0;
+    }
     this.state.lastFragment = false;
-    this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
     this.state.masked = false;
     this.expectData(2, this.processPacket);
   }

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -220,8 +220,6 @@ class Receiver {
    */
   endPacket () {
     if (this.dead) return;
-    this.expectBytes = 0;
-    this.expectHandler = null;
     if (this.state.lastFragment && this.state.opcode === this.state.activeFragmentedOperation) {
       // end current fragmented operation
       this.state.activeFragmentedOperation = null;

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -22,7 +22,6 @@ class Receiver {
     this.maxPayload = maxPayload | 0;
     this.state = {
       activeFragmentedOperation: null,
-      fragmentedOperation: false,
       lastFragment: false,
       masked: false,
       opcode: 0
@@ -181,7 +180,6 @@ class Receiver {
         return;
       }
       // continuation frame
-      this.state.fragmentedOperation = true;
       this.state.opcode = this.state.activeFragmentedOperation;
       if (!(this.state.opcode === 1 || this.state.opcode === 2)) {
         this.error(new Error('continuation frame cannot follow current opcode'), 1002);
@@ -199,10 +197,7 @@ class Receiver {
       this.state.compressed = compressed;
       this.state.opcode = opcode;
       if (this.state.lastFragment === false) {
-        this.state.fragmentedOperation = true;
         this.state.activeFragmentedOperation = opcode;
-      } else {
-        this.state.fragmentedOperation = false;
       }
     }
     const handler = opcodes[this.state.opcode];
@@ -245,8 +240,7 @@ class Receiver {
       activeFragmentedOperation: null,
       lastFragment: false,
       masked: false,
-      opcode: 0,
-      fragmentedOperation: false
+      opcode: 0
     };
     this.expectBytes = 0;
     this.expectHandler = null;

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -48,7 +48,7 @@ describe('Receiver', function () {
     p.add(Buffer.from('81933483a86801b992524fa1c60959e68a5216e6cb005ba1d5', 'hex'));
   });
 
-  it('can parse a masked text message longer than 125 bytes', function (done) {
+  it('can parse a masked text message longer than 125 B', function (done) {
     const p = new Receiver();
     const msg = 'A'.repeat(200);
 
@@ -80,7 +80,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame, 'hex'));
   });
 
-  it('can parse a fragmented masked text message of 300 bytes', function (done) {
+  it('can parse a fragmented masked text message of 300 B', function (done) {
     const p = new Receiver();
     const msg = 'A'.repeat(300);
 
@@ -129,7 +129,7 @@ describe('Receiver', function () {
     p.add(Buffer.from('8900', 'hex'));
   });
 
-  it('can parse a fragmented masked text message of 300 bytes with a ping in the middle (1/2)', function (done) {
+  it('can parse a fragmented masked text message of 300 B with a ping in the middle (1/2)', function (done) {
     const p = new Receiver();
     const msg = 'A'.repeat(300);
     const pingMessage = 'Hello';
@@ -162,7 +162,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame3, 'hex'));
   });
 
-  it('can parse a fragmented masked text message of 300 bytes with a ping in the middle (2/2)', function (done) {
+  it('can parse a fragmented masked text message of 300 B with a ping in the middle (2/2)', function (done) {
     const p = new Receiver();
     const msg = 'A'.repeat(300);
     var pingMessage = 'Hello';
@@ -201,7 +201,7 @@ describe('Receiver', function () {
     }
   });
 
-  it('can parse a 100 byte long masked binary message', function (done) {
+  it('can parse a 100 B long masked binary message', function (done) {
     const p = new Receiver();
     const msg = crypto.randomBytes(100);
 
@@ -217,7 +217,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame, 'hex'));
   });
 
-  it('can parse a 256 byte long masked binary message', function (done) {
+  it('can parse a 256 B long masked binary message', function (done) {
     const p = new Receiver();
     const msg = crypto.randomBytes(256);
 
@@ -233,7 +233,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame, 'hex'));
   });
 
-  it('can parse a 200kb long masked binary message', function (done) {
+  it('can parse a 200 KiB long masked binary message', function (done) {
     const p = new Receiver();
     const msg = crypto.randomBytes(200 * 1024);
 
@@ -249,7 +249,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame, 'hex'));
   });
 
-  it('can parse a 200kb long unmasked binary message', function (done) {
+  it('can parse a 200 KiB long unmasked binary message', function (done) {
     const p = new Receiver();
     const msg = crypto.randomBytes(200 * 1024);
 
@@ -312,7 +312,44 @@ describe('Receiver', function () {
     });
   });
 
-  it('will raise an error on a 200kb long masked binary message when maxpayload is 20kb', function (done) {
+  it('resets `currentPayloadLength` only on final frame (unfragmented)', function () {
+    const p = new Receiver({}, 10);
+
+    assert.strictEqual(p.currentPayloadLength, 0);
+    p.add(Buffer.from('810548656c6c6f', 'hex'));
+    assert.strictEqual(p.currentPayloadLength, 0);
+  });
+
+  it('resets `currentPayloadLength` only on final frame (fragmented)', function () {
+    const p = new Receiver({}, 10);
+
+    const frame1 = '01024865';
+    const frame2 = '80036c6c6f';
+
+    assert.strictEqual(p.currentPayloadLength, 0);
+    p.add(Buffer.from(frame1, 'hex'));
+    assert.strictEqual(p.currentPayloadLength, 2);
+    p.add(Buffer.from(frame2, 'hex'));
+    assert.strictEqual(p.currentPayloadLength, 0);
+  });
+
+  it('resets `currentPayloadLength` only on final frame (fragmented + ping)', function () {
+    const p = new Receiver({}, 10);
+
+    const frame1 = '01024865';
+    const frame2 = '8900';
+    const frame3 = '80036c6c6f';
+
+    assert.strictEqual(p.currentPayloadLength, 0);
+    p.add(Buffer.from(frame1, 'hex'));
+    assert.strictEqual(p.currentPayloadLength, 2);
+    p.add(Buffer.from(frame2, 'hex'));
+    assert.strictEqual(p.currentPayloadLength, 2);
+    p.add(Buffer.from(frame3, 'hex'));
+    assert.strictEqual(p.currentPayloadLength, 0);
+  });
+
+  it('will raise an error on a 200 KiB long masked binary message when maxpayload is 20 KiB', function (done) {
     const p = new Receiver({}, 20 * 1024);
     const msg = crypto.randomBytes(200 * 1024);
 
@@ -328,7 +365,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame, 'hex'));
   });
 
-  it('will raise an error on a 200kb long unmasked binary message when maxpayload is 20kb', function (done) {
+  it('will raise an error on a 200 KiB long unmasked binary message when maxpayload is 20 KiB', function (done) {
     const p = new Receiver({}, 20 * 1024);
     const msg = crypto.randomBytes(200 * 1024);
 
@@ -343,7 +380,7 @@ describe('Receiver', function () {
     p.add(Buffer.from(frame, 'hex'));
   });
 
-  it('will raise an error on a compressed message that exceeds maxpayload of 3 bytes', function (done) {
+  it('will raise an error on a compressed message that exceeds maxpayload of 3 B', function (done) {
     const perMessageDeflate = new PerMessageDeflate({}, false, 3);
     perMessageDeflate.accept([{}]);
 
@@ -363,7 +400,7 @@ describe('Receiver', function () {
     });
   });
 
-  it('will raise an error on a compressed fragment that exceeds maxpayload of 2 bytes', function (done) {
+  it('will raise an error on a compressed fragment that exceeds maxpayload of 2 B', function (done) {
     const perMessageDeflate = new PerMessageDeflate({}, false, 2);
     perMessageDeflate.accept([{}]);
 


### PR DESCRIPTION
- cc4bd20

  Right now the `currentPayloadLength` counter is reset every time `endPacket` is called. This doesn't work as expected for fragmented messages where `currentPayloadLength` should be the sum of the bytes of each incoming fragment. cc4bd20 fixes the issue by resetting `currentPayloadLength` only on the final frame.

- 9a2a3a1

  `expectData` sets a value to those properties in its body so there is no reason to do it twice.

- b2aae29

  The `fragmentedOperation` flag seems to be unnecessary. It is only assigned and never checked.