### PR TITLE
Remove path registry

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -67,15 +67,6 @@ function WebSocketServer (options, callback) {
     this._closeServer = () => this._server && this._server.close();
   } else if (options.server) {
     this._server = options.server;
-    if (options.path) {
-      // take note of the path, to avoid collisions when multiple websocket servers are
-      // listening on the same http server
-      if (this._server._webSocketPaths && options.server._webSocketPaths[options.path]) {
-        throw new Error('two instances of WebSocketServer cannot listen on the same http server path');
-      }
-      if (!this._server._webSocketPaths) this._server._webSocketPaths = {};
-      this._server._webSocketPaths[options.path] = 1;
-    }
   }
 
   if (this._server) {
@@ -124,14 +115,6 @@ WebSocketServer.prototype.close = function (callback) {
       } catch (e) {
         error = e;
       }
-    }
-  }
-
-  // remove path descriptor, if any
-  if (this.path && this._server._webSocketPaths) {
-    delete this._server._webSocketPaths[this.path];
-    if (Object.keys(this._server._webSocketPaths).length === 0) {
-      delete this._server._webSocketPaths;
     }
   }
 

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -109,48 +109,6 @@ describe('WebSocketServer', function () {
       });
     });
 
-    it('can have two different instances listening on the same http server with two different paths', function (done) {
-      const server = http.createServer();
-
-      server.listen(++port, () => {
-        const wss1 = new WebSocketServer({ server, path: '/wss1' });
-        const wss2 = new WebSocketServer({ server, path: '/wss2' });
-        let doneCount = 0;
-
-        wss1.on('connection', (client) => {
-          wss1.close();
-          if (++doneCount === 2) {
-            server.close(done);
-          }
-        });
-
-        wss2.on('connection', (client) => {
-          wss2.close();
-          if (++doneCount === 2) {
-            server.close(done);
-          }
-        });
-
-        /* eslint-disable no-unused-vars */
-        const ws1 = new WebSocket(`ws://localhost:${port}/wss1`);
-        const ws2 = new WebSocket(`ws://localhost:${port}/wss2?foo=1`);
-        /* eslint-enable no-unused-vars */
-      });
-    });
-
-    it('cannot have two different instances listening on the same http server with the same path', function (done) {
-      const server = http.createServer();
-      const wss1 = new WebSocketServer({ server: server, path: '/wss1' });
-
-      try {
-        // eslint-disable-next-line no-unused-vars
-        const wss2 = new WebSocketServer({ server: server, path: '/wss1' });
-      } catch (e) {
-        wss1.close();
-        done();
-      }
-    });
-
     it('will not crash when it receives an unhandled opcode', function (done) {
       const wss = new WebSocketServer({ port: 8080 });
 
@@ -226,27 +184,6 @@ describe('WebSocketServer', function () {
         assert.strictEqual(server.listeners('upgrade').length, 0);
         assert.strictEqual(server.listeners('error').length, 0);
 
-        server.close(done);
-      });
-    });
-
-    it('cleans up websocket data on a precreated server', function (done) {
-      const server = http.createServer();
-
-      server.listen(++port, () => {
-        const wss1 = new WebSocketServer({ server, path: '/wss1' });
-        const wss2 = new WebSocketServer({ server, path: '/wss2' });
-
-        assert.strictEqual(typeof server._webSocketPaths, 'object');
-        assert.strictEqual(Object.keys(server._webSocketPaths).length, 2);
-
-        wss1.close();
-
-        assert.strictEqual(Object.keys(server._webSocketPaths).length, 1);
-
-        wss2.close();
-
-        assert.strictEqual(typeof server._webSocketPaths, 'undefined');
         server.close(done);
       });
     });


### PR DESCRIPTION
The `_webSocketPaths` object is added to the underlying HTTP sever of a `WebSocketServer` when the `path` option is specified. It is used to store the path of each `WebSocketServer` using the same underlying HTTP server in order to avoid path conflicts.

```js
const server = http.createServer();
const wss1 = new WebSocket.Server({ server, path: '/foo' });
const wss2 = new WebSocket.Server({ server, path: '/bar' });
```

This allows to use multiple WebSocket severs (one per path) and only one shared HTTP server.

The problem here is that each `WebSocketServer` adds a new listener for the `upgrade` event on the HTTP server and when that event is emitted, [`handleUpgrade`](https://github.com/websockets/ws/blob/ebf86b58f1fb1e96ab96ebf95782bad7bc5ab8ca/lib/WebSocketServer.js#L164-L180) is called on all servers.

Now, using the above example, a connection to `ws://example.com/foo` would first be established on `wss1` and then closed by `wss2` as they both write on the same socket.

Originally this worked because path validation did not close the connection on [mismatch](https://github.com/websockets/ws/blob/0cfa5cc94d50bebd6f85b78ec1094dd9a7a17d62/lib/WebSocketServer.js#L171).

Passing the same HTTP server in the constructor when instantiating multiple WebSocket servers is not a good idea imo and should be avoided. I can't think of a use case where it makes sense.

In order to have multiple WebSocket servers and only one shared HTTP server, a developer could use something like this:

```js
const wss1 = new WebSocket.Server({ noServer: true });
const wss2 = new WebSocket.Server({ noServer: true });
const server = http.createServer();

server.on('upgrade', (request, socket, head) => {
  const pathname = url.parse(request.url).pathname;

  if (pathname === '/foo') {
    wss1.handleUpgrade(request, socket, head, (ws) => {
      wss1.emit('connection', ws);
    });
  } else if (pathname === '/bar') {
    wss2.handleUpgrade(request, socket, head, (ws) => {
      wss2.emit('connection', ws);
    });
  } else {
    socket.destroy();
  }
});
```