### PR TITLE
Call `Sender#close()` callback when data is written out

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -65,11 +65,10 @@ class Sender {
    * @private
    */
   doClose (data, mask, cb) {
-    this.frameAndSend(0x08, data, false, true, mask, false);
+    this.frameAndSend(0x08, data, false, true, mask, false, cb);
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.messageHandlerCallback();
     }
-    if (cb) cb();
   }
 
   /**

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -221,11 +221,11 @@ describe('Sender', function () {
     });
 
     it('handles many send calls while processing without crashing on flush', function (done) {
-      let cnt = 0;
+      let count = 0;
       const perMessageDeflate = new PerMessageDeflate();
       const sender = new Sender({
         write: () => {
-          if (++cnt > 1e4) done();
+          if (++count > 1e4) done();
         }
       }, {
         'permessage-deflate': perMessageDeflate
@@ -249,7 +249,10 @@ describe('Sender', function () {
 
       let count = 0;
       const sender = new Sender({
-        write: (data) => count++
+        write: (data, cb) => {
+          count++;
+          if (cb) cb();
+        }
       }, {
         'permessage-deflate': perMessageDeflate
       });
@@ -260,9 +263,9 @@ describe('Sender', function () {
       sender.send('bar', { compress: true, fin: true });
       sender.send('baz', { compress: true, fin: true });
 
-      sender.close(1000, null, false, (err) => {
+      sender.close(1000, null, false, () => {
         assert.strictEqual(count, 4);
-        done(err);
+        done();
       });
     });
   });


### PR DESCRIPTION
Currently the [callback](https://github.com/websockets/ws/blob/199c248a4a65d175fdcb351ff1d29c87debaf855/lib/Sender.js#L72) of `Sender.prototype.close()` is immediately invoked regardless of data being sent or not.

This patch forwards the callback of `Sender.prototype.close()` to `Sender.prototype.frameAndSend()` to actually call the callback when data is written out.