### PR TITLE
Simplify closing handshake

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -255,9 +255,7 @@ class WebSocket extends EventEmitter {
     }
 
     if (this.readyState === WebSocket.CLOSING) {
-      if (this._closeCode && this._isServer) {
-        this.terminate();
-      }
+      if (this._closeCode) this.terminate();
       return;
     }
 
@@ -265,7 +263,7 @@ class WebSocket extends EventEmitter {
     this._sender.close(code, data, !this._isServer, (err) => {
       if (err) this.emit('error', err);
 
-      if (this._closeCode && this._isServer) {
+      if (this._closeCode) {
         this.terminate();
       } else {
         //


### PR DESCRIPTION
Currently the close handshake works like this when initiated from the server:

```
        SERVER                                 CLIENT


+--------------------+
|ws.close()          |
|readyState = CLOSING|
+--------------------+
           |            +-----------+
           +----------->|close frame|-------------+
                        +-----------+             v
                                       +--------------------+
                                       |closeReceived = true|
                                       |ws.close()          |
                                       |readyState = CLOSING|
                                       +--------------------+
                        +-----------+             |
           +------------|close frame|<------------+
           v            +-----------+
+--------------------+
|closeReceived = true|
|ws.close()          |
|ws.terminate()      |
|socket.end()        |
+--------------------+
           |              +-------+
           +------------->|TCP FIN|---------------+
                          +-------+               v
                                        +-------------------+
                                        |readyState = CLOSED|
                                        |ws.emit('closed')  |
                                        |socket.end()       |
                                        +-------------------+
                          +-------+               |
           +--------------|TCP FIN|<--------------+
           |              +-------+
           v
 +-------------------+
 |readyState = CLOSED|
 |ws.emit('closed')  |
 +-------------------+
```

and like this when initiated from the client:

```
        CLIENT                                 SERVER


+--------------------+
|ws.close()          |
|readyState = CLOSING|
+--------------------+
           |            +-----------+
           +----------->|close frame|-------------+
                        +-----------+             v
                                       +--------------------+
                                       |closeReceived = true|
                                       |ws.close()          |
                                       |readyState = CLOSING|
                                       |ws.terminate()      |
                                       |socket.end()        |
                                       +--------------------+
                   +---------------------+        |
           +-------|close frame + TCP FIN|<-------+
           v       +---------------------+
+--------------------+
|closeReceived = true|
|ws.close()          |
|readyState = CLOSED |
|ws.emit('closed')   |
|socket.end()        |
+--------------------+
           |              +-------+
           +------------->|TCP FIN|---------------+
                          +-------+               v
                                        +-------------------+
                                        |readyState = CLOSED|
                                        |ws.emit('closed')  |
                                        +-------------------+
```

This patch uniforms the behavior making a close initiated by the server work in the same way of a close initiated by the client.

After reading https://tools.ietf.org/html/rfc6455#section-1.4 and https://tools.ietf.org/html/rfc6455#section-7, I think this is correct.

I have some doubts on this [section](https://tools.ietf.org/html/rfc6455#section-7.1.1) which is why the close handshake is currently implemented in this way for the server but I also checked other implementations for Node.js and they use the same procedure for both client and server as proposed in this patch.