### PR TITLE
Remove unnecessary `buildHostHeader` function

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -443,27 +443,6 @@ WebSocket.prototype.addEventListener = EventTarget.addEventListener;
 WebSocket.prototype.removeEventListener = EventTarget.removeEventListener;
 
 module.exports = WebSocket;
-module.exports.buildHostHeader = buildHostHeader;
-
-/**
- * Append port number to Host header, only if specified in the URL and
- * non-default.
- *
- * @param {Boolean} isSecure Specifies whether or not the URL scheme is `wss`
- * @param {String} hostname The hostname portion of the URL
- * @param {Number} port The port portion of the URL
- * @return {String} The field value of the `Host` header
- * @private
- */
-function buildHostHeader (isSecure, hostname, port) {
-  var headerHost = hostname;
-
-  if (headerHost && (isSecure && port !== 443 || !isSecure && port !== 80)) {
-    headerHost = `${headerHost}:${port}`;
-  }
-
-  return headerHost;
-}
 
 /**
  * Initialize a WebSocket server client.
@@ -550,7 +529,6 @@ function initAsClient (address, protocols, options) {
 
   const isSecure = serverUrl.protocol === 'wss:' || serverUrl.protocol === 'https:';
   const key = crypto.randomBytes(16).toString('base64');
-  const port = serverUrl.port || (isSecure ? 443 : 80);
   const httpObj = isSecure ? https : http;
 
   //
@@ -579,10 +557,9 @@ function initAsClient (address, protocols, options) {
 
   const requestOptions = {
     host: serverUrl.hostname,
+    port: serverUrl.port,
     path: '/',
-    port,
     headers: {
-      'Host': buildHostHeader(isSecure, serverUrl.hostname, port),
       'Sec-WebSocket-Version': options.protocolVersion,
       'Sec-WebSocket-Key': key,
       'Connection': 'Upgrade',


### PR DESCRIPTION
The `host` header is already correctly built when the `http.ClientRequest` is created.
If the port number is the default one it is not added to the `host` header field value.