### PR TITLE
Use a boolean instead of an options object

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -320,25 +320,23 @@ receives an `OpenEvent` named "open".
 
 Pause the socket.
 
-### websocket.ping([data[, options[, dontFailWhenClosed]]])
+### websocket.ping([data[, mask[, failSilently]]])
 
 - `data` {Any} The data to send in the ping frame.
-- `options` {Object}
-  - `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults
-    to `true` when `websocket` is not a server client.
-- `dontFailWhenClosed` {Boolean} Specifies whether or not to throw an error if
-  the connection is not open.
+- `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults
+  to `true` when `websocket` is not a server client.
+- `failSilently` {Boolean} Specifies whether or not to throw an error if the
+  connection is not open.
 
 Send a ping.
 
-### websocket.pong([data[, options[, dontFailWhenClosed]]])
+### websocket.pong([data[, mask[, failSilently]]])
 
 - `data` {Any} The data to send in the ping frame.
-- `options` {Object}
-  - `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults
-    to `true` when `websocket` is not a server client.
-- `dontFailWhenClosed` {Boolean} Specifies whether or not to throw an error if
-  the connection is not open.
+- `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults
+  to `true` when `websocket` is not a server client.
+- `failSilently` {Boolean} Specifies whether or not to throw an error if the
+  connection is not open.
 
 Send a pong.
 

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -12,8 +12,6 @@ const PerMessageDeflate = require('./PerMessageDeflate');
 const bufferUtil = require('./BufferUtil').BufferUtil;
 const ErrorCodes = require('./ErrorCodes');
 
-const noop = () => {};
-
 /**
  * HyBi Sender implementation.
  */
@@ -30,7 +28,7 @@ class Sender {
     this.processing = false;
     this.compress = false;
     this._socket = socket;
-    this.onerror = noop;
+    this.onerror = null;
     this.queue = [];
   }
 
@@ -84,15 +82,14 @@ class Sender {
    * Sends a ping message to the other peer.
    *
    * @param {*} data The message to send
-   * @param {Object} options Options object
-   * @param {Boolean} options.mask Specifies whether or not to mask `data`
+   * @param {Boolean} mask Specifies whether or not to mask `data`
    * @public
    */
-  ping (data, options) {
+  ping (data, mask) {
     if (this.perMessageDeflate) {
-      this.enqueue([this.doPing, data, options.mask]);
+      this.enqueue([this.doPing, data, mask]);
     } else {
-      this.doPing(data, options.mask);
+      this.doPing(data, mask);
     }
   }
 
@@ -119,15 +116,14 @@ class Sender {
    * Sends a pong message to the other peer.
    *
    * @param {*} data The message to send
-   * @param {Object} options Options object
-   * @param {Boolean} options.mask Specifies whether or not to mask `data`
+   * @param {Boolean} mask Specifies whether or not to mask `data`
    * @public
    */
-  pong (data, options) {
+  pong (data, mask) {
     if (this.perMessageDeflate) {
-      this.enqueue([this.doPong, data, options.mask]);
+      this.enqueue([this.doPong, data, mask]);
     } else {
-      this.doPong(data, options.mask);
+      this.doPong(data, mask);
     }
   }
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -138,7 +138,7 @@ class WebSocket extends EventEmitter {
     // receiver event handlers
     this._receiver.onmessage = (data, flags) => this.emit('message', data, flags);
     this._receiver.onping = (data, flags) => {
-      this.pong(data, { mask: !this._isServer }, true);
+      this.pong(data, !this._isServer, true);
       this.emit('ping', data, flags);
     };
     this._receiver.onpong = (data, flags) => this.emit('pong', data, flags);
@@ -282,42 +282,36 @@ class WebSocket extends EventEmitter {
    * Send a ping message.
    *
    * @param {*} data The message to send
-   * @param {Object} options Options object
-   * @param {Boolean} options.mask Indicates whether or not to mask `data`
-   * @param {Boolean} dontFailWhenClosed Indicates whether or not to throw an if the connection isn't open
+   * @param {Boolean} mask Indicates whether or not to mask `data`
+   * @param {Boolean} failSilently Indicates whether or not to throw if `readyState` isn't `OPEN`
    * @public
    */
-  ping (data, options, dontFailWhenClosed) {
+  ping (data, mask, failSilently) {
     if (this.readyState !== WebSocket.OPEN) {
-      if (dontFailWhenClosed) return;
+      if (failSilently) return;
       throw new Error('not opened');
     }
 
-    options = options || {};
-    if (options.mask === undefined) options.mask = !this._isServer;
-
-    this._sender.ping(data, options);
+    if (mask === undefined) mask = !this._isServer;
+    this._sender.ping(data, mask);
   }
 
   /**
    * Send a pong message.
    *
    * @param {*} data The message to send
-   * @param {Object} options Options object
-   * @param {Boolean} options.mask Indicates whether or not to mask `data`
-   * @param {Boolean} dontFailWhenClosed Indicates whether or not to throw an if the connection isn't open
+   * @param {Boolean} mask Indicates whether or not to mask `data`
+   * @param {Boolean} failSilently Indicates whether or not to throw if `readyState` isn't `OPEN`
    * @public
    */
-  pong (data, options, dontFailWhenClosed) {
+  pong (data, mask, failSilently) {
     if (this.readyState !== WebSocket.OPEN) {
-      if (dontFailWhenClosed) return;
+      if (failSilently) return;
       throw new Error('not opened');
     }
 
-    options = options || {};
-    if (options.mask === undefined) options.mask = !this._isServer;
-
-    this._sender.pong(data, options);
+    if (mask === undefined) mask = !this._isServer;
+    this._sender.pong(data, mask);
   }
 
   /**

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -70,12 +70,11 @@ describe('Sender', function () {
       });
 
       const array = new Uint8Array([0x68, 0x69]);
-      const options = { mask: false };
 
-      sender.ping(array.buffer, options);
-      sender.ping(array, options);
-      sender.ping('hi', options);
-      sender.ping(10, options);
+      sender.ping(array.buffer, false);
+      sender.ping(array, false);
+      sender.ping('hi', false);
+      sender.ping(10, false);
     });
   });
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -491,7 +491,7 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.on('error', () => {});
-        ws.ping('', {}, true);
+        ws.ping('', true, true);
 
         srv.close(done);
         ws.terminate();
@@ -550,7 +550,7 @@ describe('WebSocket', function () {
 
         const ws = new WebSocket(`ws://localhost:${port}`);
 
-        ws.on('open', () => ws.ping('hi', { mask: true }));
+        ws.on('open', () => ws.ping('hi', true));
       });
     });
   });
@@ -576,7 +576,7 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.on('error', () => {});
-        ws.pong('', {}, true);
+        ws.pong('', true, true);
 
         srv.close(done);
         ws.terminate();
@@ -621,7 +621,7 @@ describe('WebSocket', function () {
 
         const ws = new WebSocket(`ws://localhost:${port}`);
 
-        ws.on('open', () => ws.pong('hi', { mask: true }));
+        ws.on('open', () => ws.pong('hi', true));
       });
     });
   });


### PR DESCRIPTION
With this change `Websocket.prototype.ping()` and `Websocket.prototype.pong()` take a boolean as second argument instead of an options object.

Ping/Pong messages can't be compressed or fragmented and are always binary, so I think it doesn't make sense to use an options object as the only thing which can be (arguably) configured is whether or not to mask data.