### PR TITLE
Prevent `WebSocket#close()` from triggering an infinite loop

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -263,9 +263,12 @@ class WebSocket extends EventEmitter {
   close (code, data) {
     if (this.readyState === WebSocket.CLOSED) return;
     if (this.readyState === WebSocket.CONNECTING) {
-      this._req.abort();
-      this.emit('error', new Error('closed before the connection is established'));
-      return this.finalize(true);
+      if (this._req && !this._req.aborted) {
+        this._req.abort();
+        this.emit('error', new Error('closed before the connection is established'));
+        this.finalize(true);
+      }
+      return;
     }
 
     if (this.readyState === WebSocket.CLOSING) {
@@ -375,9 +378,12 @@ class WebSocket extends EventEmitter {
   terminate () {
     if (this.readyState === WebSocket.CLOSED) return;
     if (this.readyState === WebSocket.CONNECTING) {
-      this._req.abort();
-      this.emit('error', new Error('closed before the connection is established'));
-      return this.finalize(true);
+      if (this._req && !this._req.aborted) {
+        this._req.abort();
+        this.emit('error', new Error('closed before the connection is established'));
+        this.finalize(true);
+      }
+      return;
     }
 
     if (this._socket) {
@@ -629,6 +635,7 @@ function initAsClient (address, protocols, options) {
   this._req.on('error', (error) => {
     if (this._req.aborted) return;
 
+    this._req = null;
     this.emit('error', error);
     this.finalize(true);
   });
@@ -642,6 +649,8 @@ function initAsClient (address, protocols, options) {
   });
 
   this._req.on('upgrade', (res, socket, head) => {
+    this._req = null;
+
     const digest = crypto.createHash('sha1')
       .update(key + GUID, 'binary')
       .digest('base64');
@@ -686,7 +695,6 @@ function initAsClient (address, protocols, options) {
       this.extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
     }
 
-    this._req = null;
     this.setSocket(socket, head);
   });
 }


### PR DESCRIPTION
This prevents `WebSocket.prototype.close()` from triggering an infinite loop if called from an error listener while connecting.

Refs: https://github.com/websockets/ws/pull/956#issuecomment-272585388.