### PR TITLE
Unref the socket for a cleaner exit

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -626,7 +626,7 @@ function initAsClient (address, protocols, options) {
   });
 
   req.on('upgrade', (res, socket, head) => {
-    if (socket.unref) socket.unref()
+    if (socket.unref) socket.unref();
     if (this.readyState === WebSocket.CLOSED) {
       // client closed before server accepted connection
       this.emit('close');

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -626,6 +626,7 @@ function initAsClient (address, protocols, options) {
   });
 
   req.on('upgrade', (res, socket, head) => {
+    if (socket.unref) socket.unref()
     if (this.readyState === WebSocket.CLOSED) {
       // client closed before server accepted connection
       this.emit('close');


### PR DESCRIPTION
After hours of trying to figure it out and falling sleeping, I woke up and got the solution.

Related: https://github.com/socketio/engine.io-client/issues/528