### PR TITLE
Prevent data corruption when sending ping/pong messages

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -64,6 +64,7 @@ class Sender {
    * @api public
    */
   ping (data, options) {
+    if (data) data = toBuffer(data);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.enqueue([this.doPing, [data, options]]);
     } else {
@@ -77,8 +78,7 @@ class Sender {
    * @api private
    */
   doPing (data, options) {
-    var mask = options && options.mask;
-    this.frameAndSend(0x9, data ? Buffer.from(data.toString()) : null, true, mask);
+    this.frameAndSend(0x9, data, true, options.mask);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.messageHandlerCallback();
     }
@@ -90,6 +90,7 @@ class Sender {
    * @api public
    */
   pong (data, options) {
+    if (data) data = toBuffer(data);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.enqueue([this.doPong, [data, options]]);
     } else {
@@ -103,8 +104,7 @@ class Sender {
    * @api private
    */
   doPong (data, options) {
-    var mask = options && options.mask;
-    this.frameAndSend(0xa, data ? Buffer.from(data.toString()) : null, true, mask);
+    this.frameAndSend(0xa, data, true, options.mask);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.messageHandlerCallback();
     }
@@ -120,6 +120,7 @@ class Sender {
     var mask = options && options.mask;
     var compress = options && options.compress;
     var opcode = options && options.binary ? 2 : 1;
+
     if (this.firstFragment === false) {
       opcode = 0;
       compress = false;
@@ -127,18 +128,9 @@ class Sender {
       this.firstFragment = false;
       this.compress = compress;
     }
-    if (finalFragment) this.firstFragment = true;
 
-    if (data && !Buffer.isBuffer(data)) {
-      if ((data.buffer || data) instanceof ArrayBuffer) {
-        data = getBufferFromNative(data);
-      } else {
-        if (typeof data === 'number') {
-          data = data.toString();
-        }
-        data = Buffer.from(data);
-      }
-    }
+    if (finalFragment) this.firstFragment = true;
+    if (data) data = toBuffer(data);
 
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.enqueue([this.sendCompressed, [opcode, data, finalFragment, mask, compress, cb]]);
@@ -283,11 +275,29 @@ class Sender {
 
 module.exports = Sender;
 
-function getBufferFromNative (data) {
-  // data is either an ArrayBuffer or ArrayBufferView.
-  return !data.buffer
-    ? new Buffer(data)
-    : new Buffer(data.buffer).slice(data.byteOffset, data.byteOffset + data.byteLength);
+/**
+ * Converts `data` into a buffer.
+ *
+ * @param {*} data Data to convert
+ * @return {Buffer} Converted data
+ * @private
+ */
+function toBuffer (data) {
+  if (Buffer.isBuffer(data)) return data;
+
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+
+  if (ArrayBuffer.isView(data)) {
+    const buf = Buffer.from(data.buffer);
+
+    if (data.byteLength !== data.buffer.byteLength) {
+      return buf.slice(data.byteOffset, data.byteOffset + data.byteLength);
+    }
+
+    return buf;
+  }
+
+  return Buffer.from(typeof data === 'number' ? data.toString() : data);
 }
 
 function getRandomMask () {


### PR DESCRIPTION
6b3904b introduced a [bug](https://github.com/websockets/ws/commit/6b3904b42dbd48aed2e0d8d599787cca04f05384#commitcomment-19666069) where a buffer sent with a ping/pong message is first converted to a string and then back to a buffer, changing the original data.

This patch should fix the issue.