### PR TITLE
Rename some methods of the `Sender` class

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-const ErrorCodes = require('./ErrorCodes');
-const bufferUtil = require('./BufferUtil').BufferUtil;
 const PerMessageDeflate = require('./PerMessageDeflate');
+const bufferUtil = require('./BufferUtil').BufferUtil;
+const ErrorCodes = require('./ErrorCodes');
 
 /**
  * HyBi Sender implementation.
@@ -21,13 +21,13 @@ class Sender {
    * @param {Object} extensions An object containing the negotiated extensions
    */
   constructor (socket, extensions) {
-    this._socket = socket;
     this.extensions = extensions || {};
     this.firstFragment = true;
-    this.compress = false;
-    this.messageHandlers = [];
     this.processing = false;
+    this.compress = false;
+    this._socket = socket;
     this.onerror = null;
+    this.queue = [];
   }
 
   /**
@@ -67,7 +67,7 @@ class Sender {
   doClose (data, mask, cb) {
     this.frameAndSend(0x08, data, false, true, mask, false);
     if (this.extensions[PerMessageDeflate.extensionName]) {
-      this.messageHandlerCallback();
+      this.continue();
     }
     if (cb) cb();
   }
@@ -98,7 +98,7 @@ class Sender {
   doPing (data, mask) {
     this.frameAndSend(0x09, data, true, true, mask, false);
     if (this.extensions[PerMessageDeflate.extensionName]) {
-      this.messageHandlerCallback();
+      this.continue();
     }
   }
 
@@ -128,7 +128,7 @@ class Sender {
   doPong (data, mask) {
     this.frameAndSend(0x0a, data, true, true, mask, false);
     if (this.extensions[PerMessageDeflate.extensionName]) {
-      this.messageHandlerCallback();
+      this.continue();
     }
   }
 
@@ -182,7 +182,7 @@ class Sender {
   sendCompressed (opcode, data, fin, mask, rsv1, cb) {
     if (!this.compress) {
       this.frameAndSend(opcode, data, true, fin, mask, false, cb);
-      this.messageHandlerCallback();
+      this.continue();
       return;
     }
 
@@ -195,7 +195,7 @@ class Sender {
       }
 
       this.frameAndSend(opcode, buf, false, fin, mask, rsv1, cb);
-      this.messageHandlerCallback();
+      this.continue();
     });
   }
 
@@ -289,10 +289,10 @@ class Sender {
    *
    * @private
    */
-  flush () {
+  dequeue () {
     if (this.processing) return;
 
-    var handler = this.messageHandlers.shift();
+    const handler = this.queue.shift();
     if (!handler) return;
 
     this.processing = true;
@@ -305,10 +305,10 @@ class Sender {
    *
    * @private
    */
-  messageHandlerCallback () {
+  continue () {
     process.nextTick(() => {
       this.processing = false;
-      this.flush();
+      this.dequeue();
     });
   }
 
@@ -319,8 +319,8 @@ class Sender {
    * @private
    */
   enqueue (params) {
-    this.messageHandlers.push(params);
-    this.flush();
+    this.queue.push(params);
+    this.dequeue();
   }
 }
 


### PR DESCRIPTION
This renames `Sender#messageHandlerCallback` to `Sender#continue` and `Sender#flush` to `Sender#dequeue`.

I think these new names better reflect what the methods do. Everything is private so there shouldn't problems. I've opened this PR to see if other collaborators agree on the names.