### PR TITLE
Clean up `WebSocket.createServer()` and `WebSocket.connect()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,49 +1,60 @@
-'use strict';
-
 /*!
  * ws: a node.js websocket client
  * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
  * MIT Licensed
  */
 
-var WS = module.exports = require('./lib/WebSocket');
+'use strict';
+
+const WS = module.exports = require('./lib/WebSocket');
 
 WS.Server = require('./lib/WebSocketServer');
-WS.Sender = require('./lib/Sender');
 WS.Receiver = require('./lib/Receiver');
+WS.Sender = require('./lib/Sender');
 
 /**
- * Create a new WebSocket server.
+ * A factory function, which returns a new `WebSocketServer`.
  *
- * @param {Object} options Server options
- * @param {Function} fn Optional connection listener.
- * @returns {WS.Server}
- * @api public
+ * @param {Object} options Configuration options
+ * @param {Function} fn A listener for the `connection` event
+ * @return {WebSocketServer}
+ * @public
  */
 WS.createServer = function createServer (options, fn) {
-  var server = new WS.Server(options);
+  const server = new WS.Server(options);
 
-  if (typeof fn === 'function') {
-    server.on('connection', fn);
-  }
-
+  if (fn) server.on('connection', fn);
   return server;
 };
 
 /**
- * Create a new WebSocket connection.
+ * A factory function, which returns a new `WebSocket` and automatically
+ * connectes to the supplied address.
  *
- * @param {String} address The URL/address we need to connect to.
- * @param {Function} fn Open listener.
- * @returns {WS}
- * @api public
+ * @param {String} address The URL to which to connect
+ * @param {(String|String[])} protocols The list of subprotocols
+ * @param {Object} options Connection options
+ * @param {Function} fn A listener for the `open` event
+ * @return {WebSocket}
+ * @public
  */
-WS.connect = WS.createConnection = function connect (address, fn) {
-  var client = new WS(address);
-
-  if (typeof fn === 'function') {
-    client.on('open', fn);
+WS.connect = WS.createConnection = function connect (address, protocols, options, fn) {
+  if (typeof protocols === 'function') {
+    fn = protocols;
+    protocols = options = null;
+  } else if (typeof protocols === 'object' && !Array.isArray(protocols)) {
+    fn = options;
+    options = protocols;
+    protocols = null;
   }
 
+  if (typeof options === 'function') {
+    fn = options;
+    options = null;
+  }
+
+  const client = new WS(address, protocols, options);
+
+  if (fn) client.on('open', fn);
   return client;
 };

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -2250,3 +2250,64 @@ describe('WebSocket', function () {
     });
   });
 });
+
+describe('WebSocket.connect', function () {
+  it('creates a `WebSocket` instance', function (done) {
+    const wss = new WebSocketServer({ port: ++port }, () => {
+      const ws = WebSocket.connect(`ws://localhost:${port}`);
+
+      ws.on('open', () => wss.close(done));
+    });
+  });
+
+  it('can add a listener for the `open` event', function (done) {
+    const wss = new WebSocketServer({ port: ++port }, () => {
+      const ws = WebSocket.connect(`ws://localhost:${port}`, () => {
+        wss.close(done);
+      });
+    });
+  });
+
+  it('allows to specify a subprotocol', function (done) {
+    const wss = new WebSocketServer({ port: ++port }, () => {
+      const ws = WebSocket.connect(`ws://localhost:${port}`, 'foo', () => {
+        assert.strictEqual(ws.protocol, 'foo');
+        wss.close(done);
+      });
+    });
+  });
+
+  it('allows to specify a list of subprotocols', function (done) {
+    const wss = new WebSocketServer({ port: ++port }, () => {
+      const ws = WebSocket.connect(`ws://localhost:${port}`, ['foo', 'bar'], () => {
+        assert.strictEqual(ws.protocol, 'foo');
+        wss.close(done);
+      });
+    });
+  });
+
+  it('allows to use connection options', function (done) {
+    const wss = new WebSocketServer({ port: ++port }, () => {
+      const ws = WebSocket.connect(`ws://localhost:${port}`, {
+        protocolVersion: 8
+      }, () => {
+        assert.strictEqual(ws.protocolVersion, 8);
+        wss.close(done);
+      });
+    });
+  });
+
+  it('allows to specify a subprotocol and use connection options', function (done) {
+    const wss = new WebSocketServer({ port: ++port }, () => {
+      const ws = WebSocket.connect(`ws://localhost:${port}`, 'foo', {
+        protocolVersion: 8
+      });
+
+      ws.on('open', () => {
+        assert.strictEqual(ws.protocolVersion, 8);
+        assert.strictEqual(ws.protocol, 'foo');
+        wss.close(done);
+      });
+    });
+  });
+});

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -1046,3 +1046,18 @@ describe('WebSocketServer', function () {
     });
   });
 });
+
+describe('WebSocket.createServer', function () {
+  it('creates a `WebSocketServer` instance', function () {
+    const wss = WebSocket.createServer({ noServer: true });
+
+    assert.ok(wss instanceof WebSocketServer);
+  });
+
+  it('can add a listener for the `connection` event', function () {
+    const connectionListener = () => {};
+    const wss = WebSocket.createServer({ noServer: true }, connectionListener);
+
+    assert.strictEqual(wss.listeners('connection')[0], connectionListener);
+  });
+});


### PR DESCRIPTION
This cleans up the factory functions `WebSocket.createServer()` and `WebSocket.connect()`.

Put this in a PR because to be honest I would like to remove them but I would like to hear what other collaborators think before doing that.