### PR TITLE
Refactor `WebSocket` to use class syntax

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -11,7 +11,6 @@ const crypto = require('crypto');
 const Ultron = require('ultron');
 const https = require('https');
 const http = require('http');
-const util = require('util');
 const url = require('url');
 
 const PerMessageDeflate = require('./PerMessageDeflate');
@@ -25,277 +24,391 @@ const closeTimeout = 30 * 1000; // Allow 30 seconds to terminate the connection 
 const protocolVersion = 13;
 
 /**
- * WebSocket implementation
+ * Class representing a WebSocket.
  *
- * @constructor
- * @param {String} address Connection address.
- * @param {String|Array} protocols WebSocket protocols.
- * @param {Object} options Additional connection options.
- * @api public
+ * @extends EventEmitter
  */
-function WebSocket (address, protocols, options) {
-  if (this instanceof WebSocket === false) {
-    return new WebSocket(address, protocols, options);
-  }
+class WebSocket extends EventEmitter {
+  /**
+   * Create a new `WebSocket`.
+   *
+   * @param {String} address The URL to which to connect
+   * @param {(String|String[])} protocols The subprotocols
+   * @param {Object} options Connection options
+   */
+  constructor (address, protocols, options) {
+    super();
 
-  EventEmitter.call(this);
-
-  if (protocols && !Array.isArray(protocols) && typeof protocols === 'object') {
-    // accept the "options" Object as the 2nd argument
-    options = protocols;
-    protocols = null;
-  }
-
-  if (typeof protocols === 'string') {
-    protocols = [ protocols ];
-  }
-
-  if (!Array.isArray(protocols)) {
-    protocols = [];
-  }
-
-  this._socket = null;
-  this._ultron = null;
-  this._closeReceived = false;
-  this.bytesReceived = 0;
-  this.readyState = null;
-  this.extensions = {};
-  this._binaryType = 'nodebuffer';
-
-  if (Array.isArray(address)) {
-    initAsServerClient.apply(this, address.concat(options));
-  } else {
-    initAsClient.apply(this, [address, protocols, options]);
-  }
-}
-
-/**
- * Inherits from EventEmitter.
- */
-util.inherits(WebSocket, EventEmitter);
-
-/**
- * Ready States
- */
-['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'].forEach(function each (state, index) {
-  WebSocket.prototype[state] = WebSocket[state] = index;
-});
-
-/**
- * Gracefully closes the connection, after sending a description message to the server
- *
- * @param {Object} data to be sent to the server
- * @api public
- */
-WebSocket.prototype.close = function close (code, data) {
-  if (this.readyState === WebSocket.CLOSED) return;
-
-  if (this.readyState === WebSocket.CONNECTING) {
-    this.readyState = WebSocket.CLOSED;
-    return;
-  }
-
-  if (this.readyState === WebSocket.CLOSING) {
-    if (this._closeReceived && this._isServer) {
-      this.terminate();
-    }
-    return;
-  }
-
-  try {
-    this.readyState = WebSocket.CLOSING;
-    this._closeCode = code;
-    this._closeMessage = data;
-    var mask = !this._isServer;
-    this._sender.close(code, data, mask, (err) => {
-      if (err) this.emit('error', err);
-
-      if (this._closeReceived && this._isServer) {
-        this.terminate();
-      } else {
-        // ensure that the connection is cleaned up even when no response of closing handshake.
-        clearTimeout(this._closeTimer);
-        this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
-      }
-    });
-  } catch (e) {
-    this.emit('error', e);
-  }
-};
-
-/**
- * Pause the client stream
- *
- * @api public
- */
-WebSocket.prototype.pause = function pauser () {
-  if (this.readyState !== WebSocket.OPEN) throw new Error('not opened');
-
-  return this._socket.pause();
-};
-
-/**
- * Sends a ping
- *
- * @param {Object} data to be sent to the server
- * @param {Object} Members - mask: boolean, binary: boolean
- * @param {boolean} dontFailWhenClosed indicates whether or not to throw if the connection isnt open
- * @api public
- */
-WebSocket.prototype.ping = function ping (data, options, dontFailWhenClosed) {
-  if (this.readyState !== WebSocket.OPEN) {
-    if (dontFailWhenClosed === true) return;
-    throw new Error('not opened');
-  }
-
-  options = options || {};
-
-  if (options.mask === undefined) options.mask = !this._isServer;
-
-  this._sender.ping(data, options);
-};
-
-/**
- * Sends a pong
- *
- * @param {Object} data to be sent to the server
- * @param {Object} Members - mask: boolean, binary: boolean
- * @param {boolean} dontFailWhenClosed indicates whether or not to throw if the connection isnt open
- * @api public
- */
-WebSocket.prototype.pong = function (data, options, dontFailWhenClosed) {
-  if (this.readyState !== WebSocket.OPEN) {
-    if (dontFailWhenClosed === true) return;
-    throw new Error('not opened');
-  }
-
-  options = options || {};
-
-  if (options.mask === undefined) options.mask = !this._isServer;
-
-  this._sender.pong(data, options);
-};
-
-/**
- * Resume the client stream
- *
- * @api public
- */
-WebSocket.prototype.resume = function resume () {
-  if (this.readyState !== WebSocket.OPEN) throw new Error('not opened');
-
-  return this._socket.resume();
-};
-
-/**
- * Sends a piece of data
- *
- * @param {Object} data to be sent to the server
- * @param {Object} Members - mask: boolean, binary: boolean, compress: boolean
- * @param {function} Optional callback which is executed after the send completes
- * @api public
- */
-
-WebSocket.prototype.send = function send (data, options, cb) {
-  if (typeof options === 'function') {
-    cb = options;
-    options = {};
-  }
-
-  if (this.readyState !== WebSocket.OPEN) {
-    if (cb) cb(new Error('not opened'));
-    else throw new Error('not opened');
-    return;
-  }
-
-  if (!data) data = '';
-
-  options = options || {};
-  if (options.fin !== false) options.fin = true;
-
-  if (options.binary === undefined) {
-    options.binary = data instanceof Buffer || data instanceof ArrayBuffer ||
-      ArrayBuffer.isView(data);
-  }
-
-  if (options.mask === undefined) options.mask = !this._isServer;
-  if (options.compress === undefined) options.compress = true;
-  if (!this.extensions[PerMessageDeflate.extensionName]) {
-    options.compress = false;
-  }
-
-  this._sender.send(data, options, cb);
-};
-
-/**
- * Immediately shuts down the connection
- *
- * @api public
- */
-WebSocket.prototype.terminate = function terminate () {
-  if (this.readyState === WebSocket.CLOSED) return;
-
-  if (this._socket) {
-    this.readyState = WebSocket.CLOSING;
-
-    // End the connection
-    try {
-      this._socket.end();
-    } catch (e) {
-      // Socket error during end() call, so just destroy it right now
-      cleanupWebsocketResources.call(this, true);
-      return;
+    if (typeof protocols === 'object' && !Array.isArray(protocols)) {
+      //
+      // Accept the `options` object as the 2nd argument.
+      //
+      options = protocols;
+      protocols = null;
     }
 
-    // Add a timeout to ensure that the connection is completely
-    // cleaned up within 30 seconds, even if the clean close procedure
-    // fails for whatever reason
-    // First cleanup any pre-existing timeout from an earlier "terminate" call,
-    // if one exists.  Otherwise terminate calls in quick succession will leak timeouts
-    // and hold the program open for `closeTimout` time.
-    if (this._closeTimer) { clearTimeout(this._closeTimer); }
-    this._closeTimer = setTimeout(cleanupWebsocketResources.bind(this, true), closeTimeout);
-  } else if (this.readyState === WebSocket.CONNECTING) {
-    cleanupWebsocketResources.call(this, true);
-  }
-};
+    if (typeof protocols === 'string') protocols = [protocols];
+    if (!Array.isArray(protocols)) protocols = [];
 
-/**
- * Expose the `bufferedAmount` attribute.
- *
- * @public
- */
-Object.defineProperty(WebSocket.prototype, 'bufferedAmount', {
-  get () {
+    this._finalize = this.finalize.bind(this);
+
+    this._binaryType = 'nodebuffer';
+    this._closeReceived = false;
+    this.bytesReceived = 0;
+    this.readyState = null;
+    this.extensions = {};
+    this._socket = null;
+    this._ultron = null;
+
+    if (Array.isArray(address)) {
+      initAsServerClient.call(this, address[0], address[1], address[2], options);
+    } else {
+      initAsClient.call(this, address, protocols, options);
+    }
+  }
+
+  get CONNECTING () { return WebSocket.CONNECTING; }
+  get CLOSING () { return WebSocket.CLOSING; }
+  get CLOSED () { return WebSocket.CLOSED; }
+  get OPEN () { return WebSocket.OPEN; }
+
+  /**
+   * @type {Number}
+   */
+  get bufferedAmount () {
     var amount = 0;
-    if (this._socket) {
-      amount = this._socket.bufferSize || 0;
-    }
+
+    if (this._socket) amount = this._socket.bufferSize || 0;
     return amount;
   }
-});
 
-/**
- * Expose the `binaryType` attribute.
- *
- * This deviates from the WHATWG interface since ws doesn't support the required
- * default "blob" type (instead we define a custom "nodebuffer" type).
- *
- * @see {@link https://html.spec.whatwg.org/multipage/comms.html#dom-websocket-binarytype}
- * @public
- */
-Object.defineProperty(WebSocket.prototype, 'binaryType', {
-  get () {
+  /**
+   * This deviates from the WHATWG interface since ws doesn't support the required
+   * default "blob" type (instead we define a custom "nodebuffer" type).
+   *
+   * @type {String}
+   */
+  get binaryType () {
     return this._binaryType;
-  },
-  set (type) {
+  }
+
+  set binaryType (type) {
     if (type === 'arraybuffer' || type === 'nodebuffer') {
       this._binaryType = type;
     } else {
       throw new SyntaxError('unsupported binaryType: must be either "nodebuffer" or "arraybuffer"');
     }
   }
-});
+
+  /**
+   * Set up the socket and the internal resources.
+   *
+   * @param {net.Socket} socket The network socket between the server and client
+   * @param {Buffer} head The first packet of the upgraded stream
+   * @private
+   */
+  setSocket (socket, head) {
+    socket.setTimeout(0);
+    socket.setNoDelay();
+
+    this._receiver = new Receiver(this.extensions, this.maxPayload);
+    this._sender = new Sender(socket, this.extensions);
+    this._ultron = new Ultron(socket);
+    this._socket = socket;
+
+    // socket cleanup handlers
+    this._ultron.on('close', this._finalize);
+    this._ultron.on('error', this._finalize);
+    this._ultron.on('end', this._finalize);
+
+    // ensure that the head is added to the receiver
+    if (head && head.length > 0) {
+      socket.unshift(head);
+      head = null;
+    }
+
+    // subsequent packets are pushed to the receiver
+    this._ultron.on('data', (data) => {
+      this.bytesReceived += data.length;
+      this._receiver.add(data);
+    });
+
+    // receiver event handlers
+    this._receiver.ontext = (data, flags) => this.emit('message', data, flags);
+    this._receiver.onbinary = (data, flags) => {
+      flags.binary = true;
+      this.emit('message', data, flags);
+    };
+    this._receiver.onping = (data, flags) => {
+      this.pong(data, { mask: !this._isServer }, true);
+      this.emit('ping', data, flags);
+    };
+    this._receiver.onpong = (data, flags) => this.emit('pong', data, flags);
+    this._receiver.onclose = (code, data, flags) => {
+      this._closeReceived = true;
+      this.close(code, data);
+    };
+    this._receiver.onerror = (error, errorCode) => {
+      // close the connection when the receiver reports a HyBi error code
+      this.close(errorCode, '');
+      this.emit('error', error);
+    };
+
+    // sender event handlers
+    this._sender.onerror = (error) => {
+      this.close(1002, '');
+      this.emit('error', error);
+    };
+
+    this.readyState = WebSocket.OPEN;
+    this.emit('open');
+  }
+
+  /**
+   * Clean up and release internal resources and emit the `close` event.
+   *
+   * @param {(Boolean|Error)} Indicates whether or not an error occurred
+   * @private
+   */
+  finalize (error) {
+    if (this.readyState === WebSocket.CLOSED) return;
+
+    this.readyState = WebSocket.CLOSED;
+
+    clearTimeout(this._closeTimer);
+    this._closeTimer = null;
+
+    // If the connection was closed abnormally (with an error), or if
+    // the close control frame was not received then the close code
+    // must default to 1006.
+    if (error || !this._closeReceived) {
+      this._closeCode = 1006;
+    }
+    this.emit('close', this._closeCode || 1000, this._closeMessage || '');
+
+    if (this._socket) {
+      if (this._ultron) this._ultron.destroy();
+      this._socket.on('error', function onerror () {
+        try {
+          this.destroy();
+        } catch (e) {}
+      });
+
+      try {
+        if (!error) this._socket.end();
+        else this._socket.destroy();
+      } catch (e) { /* Ignore termination errors */ }
+
+      this._socket = null;
+      this._ultron = null;
+    }
+
+    if (this._sender) {
+      this._sender = this._sender.onerror = null;
+    }
+
+    if (this._receiver) {
+      this._receiver.cleanup();
+      this._receiver = null;
+    }
+
+    if (this.extensions[PerMessageDeflate.extensionName]) {
+      this.extensions[PerMessageDeflate.extensionName].cleanup();
+    }
+
+    this.extensions = null;
+
+    this.removeAllListeners();
+    this.on('error', function onerror () {}); // catch all errors after this
+  }
+
+  /**
+   * Pause the socket stream.
+   *
+   * @public
+   */
+  pause () {
+    if (this.readyState !== WebSocket.OPEN) throw new Error('not opened');
+
+    this._socket.pause();
+  }
+
+  /**
+   * Resume the socket stream
+   *
+   * @public
+   */
+  resume () {
+    if (this.readyState !== WebSocket.OPEN) throw new Error('not opened');
+
+    this._socket.resume();
+  }
+
+  /**
+   * Start a closing handshake.
+   *
+   * @param {Number} code Status code explaining why the connection is closing
+   * @param {String} data A string explaining why the connection is closing
+   * @public
+   */
+  close (code, data) {
+    if (this.readyState === WebSocket.CLOSED) return;
+
+    if (this.readyState === WebSocket.CONNECTING) {
+      this.readyState = WebSocket.CLOSED;
+      return;
+    }
+
+    if (this.readyState === WebSocket.CLOSING) {
+      if (this._closeReceived && this._isServer) {
+        this.terminate();
+      }
+      return;
+    }
+
+    try {
+      this.readyState = WebSocket.CLOSING;
+      this._closeCode = code;
+      this._closeMessage = data;
+      var mask = !this._isServer;
+      this._sender.close(code, data, mask, (err) => {
+        if (err) this.emit('error', err);
+
+        if (this._closeReceived && this._isServer) {
+          this.terminate();
+        } else {
+          //
+          // Ensure that the connection is cleaned up even when the closing
+          // handshake fails.
+          //
+          clearTimeout(this._closeTimer);
+          this._closeTimer = setTimeout(this._finalize, closeTimeout, true);
+        }
+      });
+    } catch (e) {
+      this.emit('error', e);
+    }
+  }
+
+  /**
+   * Send a ping message.
+   *
+   * @param {*} data The message to send
+   * @param {Object} options Options object
+   * @param {Boolean} options.mask Indicates whether or not to mask `data`
+   * @param {Boolean} dontFailWhenClosed Indicates whether or not to throw an if the connection isn't open
+   * @public
+   */
+  ping (data, options, dontFailWhenClosed) {
+    if (this.readyState !== WebSocket.OPEN) {
+      if (dontFailWhenClosed) return;
+      throw new Error('not opened');
+    }
+
+    options = options || {};
+    if (options.mask === undefined) options.mask = !this._isServer;
+
+    this._sender.ping(data, options);
+  }
+
+  /**
+   * Send a pong message.
+   *
+   * @param {*} data The message to send
+   * @param {Object} options Options object
+   * @param {Boolean} options.mask Indicates whether or not to mask `data`
+   * @param {Boolean} dontFailWhenClosed Indicates whether or not to throw an if the connection isn't open
+   * @public
+   */
+  pong (data, options, dontFailWhenClosed) {
+    if (this.readyState !== WebSocket.OPEN) {
+      if (dontFailWhenClosed) return;
+      throw new Error('not opened');
+    }
+
+    options = options || {};
+    if (options.mask === undefined) options.mask = !this._isServer;
+
+    this._sender.pong(data, options);
+  }
+
+  /**
+   * Send a data message.
+   *
+   * @param {*} data The message to send
+   * @param {Object} options Options object
+   * @param {Boolean} options.compress Specifies whether or not to compress `data`
+   * @param {Boolean} options.binary Specifies whether `data` is binary or text
+   * @param {Boolean} options.fin Specifies whether the fragment is the last one
+   * @param {Boolean} options.mask Specifies whether or not to mask `data`
+   * @param {Function} cb Callback which is executed when data is written out
+   * @public
+   */
+  send (data, options, cb) {
+    if (typeof options === 'function') {
+      cb = options;
+      options = {};
+    }
+
+    if (this.readyState !== WebSocket.OPEN) {
+      if (cb) cb(new Error('not opened'));
+      else throw new Error('not opened');
+      return;
+    }
+
+    if (!data) data = '';
+
+    options = options || {};
+    if (options.fin !== false) options.fin = true;
+
+    if (options.binary === undefined) {
+      options.binary = data instanceof Buffer || data instanceof ArrayBuffer ||
+        ArrayBuffer.isView(data);
+    }
+
+    if (options.mask === undefined) options.mask = !this._isServer;
+    if (options.compress === undefined) options.compress = true;
+    if (!this.extensions[PerMessageDeflate.extensionName]) {
+      options.compress = false;
+    }
+
+    this._sender.send(data, options, cb);
+  }
+
+  /**
+   * Half-close the socket sending a FIN packet.
+   *
+   * @public
+   */
+  terminate () {
+    if (this.readyState === WebSocket.CLOSED) return;
+
+    if (this._socket) {
+      this.readyState = WebSocket.CLOSING;
+
+      try {
+        this._socket.end();
+      } catch (e) {
+        this.finalize(true);
+        return;
+      }
+
+      //
+      // Add a timeout to ensure that the connection is completely cleaned up
+      // within 30 seconds, even if the other peer does not send a FIN packet.
+      //
+      if (this._closeTimer) clearTimeout(this._closeTimer);
+      this._closeTimer = setTimeout(this._finalize, closeTimeout, true);
+    } else if (this.readyState === WebSocket.CONNECTING) {
+      this.finalize(true);
+    }
+  }
+}
+
+WebSocket.CONNECTING = 0;
+WebSocket.OPEN = 1;
+WebSocket.CLOSING = 2;
+WebSocket.CLOSED = 3;
 
 //
 // Add the `onopen`, `onerror`, `onclose`, and `onmessage` attributes.
@@ -375,7 +488,7 @@ function initAsServerClient (req, socket, head, options) {
   this.upgradeReq = req;
   this._isServer = true;
 
-  establishConnection.call(this, socket, head);
+  this.setSocket(socket, head);
 }
 
 /**
@@ -543,7 +656,7 @@ function initAsClient (address, protocols, options) {
 
   req.on('error', (error) => {
     this.emit('error', error);
-    cleanupWebsocketResources.call(this, error);
+    this.finalize(error);
   });
 
   req.on('response', (res) => {
@@ -555,10 +668,10 @@ function initAsClient (address, protocols, options) {
       this.emit('error', error);
     }
 
-    cleanupWebsocketResources.call(this, error);
+    this.finalize(error);
   });
 
-  req.on('upgrade', (res, socket, upgradeHead) => {
+  req.on('upgrade', (res, socket, head) => {
     if (this.readyState === WebSocket.CLOSED) {
       // client closed before server accepted connection
       this.emit('close');
@@ -612,119 +725,9 @@ function initAsClient (address, protocols, options) {
       this.extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
     }
 
-    establishConnection.call(this, socket, upgradeHead);
+    this.setSocket(socket, head);
 
-    // perform cleanup on http resources
     req.removeAllListeners();
     agent = null;
   });
-}
-
-function establishConnection (socket, upgradeHead) {
-  socket.setTimeout(0);
-  socket.setNoDelay();
-
-  this._receiver = new Receiver(this.extensions, this.maxPayload);
-  this._sender = new Sender(socket, this.extensions);
-  this._ultron = new Ultron(socket);
-  this._socket = socket;
-
-  // socket cleanup handlers
-  this._ultron.on('end', cleanupWebsocketResources.bind(this));
-  this._ultron.on('close', cleanupWebsocketResources.bind(this));
-  this._ultron.on('error', cleanupWebsocketResources.bind(this));
-
-  // ensure that the upgradeHead is added to the receiver
-  if (upgradeHead && upgradeHead.length > 0) {
-    socket.unshift(upgradeHead);
-    upgradeHead = null;
-  }
-
-  // subsequent packets are pushed to the receiver
-  this._ultron.on('data', (data) => {
-    this.bytesReceived += data.length;
-    this._receiver.add(data);
-  });
-
-  // receiver event handlers
-  this._receiver.ontext = (data, flags) => this.emit('message', data, flags);
-  this._receiver.onbinary = (data, flags) => {
-    flags.binary = true;
-    this.emit('message', data, flags);
-  };
-  this._receiver.onping = (data, flags) => {
-    this.pong(data, { mask: !this._isServer }, true);
-    this.emit('ping', data, flags);
-  };
-  this._receiver.onpong = (data, flags) => this.emit('pong', data, flags);
-  this._receiver.onclose = (code, data, flags) => {
-    this._closeReceived = true;
-    this.close(code, data);
-  };
-  this._receiver.onerror = (error, errorCode) => {
-    // close the connection when the receiver reports a HyBi error code
-    this.close(errorCode, '');
-    this.emit('error', error);
-  };
-
-  // sender event handlers
-  this._sender.onerror = (error) => {
-    this.close(1002, '');
-    this.emit('error', error);
-  };
-
-  this.readyState = WebSocket.OPEN;
-  this.emit('open');
-}
-
-function cleanupWebsocketResources (error) {
-  if (this.readyState === WebSocket.CLOSED) return;
-
-  this.readyState = WebSocket.CLOSED;
-
-  clearTimeout(this._closeTimer);
-  this._closeTimer = null;
-
-  // If the connection was closed abnormally (with an error), or if
-  // the close control frame was not received then the close code
-  // must default to 1006.
-  if (error || !this._closeReceived) {
-    this._closeCode = 1006;
-  }
-  this.emit('close', this._closeCode || 1000, this._closeMessage || '');
-
-  if (this._socket) {
-    if (this._ultron) this._ultron.destroy();
-    this._socket.on('error', function onerror () {
-      try {
-        this.destroy();
-      } catch (e) {}
-    });
-
-    try {
-      if (!error) this._socket.end();
-      else this._socket.destroy();
-    } catch (e) { /* Ignore termination errors */ }
-
-    this._socket = null;
-    this._ultron = null;
-  }
-
-  if (this._sender) {
-    this._sender = this._sender.onerror = null;
-  }
-
-  if (this._receiver) {
-    this._receiver.cleanup();
-    this._receiver = null;
-  }
-
-  if (this.extensions[PerMessageDeflate.extensionName]) {
-    this.extensions[PerMessageDeflate.extensionName].cleanup();
-  }
-
-  this.extensions = null;
-
-  this.removeAllListeners();
-  this.on('error', function onerror () {}); // catch all errors after this
 }

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -20,13 +20,6 @@ class CustomAgent extends http.Agent {
 
 describe('WebSocket', function () {
   describe('#ctor', function () {
-    it('should return a new instance if called without new', function (done) {
-      const ws = WebSocket('ws://localhost');
-
-      assert.ok(ws instanceof WebSocket);
-      ws.on('error', () => done());
-    });
-
     it('throws an error when using an invalid url', function () {
       assert.throws(
         () => new WebSocket('echo.websocket.org'),


### PR DESCRIPTION
- Refactor `WebSocket` to use the ES6 class syntax.
- Move `cleanupWebsocketResources` and `establishConnection` to `WebSocket.prototype`.
- Rename `establishConnection` to `setSocket` and `cleanupWebsocketResources` to `finalize`.
- Keep `initAsServerClient` and `initAsClient` as completely private API.