### PR TITLE
Consume all data before emitting the `close` event

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -51,6 +51,8 @@ class Receiver {
     this.messageLength = 0;
     this.fragments = [];
 
+    this.cleanupCallback = null;
+    this.hadError = false;
     this.dead = false;
 
     this.onmessage = noop;
@@ -108,6 +110,21 @@ class Receiver {
   }
 
   /**
+   * Checks if the number of buffered bytes is bigger or equal than `n` and
+   * calls `cleanup` if necessary.
+   *
+   * @param {Number} n The number of bytes to check against
+   * @return {Boolean} `true` if `bufferedBytes >= n`, else `false`
+   * @private
+   */
+  hasBufferedBytes (n) {
+    if (this.bufferedBytes >= n) return true;
+
+    if (this.dead) this.cleanup(this.cleanupCallback);
+    return false;
+  }
+
+  /**
    * Adds new data to the parser.
    *
    * @public
@@ -142,7 +159,7 @@ class Receiver {
    * @private
    */
   start () {
-    if (this.bufferedBytes < 2) return;
+    if (!this.hasBufferedBytes(2)) return;
 
     const buf = this.readBuffer(2);
 
@@ -222,7 +239,7 @@ class Receiver {
    * @private
    */
   getPayloadLength16 () {
-    if (this.bufferedBytes < 2) return;
+    if (!this.hasBufferedBytes(2)) return;
 
     this.payloadLength = this.readBuffer(2).readUInt16BE(0, true);
     this.haveLength();
@@ -234,7 +251,7 @@ class Receiver {
    * @private
    */
   getPayloadLength64 () {
-    if (this.bufferedBytes < 8) return;
+    if (!this.hasBufferedBytes(8)) return;
 
     const buf = this.readBuffer(8);
     const num = buf.readUInt32BE(0, true);
@@ -277,7 +294,7 @@ class Receiver {
    * @private
    */
   getMask () {
-    if (this.bufferedBytes < 4) return;
+    if (!this.hasBufferedBytes(4)) return;
 
     this.mask = this.readBuffer(4);
     this.state = GET_DATA;
@@ -293,7 +310,7 @@ class Receiver {
     var data = EMPTY_BUFFER;
 
     if (this.payloadLength) {
-      if (this.bufferedBytes < this.payloadLength) return;
+      if (!this.hasBufferedBytes(this.payloadLength)) return;
 
       data = this.readBuffer(this.payloadLength);
       if (this.masked) bufferUtil.unmask(data, this.mask);
@@ -319,8 +336,6 @@ class Receiver {
     const extension = this.extensions[PerMessageDeflate.extensionName];
 
     extension.decompress(data, this.fin, (err, buf) => {
-      if (this.dead) return;
-
       if (err) {
         this.error(err, err.closeCode === 1009 ? 1009 : 1007);
         return;
@@ -374,7 +389,7 @@ class Receiver {
     if (this.opcode === 0x08) {
       if (data.length === 0) {
         this.onclose(1000, '', { masked: this.masked });
-        this.cleanup();
+        this.cleanup(this.cleanupCallback);
       } else if (data.length === 1) {
         this.error(new Error('invalid payload length'), 1002);
       } else {
@@ -393,7 +408,7 @@ class Receiver {
         }
 
         this.onclose(code, buf.toString(), { masked: this.masked });
-        this.cleanup();
+        this.cleanup(this.cleanupCallback);
       }
 
       return;
@@ -417,7 +432,8 @@ class Receiver {
    */
   error (err, code) {
     this.onerror(err, code);
-    this.cleanup();
+    this.hadError = true;
+    this.cleanup(this.cleanupCallback);
   }
 
   /**
@@ -466,21 +482,29 @@ class Receiver {
   /**
    * Releases resources used by the receiver.
    *
+   * @param {Function} cb Callback
    * @public
    */
-  cleanup () {
+  cleanup (cb) {
     this.dead = true;
 
-    this.extensions = null;
-    this.fragments = null;
-    this.buffers = null;
-    this.mask = null;
+    if (!this.hadError && this.state === HANDLE_DATA) {
+      this.cleanupCallback = cb;
+    } else {
+      this.extensions = null;
+      this.fragments = null;
+      this.buffers = null;
+      this.mask = null;
 
-    this.onmessage = null;
-    this.onclose = null;
-    this.onerror = null;
-    this.onping = null;
-    this.onpong = null;
+      this.cleanupCallback = null;
+      this.onmessage = null;
+      this.onclose = null;
+      this.onerror = null;
+      this.onping = null;
+      this.onpong = null;
+
+      if (cb) cb();
+    }
   }
 }
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -22,6 +22,7 @@ const Sender = require('./Sender');
 const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 const closeTimeout = 30 * 1000; // Allow 30 seconds to terminate the connection cleanly.
 const protocolVersion = 13;
+const noop = () => {};
 
 /**
  * Class representing a WebSocket.
@@ -54,6 +55,7 @@ class WebSocket extends EventEmitter {
 
     this._finalize = this.finalize.bind(this);
     this._binaryType = 'nodebuffer';
+    this._finalizeCalled = false;
     this._closeMessage = null;
     this._closeTimer = null;
     this._closeCode = null;
@@ -164,15 +166,16 @@ class WebSocket extends EventEmitter {
   }
 
   /**
-   * Clean up and release internal resources and emit the `close` event.
+   * Clean up and release internal resources.
    *
    * @param {(Boolean|Error)} Indicates whether or not an error occurred
    * @private
    */
   finalize (error) {
-    if (this.readyState === WebSocket.CLOSED) return;
+    if (this._finalizeCalled) return;
 
-    this.readyState = WebSocket.CLOSED;
+    this.readyState = WebSocket.CLOSING;
+    this._finalizeCalled = true;
 
     clearTimeout(this._closeTimer);
     this._closeTimer = null;
@@ -183,7 +186,6 @@ class WebSocket extends EventEmitter {
     // 1006.
     //
     if (error) this._closeCode = 1006;
-    this.emit('close', this._closeCode || 1006, this._closeMessage || '');
 
     if (this._socket) {
       this._ultron.destroy();
@@ -203,9 +205,21 @@ class WebSocket extends EventEmitter {
     }
 
     if (this._receiver) {
-      this._receiver.cleanup();
+      this._receiver.cleanup(() => this.emitClose());
       this._receiver = null;
+    } else {
+      this.emitClose();
     }
+  }
+
+  /**
+   * Emit the `close` event.
+   *
+   * @private
+   */
+  emitClose () {
+    this.readyState = WebSocket.CLOSED;
+    this.emit('close', this._closeCode || 1006, this._closeMessage || '');
 
     if (this.extensions[PerMessageDeflate.extensionName]) {
       this.extensions[PerMessageDeflate.extensionName].cleanup();
@@ -214,7 +228,7 @@ class WebSocket extends EventEmitter {
     this.extensions = null;
 
     this.removeAllListeners();
-    this.on('error', function onerror () {}); // catch all errors after this
+    this.on('error', noop); // Catch all errors after this.
   }
 
   /**


### PR DESCRIPTION
This makes `Receiver.prototype.cleanup()` accept an optional callback which is called when all buffered data is consumed or an error occurs.

Using this callback we can handle cases where the parser is decompressing data and the other peer closes the underlying TCP connection. Previously when this happened the buffered data was simply discarded. Now all data should be handled correctly.

Fixes #799 and #923.

This is based and supersedes #840.

@websockets/admin this really needs to be reviewed carefully so when you have time please take a look.