### PR TITLE
WebSocket object leakage in WebSocketServer.clients when using WebSocket.onclose = function(..){..}

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -148,6 +148,7 @@ class WebSocket extends EventEmitter {
       this._closeMessage = reason;
       this._closeCode = code;
       this.close(code, reason);
+      this.emit('close');
     };
     this._receiver.onerror = (error, code) => {
       // close the connection when the receiver reports a HyBi error code
@@ -219,6 +220,9 @@ class WebSocket extends EventEmitter {
    */
   emitClose () {
     this.readyState = WebSocket.CLOSED;
+    // emit 'cleanup' before 'close' because close will change attributes 
+    // and closed ws-sockets will not be found 'WebSocketServer.clients'  js-Set collection
+    this.emit('cleanup');
     this.emit('close', this._closeCode || 1006, this._closeMessage || '');
 
     if (this.extensions[PerMessageDeflate.extensionName]) {

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -148,7 +148,6 @@ class WebSocket extends EventEmitter {
       this._closeMessage = reason;
       this._closeCode = code;
       this.close(code, reason);
-      this.emit('close');
     };
     this._receiver.onerror = (error, code) => {
       // close the connection when the receiver reports a HyBi error code

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -219,7 +219,7 @@ class WebSocket extends EventEmitter {
    */
   emitClose () {
     this.readyState = WebSocket.CLOSED;
-    // emit 'cleanup' before 'close' because close will change attributes 
+    // emit 'cleanup' before 'close' because close will change attributes
     // and closed ws-sockets will not be found 'WebSocketServer.clients'  js-Set collection
     this.emit('cleanup');
     this.emit('close', this._closeCode || 1006, this._closeMessage || '');

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -221,7 +221,6 @@ class WebSocket extends EventEmitter {
     this.readyState = WebSocket.CLOSED;
     // emit 'cleanup' before 'close' because close will change attributes
     // and closed ws-sockets will not be found 'WebSocketServer.clients'  js-Set collection
-    this.emit('cleanup');
     this.emit('close', this._closeCode || 1006, this._closeMessage || '');
 
     if (this.extensions[PerMessageDeflate.extensionName]) {
@@ -412,8 +411,10 @@ WebSocket.CLOSED = 3;
      * @public
      */
     get () {
-      const listener = this.listeners(method)[0];
-      return listener ? listener._listener ? listener._listener : listener : undefined;
+	const listeners = this.listeners(method);
+	for (var i = 0; i < listeners.length; i++) {
+	  if (listeners[i]._listener) return listeners[i]._listener;
+	}
     },
     /**
      * Add a listener for the event.
@@ -422,7 +423,11 @@ WebSocket.CLOSED = 3;
      * @public
      */
     set (listener) {
-      this.removeAllListeners(method);
+      const listeners = this.listeners(method);
+      for (var i = 0; i < listeners.length; i++) {
+	/*listeners added outside usage of 'addEventListeners' are not removed*/
+        if (listeners[i]._listener) this.removeListener(method, listeners[i]);
+      }
       this.addEventListener(method, listener);
     }
   });

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -425,7 +425,7 @@ WebSocket.CLOSED = 3;
     set (listener) {
       const listeners = this.listeners(method);
       for (var i = 0; i < listeners.length; i++) {
-        /*listeners added outside usage of 'addEventListeners' are not removed*/
+        /* listeners added outside usage of 'addEventListeners' are not removed */
         if (listeners[i]._listener) this.removeListener(method, listeners[i]);
       }
       this.addEventListener(method, listener);

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -411,10 +411,10 @@ WebSocket.CLOSED = 3;
      * @public
      */
     get () {
-	const listeners = this.listeners(method);
-	for (var i = 0; i < listeners.length; i++) {
-	  if (listeners[i]._listener) return listeners[i]._listener;
-	}
+      const listeners = this.listeners(method);
+      for (var i = 0; i < listeners.length; i++) {
+        if (listeners[i]._listener) return listeners[i]._listener;
+      }
     },
     /**
      * Add a listener for the event.
@@ -425,7 +425,7 @@ WebSocket.CLOSED = 3;
     set (listener) {
       const listeners = this.listeners(method);
       for (var i = 0; i < listeners.length; i++) {
-	/*listeners added outside usage of 'addEventListeners' are not removed*/
+        /*listeners added outside usage of 'addEventListeners' are not removed*/
         if (listeners[i]._listener) this.removeListener(method, listeners[i]);
       }
       this.addEventListener(method, listener);

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -265,7 +265,7 @@ class WebSocketServer extends EventEmitter {
 
     if (this.clients) {
       this.clients.add(client);
-      client.on('close', () => this.clients.delete(client));
+      client.on('cleanup', () => this.clients.delete(client));
     }
 
     socket.removeListener('error', socketError);

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -265,7 +265,7 @@ class WebSocketServer extends EventEmitter {
 
     if (this.clients) {
       this.clients.add(client);
-      client.on('cleanup', () => this.clients.delete(client));
+      client.on('close', () => this.clients.delete(client));
     }
 
     socket.removeListener('error', socketError);


### PR DESCRIPTION
Hi, 
I discovered a leakage in WebSocket.clients when using callbacks like so for WebSocket
```
 ws.onclose = function close(evt) {
           ..
}
```
In the code I discovered that on connection on the server side a callback is registered to remove the peer from the ```WebSocket.clients``` Set

 Unfortunately this hidden callback is removed when using  `ws.onclose = function `  style.

 Since this is a cleanup operation, (after closure of socket) I changed the 'hidden' emit event name to "cleanup".

this will prevent the hidden callback removal when using  `ws.onclose == function` style callback
(Look at how onclose property is defined, in removes all event handlers , so also any hidden "close" event handlers)