### PR TITLE
Invoke the close callback when the close event is emitted

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -103,27 +103,18 @@ util.inherits(WebSocketServer, EventEmitter);
  */
 WebSocketServer.prototype.close = function (cb) {
   // terminate all associated clients
-  var error = null;
-
   if (this.clients) {
-    for (const client of this.clients) {
-      try {
-        client.terminate();
-      } catch (e) {
-        error = e;
-      }
-    }
+    for (const client of this.clients) client.terminate();
   }
 
   if (this._server) {
     // close the http server if it was internally created
-    if (this.options.port != null) this._server.close();
+    if (this.options.port != null) this._server.close(cb);
     this._ultron.destroy();
     this._ultron = this._server = null;
+  } else if (cb) {
+    cb();
   }
-
-  if (cb) cb(error);
-  else if (error) throw error;
 };
 
 /**


### PR DESCRIPTION
Right now the close callback is invoked immediately but it should be called when the HTTP server emits the 'close' event.