### PR TITLE
Remove `supports` attribute

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -143,10 +143,6 @@ The WebSocket protocol version used for this connection, `8`, `13`.
 
 The URL of the WebSocket server (only for clients)
 
-### websocket.supports
-
-Describes the feature of the used protocol version. E.g. `supports.binary` is a boolean that describes if the connection supports binary messages.
-
 ### websocket.upgradeReq
 
 The http request that initiated the upgrade. Useful for parsing authorty headers, cookie headers and other information to associate a specific Websocket to a specific Client. This is only available for WebSockets constructed by a Server.

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -59,7 +59,6 @@ function WebSocket (address, protocols, options) {
   this._closeReceived = false;
   this.bytesReceived = 0;
   this.readyState = null;
-  this.supports = { binary: true };
   this.extensions = {};
   this._binaryType = 'nodebuffer';
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -1894,24 +1894,6 @@ describe('WebSocket', function () {
     });
   });
 
-  describe('protocol support discovery', function () {
-    describe('#supports', function () {
-      describe('#binary', function () {
-        it('returns true', function (done) {
-          const wss = new WebSocketServer({ port: ++port }, () => {
-            const ws = new WebSocket(`ws://localhost:${port}`);
-          });
-
-          wss.on('connection', (client) => {
-            assert.strictEqual(client.supports.binary, true);
-            wss.close();
-            done();
-          });
-        });
-      });
-    });
-  });
-
   describe('host and origin headers', function () {
     it('includes the host header with port number', function (done) {
       const server = http.createServer();


### PR DESCRIPTION
Hixie-76 is no longer supported so this non-standard attribute can be removed as binary messages are always supported.