### PR TITLE
Fix ember (browserify) usage correcting dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "ultron": "~1.0.2"
+    "bufferutil": "^1.3.0",
+    "ultron": "~1.0.2",
+    "utf-8-validate": "~2.0.0"
   },
   "devDependencies": {
     "benchmark": "~2.1.2",
-    "bufferutil": "~1.3.0",
     "eslint": "~3.12.0",
     "eslint-config-semistandard": "~7.0.0",
     "eslint-config-standard": "~6.2.1",
     "eslint-plugin-promise": "~3.4.0",
     "eslint-plugin-standard": "~2.0.1",
     "istanbul": "~0.4.5",
-    "mocha": "~3.2.0",
-    "utf-8-validate": "~2.0.0"
+    "mocha": "~3.2.0"
   }
 }


### PR DESCRIPTION
I'm trying to use this module for a library that uses websockets and that must work both from node (command line) and the browser (using ember).

While in node everything works fine, ember is unable to build the dependencies because it lacks those two packages:
* bufferutil
* utf-8-validate

I hence modified the package.json to define those modules as dependencies instead of dev-dependencies.

Since without this patch the package is unusable (at least with ember), I ask for this patch to be accepted upstream :-)