### PR TITLE
Move the EventTarget methods to lib/EventTarget.js

### DIFF
--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * Class representing an event.
+ *
+ * @private
+ */
+class Event {
+  /**
+   * Create a new `Event`.
+   *
+   * @param {String} type The name of the event
+   * @param {Object} target A reference to the target to which the event was dispatched
+   */
+  constructor (type, target) {
+    this.target = target;
+    this.type = type;
+  }
+}
+
+/**
+ * Class representing a message event.
+ *
+ * @extends Event
+ * @private
+ */
+class MessageEvent extends Event {
+  /**
+   * Create a new `MessageEvent`.
+   *
+   * @param {(String|Buffer|ArrayBuffer)} data The received data
+   * @param {Boolean} isBinary Specifies if `data` is binary
+   * @param {WebSocket} target A reference to the target to which the event was dispatched
+   */
+  constructor (data, isBinary, target) {
+    super('message', target);
+
+    this.binary = isBinary; // non-standard.
+    this.data = data;
+  }
+}
+
+/**
+ * Class representing a close event.
+ *
+ * @extends Event
+ * @private
+ */
+class CloseEvent extends Event {
+  /**
+   * Create a new `CloseEvent`.
+   *
+   * @param {Number} code The status code explaining why the connection is being closed
+   * @param {String} reason A human-readable string explaining why the connection is closing
+   * @param {WebSocket} target A reference to the target to which the event was dispatched
+   */
+  constructor (code, reason, target) {
+    super('close', target);
+
+    this.wasClean = code === undefined || code === 1000;
+    this.reason = reason;
+    this.target = target;
+    this.type = 'close';
+    this.code = code;
+  }
+}
+
+/**
+ * Class representing an open event.
+ *
+ * @extends Event
+ * @private
+ */
+class OpenEvent extends Event {
+  /**
+   * Create a new `OpenEvent`.
+   *
+   * @param {WebSocket} target A reference to the target to which the event was dispatched
+   */
+  constructor (target) {
+    super('open', target);
+  }
+}
+
+/**
+ * This provides methods for emulating the `EventTarget` interface. It's not
+ * meant to be used directly.
+ *
+ * @mixin
+ */
+const EventTarget = {
+  /**
+   * Register an event listener.
+   *
+   * @param {String} method A string representing the event type to listen for
+   * @param {Function} listener The listener to add
+   * @public
+   */
+  addEventListener (method, listener) {
+    if (typeof listener !== 'function') return;
+
+    function onMessage (data, flags) {
+      if (flags.binary && this.binaryType === 'arraybuffer') {
+        data = new Uint8Array(data).buffer;
+      }
+      listener.call(this, new MessageEvent(data, !!flags.binary, this));
+    }
+
+    function onClose (code, message) {
+      listener.call(this, new CloseEvent(code, message, this));
+    }
+
+    function onError (event) {
+      event.type = 'error';
+      event.target = this;
+      listener.call(this, event);
+    }
+
+    function onOpen () {
+      listener.call(this, new OpenEvent(this));
+    }
+
+    if (method === 'message') {
+      onMessage._listener = listener;
+      this.on(method, onMessage);
+    } else if (method === 'close') {
+      onClose._listener = listener;
+      this.on(method, onClose);
+    } else if (method === 'error') {
+      onError._listener = listener;
+      this.on(method, onError);
+    } else if (method === 'open') {
+      onOpen._listener = listener;
+      this.on(method, onOpen);
+    } else {
+      this.on(method, listener);
+    }
+  },
+
+  /**
+   * Remove an event listener.
+   *
+   * @param {String} method A string representing the event type to remove
+   * @param {Function} listener The listener to remove
+   * @public
+   */
+  removeEventListener (method, listener) {
+    const listeners = this.listeners(method);
+
+    for (var i = 0; i < listeners.length; i++) {
+      if (listeners[i]._listener === listener) {
+        this.removeListener(method, listeners[i]);
+      }
+    }
+  }
+};
+
+module.exports = EventTarget;

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -16,6 +16,7 @@ const util = require('util');
 const url = require('url');
 
 const PerMessageDeflate = require('./PerMessageDeflate');
+const EventTarget = require('./EventTarget');
 const Extensions = require('./Extensions');
 const Receiver = require('./Receiver');
 const Sender = require('./Sender');
@@ -332,12 +333,12 @@ WebSocket.prototype.terminate = function terminate () {
 };
 
 /**
- * Expose bufferedAmount
+ * Expose the `bufferedAmount` attribute.
  *
- * @api public
+ * @public
  */
 Object.defineProperty(WebSocket.prototype, 'bufferedAmount', {
-  get: function get () {
+  get () {
     var amount = 0;
     if (this._socket) {
       amount = this._socket.bufferSize || 0;
@@ -347,19 +348,19 @@ Object.defineProperty(WebSocket.prototype, 'bufferedAmount', {
 });
 
 /**
- * Expose binaryType
+ * Expose the `binaryType` attribute.
  *
- * This deviates from the W3C interface since ws doesn't support the required
+ * This deviates from the WHATWG interface since ws doesn't support the required
  * default "blob" type (instead we define a custom "nodebuffer" type).
  *
- * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
- * @api public
+ * @see {@link https://html.spec.whatwg.org/multipage/comms.html#dom-websocket-binarytype}
+ * @public
  */
 Object.defineProperty(WebSocket.prototype, 'binaryType', {
-  get: function get () {
+  get () {
     return this._binaryType;
   },
-  set: function set (type) {
+  set (type) {
     if (type === 'arraybuffer' || type === 'nodebuffer') {
       this._binaryType = type;
     } else {
@@ -368,174 +369,85 @@ Object.defineProperty(WebSocket.prototype, 'binaryType', {
   }
 });
 
-/**
- * Emulates the W3C Browser based WebSocket interface using function members.
- *
- * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
- * @api public
- */
-['open', 'error', 'close', 'message'].forEach(function (method) {
-  Object.defineProperty(WebSocket.prototype, 'on' + method, {
+//
+// Add the `onopen`, `onerror`, `onclose`, and `onmessage` attributes.
+// See https://html.spec.whatwg.org/multipage/comms.html#the-websocket-interface
+//
+['open', 'error', 'close', 'message'].forEach((method) => {
+  Object.defineProperty(WebSocket.prototype, `on${method}`, {
     /**
-     * Returns the current listener
+     * Return the listener of the event.
      *
-     * @returns {Mixed} the set function or undefined
-     * @api public
+     * @return {(Function|undefined)} The event listener or `undefined`
+     * @public
      */
-    get: function get () {
-      var listener = this.listeners(method)[0];
-      return listener ? (listener._listener ? listener._listener : listener) : undefined;
+    get () {
+      const listener = this.listeners(method)[0];
+      return listener ? listener._listener ? listener._listener : listener : undefined;
     },
-
     /**
-     * Start listening for events
+     * Add a listener for the event.
      *
-     * @param {Function} listener the listener
-     * @returns {Mixed} the set function or undefined
-     * @api public
+     * @param {Function} listener The listener to add
+     * @public
      */
-    set: function set (listener) {
+    set (listener) {
       this.removeAllListeners(method);
       this.addEventListener(method, listener);
     }
   });
 });
 
-/**
- * Registers an event listener emulating the `EventTarget` interface.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
- * @param {String} method A string representing the event type to listen for
- * @param {Function} listener The listener to add
- * @public
- */
-WebSocket.prototype.addEventListener = function (method, listener) {
-  if (typeof listener !== 'function') return;
-
-  function onMessage (data, flags) {
-    if (flags.binary && this.binaryType === 'arraybuffer') {
-      data = new Uint8Array(data).buffer;
-    }
-    listener.call(this, new MessageEvent(data, !!flags.binary, this));
-  }
-
-  function onClose (code, message) {
-    listener.call(this, new CloseEvent(code, message, this));
-  }
-
-  function onError (event) {
-    event.type = 'error';
-    event.target = this;
-    listener.call(this, event);
-  }
-
-  function onOpen () {
-    listener.call(this, new OpenEvent(this));
-  }
-
-  if (method === 'message') {
-    onMessage._listener = listener;
-    this.on(method, onMessage);
-  } else if (method === 'close') {
-    onClose._listener = listener;
-    this.on(method, onClose);
-  } else if (method === 'error') {
-    onError._listener = listener;
-    this.on(method, onError);
-  } else if (method === 'open') {
-    onOpen._listener = listener;
-    this.on(method, onOpen);
-  } else {
-    this.on(method, listener);
-  }
-};
-
-/**
- * Removes an event listener previously registered with `addEventListener`.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
- * @param {String} method A string representing the event type to remove
- * @param {Function} listener The listener to remove
- * @public
- */
-WebSocket.prototype.removeEventListener = function (method, listener) {
-  const listeners = this.listeners(method);
-
-  for (var i = 0; i < listeners.length; i++) {
-    if (listeners[i]._listener === listener) {
-      this.removeListener(method, listeners[i]);
-    }
-  }
-};
+WebSocket.prototype.addEventListener = EventTarget.addEventListener;
+WebSocket.prototype.removeEventListener = EventTarget.removeEventListener;
 
 module.exports = WebSocket;
 module.exports.buildHostHeader = buildHostHeader;
 
 /**
- * W3C MessageEvent
+ * Append port number to Host header, only if specified in the URL and
+ * non-default.
  *
- * @see http://www.w3.org/TR/html5/comms.html
- * @constructor
- * @api private
+ * @param {Boolean} isSecure Specifies whether or not the URL scheme is `wss`
+ * @param {String} hostname The hostname portion of the URL
+ * @param {Number} port The port portion of the URL
+ * @return {String} The field value of the `Host` header
+ * @private
  */
-function MessageEvent (dataArg, isBinary, target) {
-  this.type = 'message';
-  this.data = dataArg;
-  this.target = target;
-  this.binary = isBinary; // non-standard.
-}
-
-/**
- * W3C CloseEvent
- *
- * @see http://www.w3.org/TR/html5/comms.html
- * @constructor
- * @api private
- */
-function CloseEvent (code, reason, target) {
-  this.type = 'close';
-  this.wasClean = code === undefined || code === 1000;
-  this.code = code;
-  this.reason = reason;
-  this.target = target;
-}
-
-/**
- * W3C OpenEvent
- *
- * @see http://www.w3.org/TR/html5/comms.html
- * @constructor
- * @api private
- */
-function OpenEvent (target) {
-  this.type = 'open';
-  this.target = target;
-}
-
-// Append port number to Host header, only if specified in the url
-// and non-default
 function buildHostHeader (isSecure, hostname, port) {
   var headerHost = hostname;
-  if (hostname) {
-    if ((isSecure && (port !== 443)) || (!isSecure && (port !== 80))) {
-      headerHost = headerHost + ':' + port;
-    }
+
+  if (headerHost && (isSecure && port !== 443 || !isSecure && port !== 80)) {
+    headerHost = `${headerHost}:${port}`;
   }
+
   return headerHost;
 }
 
 /**
- * Entirely private apis,
- * which may or may not be bound to a sepcific WebSocket instance.
+ * Initialize a WebSocket server client.
+ *
+ * @param {http.IncomingMessage} req The request object
+ * @param {net.Socket} socket The network socket between the server and client
+ * @param {Buffer} head The first packet of the upgraded stream
+ * @param {Object} options WebSocket attributes
+ * @param {Number} options.protocolVersion The WebSocket protocol version
+ * @param {Object} options.extensions The negotiated extensions
+ * @param {Number} options.maxPayload The maximum allowed message size
+ * @param {String} options.protocol The chosen subprotocol
+ * @private
  */
-function initAsServerClient (req, socket, upgradeHead, options) {
-  // expose state properties
-  Object.assign(this, options);
+function initAsServerClient (req, socket, head, options) {
+  this.protocolVersion = options.protocolVersion;
+  this.extensions = options.extensions;
+  this.maxPayload = options.maxPayload;
+  this.protocol = options.protocol;
+
   this.readyState = WebSocket.CONNECTING;
   this.upgradeReq = req;
   this._isServer = true;
-  // establish connection
-  establishConnection.call(this, socket, upgradeHead);
+
+  establishConnection.call(this, socket, head);
 }
 
 /**
@@ -543,7 +455,7 @@ function initAsServerClient (req, socket, upgradeHead, options) {
  *
  * @param {String} address The URL to which to connect
  * @param {String[]} protocols The list of subprotocols
- * @param {Object} options Configuration options
+ * @param {Object} options Connection options
  * @param {String} option.protocol Value of the `Sec-WebSocket-Protocol` header
  * @param {(Boolean|Object)} options.perMessageDeflate Enable/disable permessage-deflate
  * @param {String} options.localAddress Local interface to bind for network connections


### PR DESCRIPTION
This patch:

- Moves the `EventTarget` methods (`addEventListener` and `removeEventListener`) and classes (`MessageEvent`, `CloseEvent` and `OpenEvent`) to the `EventTarget.js` file.
- Cleans up a bit `WebSocket.js` by adding JSDoc and modernizing the code of some methods/attributes.