### PR TITLE
Rewrite the parser

### DIFF
--- a/bench/parser.benchmark.js
+++ b/bench/parser.benchmark.js
@@ -7,48 +7,55 @@
 'use strict';
 
 const benchmark = require('benchmark');
+const crypto = require('crypto');
 
 const util = require('../test/hybi-util');
 const Receiver = require('../').Receiver;
 
+//
+// Override the `cleanup` method to make the "close message" test work as
+// expected.
+//
+Receiver.prototype.cleanup = function () {
+  this.state = 0;
+  this.start();
+};
+
 function createBinaryPacket (length) {
-  const message = Buffer.alloc(length);
+  const message = crypto.randomBytes(length);
 
-  for (var i = 0; i < length; ++i) message[i] = i % 10;
-
-  return Buffer.from('82' + util.getHybiLengthAsHexString(length, true) + '3483a868' +
-    util.mask(message, '3483a868').toString('hex'), 'hex');
+  return Buffer.from('82' + util.getHybiLengthAsHexString(length, true) +
+    '3483a868' + util.mask(message, '3483a868').toString('hex'), 'hex');
 }
 
 const pingMessage = 'Hello';
 const pingPacket1 = Buffer.from('89' + util.pack(2, 0x80 | pingMessage.length) +
   '3483a868' + util.mask(pingMessage, '3483a868').toString('hex'), 'hex');
+
+const textMessage = 'a'.repeat(20);
+const maskedTextPacket = Buffer.from('81' + util.pack(2, 0x80 | textMessage.length) +
+  '61616161' + util.mask(textMessage, '61616161').toString('hex'), 'hex');
+
 const pingPacket2 = Buffer.from('8900', 'hex');
 const closePacket = Buffer.from('8800', 'hex');
-const maskedTextPacket = Buffer.from('81933483a86801b992524fa1c60959e68a5216e6cb005ba1d5', 'hex');
 const binaryDataPacket = createBinaryPacket(125);
 const binaryDataPacket2 = createBinaryPacket(65535);
 const binaryDataPacket3 = createBinaryPacket(200 * 1024);
 const binaryDataPacket4 = createBinaryPacket(1024 * 1024);
 
-var receiver = new Receiver({}, 1024 * 1024);
+const receiver = new Receiver();
 const suite = new benchmark.Suite();
 
 suite.add('ping message', () => receiver.add(pingPacket1));
 suite.add('ping with no data', () => receiver.add(pingPacket2));
-suite.add('close message', () => {
-  receiver.add(closePacket);
-  receiver.endPacket();
-});
-suite.add('masked text message', () => receiver.add(maskedTextPacket));
+suite.add('close message', () => receiver.add(closePacket));
+suite.add('masked text message (20 bytes)', () => receiver.add(maskedTextPacket));
 suite.add('binary data (125 bytes)', () => receiver.add(binaryDataPacket));
 suite.add('binary data (65535 bytes)', () => receiver.add(binaryDataPacket2));
 suite.add('binary data (200 KiB)', () => receiver.add(binaryDataPacket3));
 suite.add('binary data (1 MiB)', () => receiver.add(binaryDataPacket4));
-suite.on('cycle', (e) => {
-  console.log(e.target.toString());
-  receiver = new Receiver();
-});
+
+suite.on('cycle', (e) => console.log(e.target.toString()));
 
 if (require.main === module) {
   suite.run({ async: true });

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -291,17 +291,14 @@ class Receiver {
    * @private
    */
   getData () {
-    if (this.payloadLength === 0) {
-      if (this.opcode > 0x07) this.controlMessage(EMPTY_BUFFER);
-      else this.dataMessage();
-      return;
+    var data = EMPTY_BUFFER;
+
+    if (this.payloadLength) {
+      if (this.bufferedBytes < this.payloadLength) return;
+
+      data = this.readBuffer(this.payloadLength);
+      if (this.masked) bufferUtil.unmask(data, this.mask);
     }
-
-    if (this.bufferedBytes < this.payloadLength) return;
-
-    const data = this.readBuffer(this.payloadLength);
-
-    if (this.masked) bufferUtil.unmask(data, this.mask);
 
     if (this.opcode > 0x07) {
       this.controlMessage(data);
@@ -453,8 +450,12 @@ class Receiver {
    * @private
    */
   pushFragment (fragment) {
-    if (this.maxPayload < 1 || this.messageLength + fragment.length <= this.maxPayload) {
-      this.messageLength += fragment.length;
+    if (fragment.length === 0) return true;
+
+    const totalLength = this.messageLength + fragment.length;
+
+    if (this.maxPayload < 1 || totalLength <= this.maxPayload) {
+      this.messageLength = totalLength;
       this.fragments.push(fragment);
       return true;
     }

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -6,10 +6,19 @@
 
 'use strict';
 
+const PerMessageDeflate = require('./PerMessageDeflate');
+const bufferUtil = require('./BufferUtil').BufferUtil;
 const Validation = require('./Validation').Validation;
 const ErrorCodes = require('./ErrorCodes');
-const bufferUtil = require('./BufferUtil').BufferUtil;
-const PerMessageDeflate = require('./PerMessageDeflate');
+
+const EMPTY_BUFFER = Buffer.alloc(0);
+
+const START = 0;
+const GET_PAYLOAD_LENGTH_16 = 1;
+const GET_PAYLOAD_LENGTH_64 = 2;
+const GET_MASK = 3;
+const GET_DATA = 4;
+const HANDLE_DATA = 5;
 
 const noop = () => {};
 
@@ -17,70 +26,53 @@ const noop = () => {};
  * HyBi Receiver implementation.
  */
 class Receiver {
+  /**
+   * Creates a Receiver instance.
+   *
+   * @param {Object} extensions An object containing the negotiated extensions
+   * @param {Number} maxPayload The maximum allowed message length
+   */
   constructor (extensions, maxPayload) {
     this.extensions = extensions || {};
     this.maxPayload = maxPayload | 0;
-    this.state = {
-      activeFragmentedOperation: null,
-      lastFragment: false,
-      masked: false,
-      opcode: 0
-    };
-    this.expectBytes = 0;
-    this.expectHandler = null;
-    this.currentMessage = [];
-    this.currentMessageLength = 0;
-    this.currentPayloadLength = 0;
-    this.expectData(2, this.processPacket);
+
+    this.bufferedBytes = 0;
+    this.buffers = [];
+
+    this.compressed = false;
+    this.payloadLength = 0;
+    this.fragmented = 0;
+    this.masked = false;
+    this.fin = false;
+    this.mask = null;
+    this.opcode = 0;
+
+    this.totalPayloadLength = 0;
+    this.messageLength = 0;
+    this.fragments = [];
+
     this.dead = false;
 
-    this.onerror = noop;
-    this.ontext = noop;
     this.onbinary = noop;
     this.onclose = noop;
+    this.onerror = noop;
+    this.ontext = noop;
     this.onping = noop;
     this.onpong = noop;
 
-    this.buffers = [];
-    this.bufferedBytes = 0;
+    this.state = START;
   }
 
   /**
-   * Add new data to the parser.
+   * Consumes bytes from the available buffered data.
    *
-   * @api public
-   */
-  add (data) {
-    if (this.dead) return;
-
-    this.buffers.push(data);
-    this.bufferedBytes += data.length;
-
-    this.process();
-  }
-
-  /**
-   * Check buffer for data.
-   *
-   * @api private
-   */
-  process () {
-    if (this.expectBytes && this.expectBytes <= this.bufferedBytes) {
-      var bufferForHandler = this.readBuffer(this.expectBytes);
-      this.expectBytes = 0;
-      this.expectHandler(bufferForHandler);
-    }
-  }
-
-  /**
-   * Consume bytes from the available buffered data.
-   *
-   * @api private
+   * @param {Number} bytes The number of bytes to consume
+   * @private
    */
   readBuffer (bytes) {
+    var bufoff = 0;
     var dst;
     var l;
-    var bufoff = 0;
 
     if (bytes === this.buffers[0].length) {
       this.bufferedBytes -= bytes;
@@ -117,441 +109,380 @@ class Receiver {
   }
 
   /**
-   * Releases all resources used by the receiver.
+   * Adds new data to the parser.
    *
-   * @api public
+   * @public
    */
-  cleanup () {
-    this.dead = true;
-    this.expectBytes = 0;
-    this.expectHandler = null;
-    this.buffers = [];
-    this.bufferedBytes = 0;
-    this.state = null;
-    this.currentMessage = null;
-    this.onerror = null;
-    this.ontext = null;
-    this.onbinary = null;
-    this.onclose = null;
-    this.onping = null;
-    this.onpong = null;
+  add (data) {
+    if (this.dead) return;
+
+    this.bufferedBytes += data.length;
+    this.buffers.push(data);
+
+    switch (this.state) {
+      case START:
+        this.start();
+        break;
+      case GET_PAYLOAD_LENGTH_16:
+        this.getPayloadLength16();
+        break;
+      case GET_PAYLOAD_LENGTH_64:
+        this.getPayloadLength64();
+        break;
+      case GET_MASK:
+        this.getMask();
+        break;
+      case GET_DATA:
+        this.getData();
+    }
   }
 
   /**
-   * Waits for a certain amount of data bytes to be available, then fires a callback.
+   * Reads the first two bytes of a frame.
    *
-   * @api private
+   * @private
    */
-  expectData (length, handler) {
-    if (length === 0) {
-      handler(null);
+  start () {
+    if (this.bufferedBytes < 2) return;
+
+    const buf = this.readBuffer(2);
+
+    if ((buf[0] & 0x30) !== 0x00) {
+      this.error(new Error('RSV2 and RSV3 must be clear'), 1002);
       return;
     }
-    this.expectBytes = length;
-    this.expectHandler = handler;
 
-    this.process();
-  }
+    const compressed = (buf[0] & 0x40) === 0x40;
 
-  /**
-   * Start processing a new packet.
-   *
-   * @api private
-   */
-  processPacket (data) {
-    if (this.extensions[PerMessageDeflate.extensionName]) {
-      if ((data[0] & 0x30) !== 0) {
-        this.error(new Error('reserved fields (2, 3) must be empty'), 1002);
-        return;
-      }
-    } else {
-      if ((data[0] & 0x70) !== 0) {
-        this.error(new Error('reserved fields must be empty'), 1002);
-        return;
-      }
+    if (compressed && !this.extensions[PerMessageDeflate.extensionName]) {
+      this.error(new Error('RSV1 must be clear'), 1002);
+      return;
     }
-    this.state.lastFragment = (data[0] & 0x80) === 0x80;
-    this.state.masked = (data[1] & 0x80) === 0x80;
-    const compressed = (data[0] & 0x40) === 0x40;
-    const opcode = data[0] & 0xf;
-    if (opcode === 0) {
+
+    this.fin = (buf[0] & 0x80) === 0x80;
+    this.opcode = buf[0] & 0x0f;
+    this.payloadLength = buf[1] & 0x7f;
+
+    if (this.opcode === 0x00) {
       if (compressed) {
-        this.error(new Error('continuation frame cannot have the Per-message Compressed bits'), 1002);
+        this.error(new Error('RSV1 must be clear'), 1002);
         return;
       }
-      // continuation frame
-      this.state.opcode = this.state.activeFragmentedOperation;
-      if (!(this.state.opcode === 1 || this.state.opcode === 2)) {
-        this.error(new Error('continuation frame cannot follow current opcode'), 1002);
+
+      if (!this.fragmented) {
+        this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
+        return;
+      } else {
+        this.opcode = this.fragmented;
+      }
+    } else if (this.opcode === 0x01 || this.opcode === 0x02) {
+      if (this.fragmented) {
+        this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
+        return;
+      }
+
+      this.compressed = compressed;
+    } else if (this.opcode > 0x07 && this.opcode < 0x0b) {
+      if (!this.fin) {
+        this.error(new Error('FIN must be set'), 1002);
+        return;
+      }
+
+      if (compressed) {
+        this.error(new Error('RSV1 must be clear'), 1002);
+        return;
+      }
+
+      if (this.payloadLength > 0x7d) {
+        this.error(new Error('invalid payload length'), 1002);
         return;
       }
     } else {
-      if (opcode < 3 && this.state.activeFragmentedOperation != null) {
-        this.error(new Error('data frames after the initial data frame must have opcode 0'), 1002);
-        return;
-      }
-      if (opcode >= 8 && compressed) {
-        this.error(new Error('control frames cannot have the Per-message Compressed bits'), 1002);
-        return;
-      }
-      this.state.compressed = compressed;
-      this.state.opcode = opcode;
-      if (this.state.lastFragment === false) {
-        this.state.activeFragmentedOperation = opcode;
-      }
+      this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
+      return;
     }
-    const handler = opcodes[this.state.opcode];
-    if (handler === undefined) {
-      this.error(new Error(`no handler for opcode ${this.state.opcode}`), 1002);
+
+    if (!this.fin && !this.fragmented) this.fragmented = this.opcode;
+
+    this.masked = (buf[1] & 0x80) === 0x80;
+
+    if (this.payloadLength === 126) {
+      this.state = GET_PAYLOAD_LENGTH_16;
+      this.getPayloadLength16();
+    } else if (this.payloadLength === 127) {
+      this.state = GET_PAYLOAD_LENGTH_64;
+      this.getPayloadLength64();
     } else {
-      handler.start(this, data);
+      this.haveLength();
     }
   }
 
   /**
-   * Endprocessing a packet.
+   * Gets extended payload length (7+16).
    *
-   * @api private
+   * @private
    */
-  endPacket () {
-    if (this.dead) return;
-    if (this.state.lastFragment && this.state.opcode === this.state.activeFragmentedOperation) {
-      // end current fragmented operation
-      this.state.activeFragmentedOperation = null;
+  getPayloadLength16 () {
+    if (this.bufferedBytes < 2) return;
+
+    this.payloadLength = this.readBuffer(2).readUInt16BE(0, true);
+    this.haveLength();
+  }
+
+  /**
+   * Gets extended payload length (7+64).
+   *
+   * @private
+   */
+  getPayloadLength64 () {
+    if (this.bufferedBytes < 8) return;
+
+    const buf = this.readBuffer(8);
+    const num = buf.readUInt32BE(0, true);
+
+    //
+    // The maximum safe integer in JavaScript is 2^53 - 1. An error is returned
+    // if payload length is greater than this number.
+    //
+    if (num > Math.pow(2, 53 - 32) - 1) {
+      this.error(new Error('max payload size exceeded'), 1009);
+      return;
     }
-    if (this.state.activeFragmentedOperation !== null) {
-      this.state.opcode = this.state.activeFragmentedOperation;
+
+    this.payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4, true);
+    this.haveLength();
+  }
+
+  /**
+   * Payload length has been read.
+   *
+   * @private
+   */
+  haveLength () {
+    if (this.opcode < 0x08 && this.maxPayloadExceeded(this.payloadLength)) {
+      return;
+    }
+
+    if (this.masked) {
+      this.state = GET_MASK;
+      this.getMask();
     } else {
-      this.currentPayloadLength = this.state.opcode = 0;
+      this.state = GET_DATA;
+      this.getData();
     }
-    this.state.lastFragment = false;
-    this.state.masked = false;
-    this.expectData(2, this.processPacket);
   }
 
   /**
-   * Reset the parser state.
+   * Reads mask bytes.
    *
-   * @api private
+   * @private
    */
-  reset () {
-    if (this.dead) return;
-    this.state = {
-      activeFragmentedOperation: null,
-      lastFragment: false,
-      masked: false,
-      opcode: 0
-    };
-    this.expectBytes = 0;
-    this.expectHandler = null;
-    this.buffers = [];
-    this.bufferedBytes = 0;
-    this.currentMessage = [];
-    this.currentMessageLength = 0;
-    this.currentPayloadLength = 0;
+  getMask () {
+    if (this.bufferedBytes < 4) return;
+
+    this.mask = this.readBuffer(4);
+    this.state = GET_DATA;
+    this.getData();
   }
 
   /**
-   * Unmask received data.
+   * Reads data bytes.
    *
-   * @api private
+   * @private
    */
-  unmask (mask, buf) {
-    if (mask != null && buf != null) bufferUtil.unmask(buf, mask);
-    return buf;
-  }
-
-  /**
-   * Handles an error.
-   *
-   * @api private
-   */
-  error (err, protocolErrorCode) {
-    this.reset();
-    this.onerror(err, protocolErrorCode);
-    return this;
-  }
-
-  /**
-   * Checks payload size, disconnects socket when it exceeds `maxPayload`.
-   *
-   * @api private
-   */
-  maxPayloadExceeded (length) {
-    if (this.maxPayload < 1) return false;
-
-    const fullLength = this.currentPayloadLength + length;
-    if (fullLength <= this.maxPayload) {
-      this.currentPayloadLength = fullLength;
-      return false;
+  getData () {
+    if (this.payloadLength === 0) {
+      if (this.opcode > 0x07) this.controlMessage(EMPTY_BUFFER);
+      else this.dataMessage();
+      return;
     }
-    this.error(new Error(`payload cannot exceed ${this.maxPayload} bytes`), 1009);
-    this.cleanup();
 
-    return true;
+    if (this.bufferedBytes < this.payloadLength) return;
+
+    const data = this.readBuffer(this.payloadLength);
+
+    if (this.masked) bufferUtil.unmask(data, this.mask);
+
+    if (this.opcode > 0x07) {
+      this.controlMessage(data);
+    } else if (this.compressed) {
+      this.state = HANDLE_DATA;
+      this.decompress(data);
+    } else if (this.pushFragment(data)) {
+      this.dataMessage();
+    }
   }
 
   /**
-   * Handles compressed data.
+   * Decompresses data.
    *
-   * @api private
+   * @param {Buffer} data Compressed data
+   * @private
    */
-  handleDataCompressed (packet) {
+  decompress (data) {
     const extension = this.extensions[PerMessageDeflate.extensionName];
-    extension.decompress(packet, this.state.lastFragment, (err, buffer) => {
+
+    extension.decompress(data, this.fin, (err, buf) => {
       if (this.dead) return;
+
       if (err) {
         this.error(err, err.closeCode === 1009 ? 1009 : 1007);
         return;
       }
 
-      this.handleData(buffer);
-      this.endPacket();
+      if (this.pushFragment(buf)) this.dataMessage();
     });
   }
 
   /**
-   * Handles uncompressed data.
+   * Handles a data message.
    *
-   * @api private
+   * @private
    */
-  handleData (buffer) {
-    if (buffer != null) {
-      if (this.maxPayload < 1 || this.currentMessageLength + buffer.length <= this.maxPayload) {
-        this.currentMessageLength += buffer.length;
-        this.currentMessage.push(buffer);
-      } else {
-        this.error(new Error(`payload cannot exceed ${this.maxPayload} bytes`), 1009);
-        return;
-      }
-    }
-    if (this.state.lastFragment) {
-      const messageBuffer = this.currentMessage.length === 1
-        ? this.currentMessage[0]
-        : Buffer.concat(this.currentMessage, this.currentMessageLength);
-      this.currentMessage = [];
-      this.currentMessageLength = 0;
+  dataMessage () {
+    if (this.fin) {
+      const buf = this.fragments.length > 1
+        ? Buffer.concat(this.fragments, this.messageLength)
+        : this.fragments.length === 1
+          ? this.fragments[0]
+          : EMPTY_BUFFER;
 
-      if (this.state.opcode === 2) {
-        this.onbinary(messageBuffer, { masked: this.state.masked });
+      this.totalPayloadLength = 0;
+      this.fragments.length = 0;
+      this.messageLength = 0;
+      this.fragmented = 0;
+
+      if (this.opcode === 2) {
+        this.onbinary(buf, { masked: this.masked });
       } else {
-        if (!Validation.isValidUTF8(messageBuffer)) {
+        if (!Validation.isValidUTF8(buf)) {
           this.error(new Error('invalid utf8 sequence'), 1007);
           return;
         }
-        this.ontext(messageBuffer.toString(), { masked: this.state.masked });
+
+        this.ontext(buf.toString(), { masked: this.masked });
       }
     }
+
+    this.state = START;
+    this.start();
+  }
+
+  /**
+   * Handles a control message.
+   *
+   * @param {Buffer} data Data to handle
+   * @private
+   */
+  controlMessage (data) {
+    if (this.opcode === 0x08) {
+      if (data.length === 0) {
+        this.onclose(1000, '', { masked: this.masked });
+        this.cleanup();
+      } else if (data.length === 1) {
+        this.error(new Error('invalid payload length'), 1002);
+      } else {
+        const code = data.readUInt16BE(0, true);
+
+        if (!ErrorCodes.isValidErrorCode(code)) {
+          this.error(new Error(`invalid status code: ${code}`), 1002);
+          return;
+        }
+
+        const buf = data.slice(2);
+
+        if (!Validation.isValidUTF8(buf)) {
+          this.error(new Error('invalid utf8 sequence'), 1007);
+          return;
+        }
+
+        this.onclose(code, buf.toString(), { masked: this.masked });
+        this.cleanup();
+      }
+
+      return;
+    }
+
+    const flags = { masked: this.masked, binary: true };
+
+    if (this.opcode === 0x09) this.onping(data, flags);
+    else this.onpong(data, flags);
+
+    this.state = START;
+    this.start();
+  }
+
+  /**
+   * Handles an error.
+   *
+   * @param {Error} err The error
+   * @param {Number} code Close code
+   * @private
+   */
+  error (err, code) {
+    this.onerror(err, code);
+    this.cleanup();
+  }
+
+  /**
+   * Checks payload size, disconnects socket when it exceeds `maxPayload`.
+   *
+   * @param {Number} length Payload length
+   * @private
+   */
+  maxPayloadExceeded (length) {
+    if (length === 0 || this.maxPayload < 1) return false;
+
+    const fullLength = this.totalPayloadLength + length;
+
+    if (fullLength <= this.maxPayload) {
+      this.totalPayloadLength = fullLength;
+      return false;
+    }
+
+    this.error(new Error('max payload size exceeded'), 1009);
+    return true;
+  }
+
+  /**
+   * Appends a fragment in the fragments array after checking that the sum of
+   * fragment lengths does not exceed `maxPayload`.
+   *
+   * @param {Buffer} fragment The fragment to add
+   * @return {Boolean} `true` if `maxPayload` is not exceeded, else `false`
+   * @private
+   */
+  pushFragment (fragment) {
+    if (this.maxPayload < 1 || this.messageLength + fragment.length <= this.maxPayload) {
+      this.messageLength += fragment.length;
+      this.fragments.push(fragment);
+      return true;
+    }
+
+    this.error(new Error('max payload size exceeded'), 1009);
+    return false;
+  }
+
+  /**
+   * Releases resources used by the receiver.
+   *
+   * @public
+   */
+  cleanup () {
+    this.dead = true;
+
+    this.extensions = null;
+    this.fragments = null;
+    this.buffers = null;
+    this.mask = null;
+
+    this.onbinary = null;
+    this.onclose = null;
+    this.onerror = null;
+    this.ontext = null;
+    this.onping = null;
+    this.onpong = null;
   }
 }
 
 module.exports = Receiver;
-
-//
-// Opcode handlers.
-//
-const opcodes = {
-  // text
-  '1': {
-    start: (receiver, data) => {
-      // decode length
-      const firstLength = data[1] & 0x7f;
-      if (firstLength < 126) {
-        if (receiver.maxPayloadExceeded(firstLength)) return;
-        opcodes['1'].getData(receiver, firstLength);
-      } else if (firstLength === 126) {
-        receiver.expectData(2, (data) => {
-          const length = data.readUInt16BE(0, true);
-          if (receiver.maxPayloadExceeded(length)) return;
-          opcodes['1'].getData(receiver, length);
-        });
-      } else if (firstLength === 127) {
-        receiver.expectData(8, (data) => {
-          if (data.readUInt32BE(0, true) !== 0) {
-            receiver.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
-            return;
-          }
-          const length = data.readUInt32BE(4, true);
-          if (receiver.maxPayloadExceeded(length)) return;
-          opcodes['1'].getData(receiver, length);
-        });
-      }
-    },
-    getData: (receiver, length) => {
-      if (receiver.state.masked) {
-        receiver.expectData(4, (mask) => {
-          receiver.expectData(length, (data) => opcodes['1'].finish(receiver, mask, data));
-        });
-      } else {
-        receiver.expectData(length, (data) => opcodes['1'].finish(receiver, null, data));
-      }
-    },
-    finish: (receiver, mask, data) => {
-      const packet = receiver.unmask(mask, data) || new Buffer(0);
-      if (receiver.state.compressed) {
-        receiver.handleDataCompressed(packet);
-      } else {
-        receiver.handleData(packet);
-        receiver.endPacket();
-      }
-    }
-  },
-  // binary
-  '2': {
-    start: (receiver, data) => {
-      // decode length
-      const firstLength = data[1] & 0x7f;
-      if (firstLength < 126) {
-        if (receiver.maxPayloadExceeded(firstLength)) return;
-        opcodes['2'].getData(receiver, firstLength);
-      } else if (firstLength === 126) {
-        receiver.expectData(2, (data) => {
-          const length = data.readUInt16BE(0, true);
-          if (receiver.maxPayloadExceeded(length)) return;
-          opcodes['2'].getData(receiver, length);
-        });
-      } else if (firstLength === 127) {
-        receiver.expectData(8, (data) => {
-          if (data.readUInt32BE(0, true) !== 0) {
-            receiver.error(new Error('packets with length spanning more than 32 bit is currently not supported'), 1008);
-            return;
-          }
-          const length = data.readUInt32BE(4, true);
-          if (receiver.maxPayloadExceeded(length)) return;
-          opcodes['2'].getData(receiver, length);
-        });
-      }
-    },
-    getData: (receiver, length) => {
-      if (receiver.state.masked) {
-        receiver.expectData(4, (mask) => {
-          receiver.expectData(length, (data) => opcodes['2'].finish(receiver, mask, data));
-        });
-      } else {
-        receiver.expectData(length, (data) => opcodes['2'].finish(receiver, null, data));
-      }
-    },
-    finish: (receiver, mask, data) => {
-      const packet = receiver.unmask(mask, data) || new Buffer(0);
-      if (receiver.state.compressed) {
-        receiver.handleDataCompressed(packet);
-      } else {
-        receiver.handleData(packet);
-        receiver.endPacket();
-      }
-    }
-  },
-  // close
-  '8': {
-    start: (receiver, data) => {
-      if (receiver.state.lastFragment === false) {
-        receiver.error('fragmented close is not supported', 1002);
-        return;
-      }
-
-      // decode length
-      const firstLength = data[1] & 0x7f;
-      if (firstLength < 126) {
-        opcodes['8'].getData(receiver, firstLength);
-      } else {
-        receiver.error('control frames cannot have more than 125 bytes of data', 1002);
-      }
-    },
-    getData: (receiver, length) => {
-      if (receiver.state.masked) {
-        receiver.expectData(4, (mask) => {
-          receiver.expectData(length, (data) => opcodes['8'].finish(receiver, mask, data));
-        });
-      } else {
-        receiver.expectData(length, (data) => opcodes['8'].finish(receiver, null, data));
-      }
-    },
-    finish: (receiver, mask, data) => {
-      const packet = receiver.unmask(mask, data);
-      if (packet && packet.length === 1) {
-        receiver.error('close packets with data must be at least two bytes long', 1002);
-        return;
-      }
-      const code = packet && packet.length > 1 ? packet.readUInt16BE(0, true) : 1000;
-      if (!ErrorCodes.isValidErrorCode(code)) {
-        receiver.error('invalid error code', 1002);
-        return;
-      }
-      var message = '';
-      if (packet && packet.length > 2) {
-        const messageBuffer = packet.slice(2);
-        if (!Validation.isValidUTF8(messageBuffer)) {
-          receiver.error('invalid utf8 sequence', 1007);
-          return;
-        }
-        message = messageBuffer.toString();
-      }
-      receiver.onclose(code, message, { masked: receiver.state.masked });
-      receiver.reset();
-    }
-  },
-  // ping
-  '9': {
-    start: (receiver, data) => {
-      if (receiver.state.lastFragment === false) {
-        receiver.error('fragmented ping is not supported', 1002);
-        return;
-      }
-
-      // decode length
-      const firstLength = data[1] & 0x7f;
-      if (firstLength < 126) {
-        opcodes['9'].getData(receiver, firstLength);
-      } else {
-        receiver.error('control frames cannot have more than 125 bytes of data', 1002);
-      }
-    },
-    getData: (receiver, length) => {
-      if (receiver.state.masked) {
-        receiver.expectData(4, (mask) => {
-          receiver.expectData(length, (data) => opcodes['9'].finish(receiver, mask, data));
-        });
-      } else {
-        receiver.expectData(length, (data) => opcodes['9'].finish(receiver, null, data));
-      }
-    },
-    finish: (receiver, mask, data) => {
-      const packet = receiver.unmask(mask, data);
-      const flags = { masked: receiver.state.masked, binary: true };
-      receiver.onping(packet, flags);
-      receiver.endPacket();
-    }
-  },
-  // pong
-  '10': {
-    start: (receiver, data) => {
-      if (receiver.state.lastFragment === false) {
-        receiver.error('fragmented pong is not supported', 1002);
-        return;
-      }
-
-      // decode length
-      const firstLength = data[1] & 0x7f;
-      if (firstLength < 126) {
-        opcodes['10'].getData(receiver, firstLength);
-      } else {
-        receiver.error('control frames cannot have more than 125 bytes of data', 1002);
-      }
-    },
-    getData: (receiver, length) => {
-      if (receiver.state.masked) {
-        receiver.expectData(4, (mask) => {
-          receiver.expectData(length, (data) => opcodes['10'].finish(receiver, mask, data));
-        });
-      } else {
-        receiver.expectData(length, (data) => opcodes['10'].finish(receiver, null, data));
-      }
-    },
-    finish: (receiver, mask, data) => {
-      const packet = receiver.unmask(mask, data);
-      const flags = { masked: receiver.state.masked, binary: true };
-      receiver.onpong(packet, flags);
-      receiver.endPacket();
-    }
-  }
-};

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -122,7 +122,7 @@ describe('Receiver', function () {
     const p = new Receiver();
 
     p.onping = function (data) {
-      assert.strictEqual(data, null);
+      assert.ok(data.equals(Buffer.alloc(0)));
       done();
     };
 
@@ -312,41 +312,41 @@ describe('Receiver', function () {
     });
   });
 
-  it('resets `currentPayloadLength` only on final frame (unfragmented)', function () {
+  it('resets `totalPayloadLength` only on final frame (unfragmented)', function () {
     const p = new Receiver({}, 10);
 
-    assert.strictEqual(p.currentPayloadLength, 0);
+    assert.strictEqual(p.totalPayloadLength, 0);
     p.add(Buffer.from('810548656c6c6f', 'hex'));
-    assert.strictEqual(p.currentPayloadLength, 0);
+    assert.strictEqual(p.totalPayloadLength, 0);
   });
 
-  it('resets `currentPayloadLength` only on final frame (fragmented)', function () {
+  it('resets `totalPayloadLength` only on final frame (fragmented)', function () {
     const p = new Receiver({}, 10);
 
     const frame1 = '01024865';
     const frame2 = '80036c6c6f';
 
-    assert.strictEqual(p.currentPayloadLength, 0);
+    assert.strictEqual(p.totalPayloadLength, 0);
     p.add(Buffer.from(frame1, 'hex'));
-    assert.strictEqual(p.currentPayloadLength, 2);
+    assert.strictEqual(p.totalPayloadLength, 2);
     p.add(Buffer.from(frame2, 'hex'));
-    assert.strictEqual(p.currentPayloadLength, 0);
+    assert.strictEqual(p.totalPayloadLength, 0);
   });
 
-  it('resets `currentPayloadLength` only on final frame (fragmented + ping)', function () {
+  it('resets `totalPayloadLength` only on final frame (fragmented + ping)', function () {
     const p = new Receiver({}, 10);
 
     const frame1 = '01024865';
     const frame2 = '8900';
     const frame3 = '80036c6c6f';
 
-    assert.strictEqual(p.currentPayloadLength, 0);
+    assert.strictEqual(p.totalPayloadLength, 0);
     p.add(Buffer.from(frame1, 'hex'));
-    assert.strictEqual(p.currentPayloadLength, 2);
+    assert.strictEqual(p.totalPayloadLength, 2);
     p.add(Buffer.from(frame2, 'hex'));
-    assert.strictEqual(p.currentPayloadLength, 2);
+    assert.strictEqual(p.totalPayloadLength, 2);
     p.add(Buffer.from(frame3, 'hex'));
-    assert.strictEqual(p.currentPayloadLength, 0);
+    assert.strictEqual(p.totalPayloadLength, 0);
   });
 
   it('will raise an error on a 200 KiB long masked binary message when maxpayload is 20 KiB', function (done) {


### PR DESCRIPTION
This is a rewrite of the parser. The main advantages are:

- No callbacks.
- No duplicated code.
- Faster for small frames.
- Easier to read and understand (I hope).
- Better error messages.

**Benchmarks**

before (master branch with the same changes applied to `parser.benchmark.js`)

```
ping message x 635,655 ops/sec ±1.15% (84 runs sampled)
ping with no data x 3,950,735 ops/sec ±1.60% (84 runs sampled)
close message x 3,851,346 ops/sec ±1.37% (85 runs sampled)
masked text message (20 bytes) x 428,833 ops/sec ±1.54% (85 runs sampled)
binary data (125 bytes) x 536,784 ops/sec ±1.56% (82 runs sampled)
binary data (65535 bytes) x 48,578 ops/sec ±1.07% (84 runs sampled)
binary data (200 KiB) x 6,213 ops/sec ±0.83% (86 runs sampled)
binary data (1 MiB) x 1,238 ops/sec ±0.72% (85 runs sampled)
```

after

```
ping message x 952,050 ops/sec ±0.68% (86 runs sampled)
ping with no data x 12,193,515 ops/sec ±1.45% (82 runs sampled)
close message x 11,780,404 ops/sec ±0.79% (82 runs sampled)
masked text message (20 bytes) x 540,285 ops/sec ±2.23% (82 runs sampled)
binary data (125 bytes) x 744,835 ops/sec ±2.47% (82 runs sampled)
binary data (65535 bytes) x 50,498 ops/sec ±1.21% (84 runs sampled)
binary data (200 KiB) x 6,286 ops/sec ±0.70% (83 runs sampled)
binary data (1 MiB) x 1,235 ops/sec ±0.75% (84 runs sampled)
```

If anyone would like to review this, it would be greatly appreciated. I know that it's not easy given the amount of changes.

Tests pass and benchmarks run but it is totally possible that I missed something or introduced some bugs. I plan to run the Autobahn test suite on both master and this branch and compare the results.