### PR TITLE
Avoid stack overflow when processing payloads with a large number of fragments

### DIFF
--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -370,7 +370,7 @@ class Receiver {
     }
 
     this.state = START;
-    this.start();
+    process.nextTick(() => this.start());
   }
 
   /**


### PR DESCRIPTION
Sending ~10000 empty fragments in one message can crash the server otherwise.