### PR TITLE
Avoid copying buffers when possible

### DIFF
--- a/bench/sender.benchmark.js
+++ b/bench/sender.benchmark.js
@@ -7,25 +7,32 @@
 'use strict';
 
 const benchmark = require('benchmark');
+const crypto = require('crypto');
 
 const Sender = require('../').Sender;
 
-const data1 = Buffer.alloc(200 * 1024, 99);
-const data2 = Buffer.alloc(1024 * 1024, 99);
+const data1 = crypto.randomBytes(64);
+const data2 = crypto.randomBytes(16 * 1024);
+const data3 = crypto.randomBytes(64 * 1024);
+const data4 = crypto.randomBytes(200 * 1024);
+const data5 = crypto.randomBytes(1024 * 1024);
 
 const suite = new benchmark.Suite();
 var sender = new Sender();
 sender._socket = { write () {} };
 
-suite.add('frameAndSend, unmasked (200 KiB)', () => sender.frameAndSend(0x2, data1, true, false));
-suite.add('frameAndSend, masked (200 KiB)', () => sender.frameAndSend(0x2, data1, true, true));
-suite.add('frameAndSend, unmasked (1 MiB)', () => sender.frameAndSend(0x2, data2, true, false));
-suite.add('frameAndSend, masked (1 MiB)', () => sender.frameAndSend(0x2, data2, true, true));
-suite.on('cycle', (e) => {
-  console.log(e.target.toString());
-  sender = new Sender();
-  sender._socket = { write () {} };
-});
+suite.add('frameAndSend, unmasked (64 B)', () => sender.frameAndSend(0x2, data1, false, true, false));
+suite.add('frameAndSend, masked (64 B)', () => sender.frameAndSend(0x2, data1, true, true, true));
+suite.add('frameAndSend, unmasked (16 KiB)', () => sender.frameAndSend(0x2, data2, false, true, false));
+suite.add('frameAndSend, masked (16 KiB)', () => sender.frameAndSend(0x2, data2, true, true, true));
+suite.add('frameAndSend, unmasked (64 KiB)', () => sender.frameAndSend(0x2, data3, false, true, false));
+suite.add('frameAndSend, masked (64 KiB)', () => sender.frameAndSend(0x2, data3, true, true, true));
+suite.add('frameAndSend, unmasked (200 KiB)', () => sender.frameAndSend(0x2, data4, false, true, false));
+suite.add('frameAndSend, masked (200 KiB)', () => sender.frameAndSend(0x2, data4, true, true, true));
+suite.add('frameAndSend, unmasked (1 MiB)', () => sender.frameAndSend(0x2, data5, false, true, false));
+suite.add('frameAndSend, masked (1 MiB)', () => sender.frameAndSend(0x2, data5, true, true, true));
+
+suite.on('cycle', (e) => console.log(e.target.toString()));
 
 if (require.main === module) {
   suite.run({ async: true });

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -43,15 +43,16 @@ class Sender {
     if (code !== undefined && (typeof code !== 'number' || !ErrorCodes.isValidErrorCode(code))) {
       throw new Error('first argument must be a valid error code number');
     }
-    code = code || 1000;
-    var dataBuffer = new Buffer(2 + (data ? Buffer.byteLength(data) : 0));
-    dataBuffer.writeUInt16BE(code, 0, true);
-    if (dataBuffer.length > 2) dataBuffer.write(data, 2);
+
+    const buf = Buffer.allocUnsafe(2 + (data ? Buffer.byteLength(data) : 0));
+
+    buf.writeUInt16BE(code || 1000, 0, true);
+    if (buf.length > 2) buf.write(data, 2);
 
     if (this.extensions[PerMessageDeflate.extensionName]) {
-      this.enqueue([this.doClose, [dataBuffer, mask, cb]]);
+      this.enqueue([this.doClose, [buf, mask, cb]]);
     } else {
-      this.doClose(dataBuffer, mask, cb);
+      this.doClose(buf, mask, cb);
     }
   }
 
@@ -64,7 +65,7 @@ class Sender {
    * @private
    */
   doClose (data, mask, cb) {
-    this.frameAndSend(0x8, data, true, mask);
+    this.frameAndSend(0x08, data, false, true, mask, false);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.messageHandlerCallback();
     }
@@ -80,24 +81,22 @@ class Sender {
    * @public
    */
   ping (data, options) {
-    if (data) data = toBuffer(data);
     if (this.extensions[PerMessageDeflate.extensionName]) {
-      this.enqueue([this.doPing, [data, options]]);
+      this.enqueue([this.doPing, [data, options.mask]]);
     } else {
-      this.doPing(data, options);
+      this.doPing(data, options.mask);
     }
   }
 
   /**
    * Frames and sends a ping message.
    *
-   * @param {Buffer} data The message to send
-   * @param {Object} options Options object
-   * @param {Boolean} options.mask Specifies whether or not to mask `data`
+   * @param {*} data The message to send
+   * @param {Boolean} mask Specifies whether or not to mask `data`
    * @private
    */
-  doPing (data, options) {
-    this.frameAndSend(0x9, data, true, options.mask);
+  doPing (data, mask) {
+    this.frameAndSend(0x09, data, true, true, mask, false);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.messageHandlerCallback();
     }
@@ -112,24 +111,22 @@ class Sender {
    * @public
    */
   pong (data, options) {
-    if (data) data = toBuffer(data);
     if (this.extensions[PerMessageDeflate.extensionName]) {
-      this.enqueue([this.doPong, [data, options]]);
+      this.enqueue([this.doPong, [data, options.mask]]);
     } else {
-      this.doPong(data, options);
+      this.doPong(data, options.mask);
     }
   }
 
   /**
    * Frames and sends a pong message.
    *
-   * @param {Buffer} data The message to send
-   * @param {Object} options Options object
-   * @param {Boolean} options.mask Specifies whether or not to mask `data`
+   * @param {*} data The message to send
+   * @param {Boolean} mask Specifies whether or not to mask `data`
    * @private
    */
-  doPong (data, options) {
-    this.frameAndSend(0xa, data, true, options.mask);
+  doPong (data, mask) {
+    this.frameAndSend(0x0a, data, true, true, mask, false);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.messageHandlerCallback();
     }
@@ -140,10 +137,10 @@ class Sender {
    *
    * @param {*} data The message to send
    * @param {Object} options Options object
-   * @param {Boolean} options.binary Specifies whether `data` is binary or text
    * @param {Boolean} options.compress Specifies whether or not to compress `data`
-   * @param {Boolean} options.mask Specifies whether or not to mask `data`
+   * @param {Boolean} options.binary Specifies whether `data` is binary or text
    * @param {Boolean} options.fin Specifies whether the fragment is the last one
+   * @param {Boolean} options.mask Specifies whether or not to mask `data`
    * @param {Function} cb Callback
    * @public
    */
@@ -151,8 +148,6 @@ class Sender {
     const pmd = this.extensions[PerMessageDeflate.extensionName];
     var opcode = options.binary ? 2 : 1;
     var compress = options.compress;
-
-    if (data) data = toBuffer(data);
 
     if (this.firstFragment) {
       this.firstFragment = false;
@@ -169,7 +164,7 @@ class Sender {
       const args = [opcode, data, options.fin, options.mask, compress, cb];
       this.enqueue([this.sendCompressed, args]);
     } else {
-      this.frameAndSend(opcode, data, options.fin, options.mask, false, cb);
+      this.frameAndSend(opcode, data, true, options.fin, options.mask, false, cb);
     }
   }
 
@@ -177,26 +172,29 @@ class Sender {
    * Compresses, frames and sends a data message.
    *
    * @param {Number} opcode The opcode
-   * @param {Buffer} data The message to send
-   * @param {Boolean} finalFragment Specifies whether or not to set the FIN bit
+   * @param {*} data The message to send
+   * @param {Boolean} fin Specifies whether or not to set the FIN bit
    * @param {Boolean} mask Specifies whether or not to mask `data`
-   * @param {Boolean} compress Specifies whether or not to set the RSV1 bit
+   * @param {Boolean} rsv1 Specifies whether or not to set the RSV1 bit
    * @param {Function} cb Callback
    * @private
    */
-  sendCompressed (opcode, data, finalFragment, mask, compress, cb) {
+  sendCompressed (opcode, data, fin, mask, rsv1, cb) {
     if (!this.compress) {
-      this.frameAndSend(opcode, data, finalFragment, mask, false, cb);
+      this.frameAndSend(opcode, data, true, fin, mask, false, cb);
       this.messageHandlerCallback();
       return;
     }
-    this.extensions[PerMessageDeflate.extensionName].compress(data, finalFragment, (err, data) => {
+
+    if (data && !Buffer.isBuffer(data)) data = toBuffer(data);
+    this.extensions[PerMessageDeflate.extensionName].compress(data, fin, (err, buf) => {
       if (err) {
         if (cb) cb(err);
         else this.onerror(err);
         return;
       }
-      this.frameAndSend(opcode, data, finalFragment, mask, compress, cb);
+
+      this.frameAndSend(opcode, buf, false, fin, mask, rsv1, cb);
       this.messageHandlerCallback();
     });
   }
@@ -205,67 +203,84 @@ class Sender {
    * Frames and sends a piece of data according to the HyBi WebSocket protocol.
    *
    * @param {Number} opcode The opcode
-   * @param {Buffer} data The data to send
-   * @param {Boolean} finalFragment Specifies whether or not to set the FIN bit
+   * @param {*} data The data to send
+   * @param {Boolean} readOnly Specifies whether `data` can be modified
+   * @param {Boolean} fin Specifies whether or not to set the FIN bit
    * @param {Boolean} maskData Specifies whether or not to mask `data`
-   * @param {Boolean} compressed Specifies whether or not to set the RSV1 bit
+   * @param {Boolean} rsv1 Specifies whether or not to set the RSV1 bit
    * @param {Function} cb Callback
    * @private
    */
-  frameAndSend (opcode, data, finalFragment, maskData, compressed, cb) {
+  frameAndSend (opcode, data, readOnly, fin, maskData, rsv1, cb) {
     if (!data) {
-      var buff = [opcode | (finalFragment ? 0x80 : 0), 0 | (maskData ? 0x80 : 0)]
-        .concat(maskData ? [0, 0, 0, 0] : []);
-      sendFramedData(this, new Buffer(buff), null, cb);
+      const bytes = [opcode, 0];
+
+      if (fin) bytes[0] |= 0x80;
+      if (maskData) {
+        bytes[1] |= 0x80;
+        bytes.push(0, 0, 0, 0);
+      }
+
+      sendFramedData(this, Buffer.from(bytes), null, cb);
       return;
     }
 
-    var dataLength = data.length;
-    var dataOffset = maskData ? 6 : 2;
-    var secondByte = dataLength;
-
-    if (dataLength >= 65536) {
-      dataOffset += 8;
-      secondByte = 127;
-    } else if (dataLength > 125) {
-      dataOffset += 2;
-      secondByte = 126;
+    if (!Buffer.isBuffer(data)) {
+      if (data instanceof ArrayBuffer) {
+        data = Buffer.from(data);
+      } else if (ArrayBuffer.isView(data)) {
+        data = viewToBuffer(data);
+      } else {
+        data = Buffer.from(typeof data === 'number' ? data.toString() : data);
+        readOnly = false;
+      }
     }
 
-    var canModifyData = compressed;
-    var mergeBuffers = dataLength < 32768 || (maskData && !canModifyData);
-    var totalLength = mergeBuffers ? dataLength + dataOffset : dataOffset;
-    var outputBuffer = new Buffer(totalLength);
-    outputBuffer[0] = finalFragment ? opcode | 0x80 : opcode;
-    if (compressed) outputBuffer[0] |= 0x40;
+    const mergeBuffers = data.length < 1024 || maskData && readOnly;
+    var dataOffset = maskData ? 6 : 2;
+    var payloadLength = data.length;
 
-    switch (secondByte) {
-      case 126:
-        outputBuffer.writeUInt16BE(dataLength, 2, true);
-        break;
-      case 127:
-        outputBuffer.writeUInt32BE(0, 2, true);
-        outputBuffer.writeUInt32BE(dataLength, 6, true);
+    if (data.length >= 65536) {
+      dataOffset += 8;
+      payloadLength = 127;
+    } else if (data.length > 125) {
+      dataOffset += 2;
+      payloadLength = 126;
+    }
+
+    const outputBuffer = Buffer.allocUnsafe(
+      mergeBuffers ? data.length + dataOffset : dataOffset
+    );
+
+    outputBuffer[0] = fin ? opcode | 0x80 : opcode;
+    if (rsv1) outputBuffer[0] |= 0x40;
+
+    if (payloadLength === 126) {
+      outputBuffer.writeUInt16BE(data.length, 2, true);
+    } else if (payloadLength === 127) {
+      outputBuffer.writeUInt32BE(0, 2, true);
+      outputBuffer.writeUInt32BE(data.length, 6, true);
     }
 
     if (maskData) {
-      outputBuffer[1] = secondByte | 0x80;
-      var mask = getRandomMask();
+      const mask = getRandomMask();
+
+      outputBuffer[1] = payloadLength | 0x80;
       outputBuffer[dataOffset - 4] = mask[0];
       outputBuffer[dataOffset - 3] = mask[1];
       outputBuffer[dataOffset - 2] = mask[2];
       outputBuffer[dataOffset - 1] = mask[3];
+
       if (mergeBuffers) {
-        bufferUtil.mask(data, mask, outputBuffer, dataOffset, dataLength);
+        bufferUtil.mask(data, mask, outputBuffer, dataOffset, data.length);
       } else {
-        bufferUtil.mask(data, mask, data, 0, dataLength);
+        bufferUtil.mask(data, mask, data, 0, data.length);
       }
     } else {
-      outputBuffer[1] = secondByte;
-      if (mergeBuffers) {
-        data.copy(outputBuffer, dataOffset);
-      }
+      outputBuffer[1] = payloadLength;
+      if (mergeBuffers) data.copy(outputBuffer, dataOffset);
     }
+
     sendFramedData(this, outputBuffer, mergeBuffers ? null : data, cb);
   }
 
@@ -300,6 +315,7 @@ class Sender {
   /**
    * Enqueues a send operation.
    *
+   * @param {Array} params Send operation parameters.
    * @private
    */
   enqueue (params) {
@@ -311,6 +327,23 @@ class Sender {
 module.exports = Sender;
 
 /**
+ * Converts an `ArrayBuffer` view into a buffer.
+ *
+ * @param {(DataView|TypedArray)} view The view to convert
+ * @return {Buffer} Converted view
+ * @private
+ */
+function viewToBuffer (view) {
+  const buf = Buffer.from(view.buffer);
+
+  if (view.byteLength !== view.buffer.byteLength) {
+    return buf.slice(view.byteOffset, view.byteOffset + view.byteLength);
+  }
+
+  return buf;
+}
+
+/**
  * Converts `data` into a buffer.
  *
  * @param {*} data Data to convert
@@ -318,19 +351,8 @@ module.exports = Sender;
  * @private
  */
 function toBuffer (data) {
-  if (Buffer.isBuffer(data)) return data;
-
   if (data instanceof ArrayBuffer) return Buffer.from(data);
-
-  if (ArrayBuffer.isView(data)) {
-    const buf = Buffer.from(data.buffer);
-
-    if (data.byteLength !== data.buffer.byteLength) {
-      return buf.slice(data.byteOffset, data.byteOffset + data.byteLength);
-    }
-
-    return buf;
-  }
+  if (ArrayBuffer.isView(data)) return viewToBuffer(data);
 
   return Buffer.from(typeof data === 'number' ? data.toString() : data);
 }


### PR DESCRIPTION
This adds an additional argument to `Sender.prototype.frameAndSend()` to specify if `data` can be masked in place.
This is useful for example when the data to send is a string or when data is compressed. In these cases it is safe to mask in place as the original data is left untouched.

Buffers whose size is less than 1 KiB are still copied unconditionally to reduce system calls.