### PR TITLE
Use Object.assign() for send() options

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -355,16 +355,18 @@ class WebSocket extends EventEmitter {
     if (typeof data === 'number') data = data.toString();
     else if (!data) data = '';
 
-    options = options || {};
-    if (options.fin !== false) options.fin = true;
-    if (options.binary === undefined) options.binary = typeof data !== 'string';
-    if (options.mask === undefined) options.mask = !this._isServer;
-    if (options.compress === undefined) options.compress = true;
+    const opts = Object.assign({
+      fin: true,
+      binary: typeof data !== 'string',
+      mask: !this._isServer,
+      compress: true
+    }, options);
+
     if (!this.extensions[PerMessageDeflate.extensionName]) {
-      options.compress = false;
+      opts.compress = false;
     }
 
-    this._sender.send(data, options, cb);
+    this._sender.send(data, opts, cb);
   }
 
   /**


### PR DESCRIPTION
This avoids mutating the passed in arguments.

The current behaviour breaks sending if you use the same options object for multiple send() calls. I don't know if anyone relies on the arguments being mutated or in being able to pass in undefined explicitly.