### PR TITLE
Prevent the parser from triggering a stack overflow

### DIFF
--- a/bench/parser.benchmark.js
+++ b/bench/parser.benchmark.js
@@ -18,7 +18,6 @@ const Receiver = require('../').Receiver;
 //
 Receiver.prototype.cleanup = function () {
   this.state = 0;
-  this.start();
 };
 
 function createBinaryPacket (length) {

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -13,12 +13,14 @@ const ErrorCodes = require('./ErrorCodes');
 
 const EMPTY_BUFFER = Buffer.alloc(0);
 
-const START = 0;
+const GET_INFO = 0;
 const GET_PAYLOAD_LENGTH_16 = 1;
 const GET_PAYLOAD_LENGTH_64 = 2;
-const GET_MASK = 3;
-const GET_DATA = 4;
-const HANDLE_DATA = 5;
+const HAVE_LENGTH = 3;
+const GET_MASK = 4;
+const GET_DATA = 5;
+const HANDLE_DATA = 6;
+const INFLATING = 7;
 
 /**
  * HyBi Receiver implementation.
@@ -59,13 +61,14 @@ class Receiver {
     this.onping = null;
     this.onpong = null;
 
-    this.state = START;
+    this.state = GET_INFO;
   }
 
   /**
    * Consumes bytes from the available buffered data.
    *
    * @param {Number} bytes The number of bytes to consume
+   * @return {Buffer} Consumed bytes
    * @private
    */
   readBuffer (bytes) {
@@ -128,45 +131,55 @@ class Receiver {
 
     this.bufferedBytes += data.length;
     this.buffers.push(data);
+    this.startLoop();
+  }
 
-    switch (this.state) {
-      case START:
-        this.start();
+  /**
+   * Starts the parsing loop.
+   *
+   * @private
+   */
+  startLoop () {
+    while (true) {
+      if (this.state === GET_INFO) {
+        if (!this.getInfo()) break;
+      } else if (this.state === GET_PAYLOAD_LENGTH_16) {
+        if (!this.getPayloadLength16()) break;
+      } else if (this.state === GET_PAYLOAD_LENGTH_64) {
+        if (!this.getPayloadLength64()) break;
+      } else if (this.state === HAVE_LENGTH) {
+        if (!this.haveLength()) break;
+      } else if (this.state === GET_MASK) {
+        if (!this.getMask()) break;
+      } else if (this.state === GET_DATA) {
+        if (!this.getData()) break;
+      } else { // `HANDLE_DATA` or `INFLATING`
         break;
-      case GET_PAYLOAD_LENGTH_16:
-        this.getPayloadLength16();
-        break;
-      case GET_PAYLOAD_LENGTH_64:
-        this.getPayloadLength64();
-        break;
-      case GET_MASK:
-        this.getMask();
-        break;
-      case GET_DATA:
-        this.getData();
+      }
     }
   }
 
   /**
    * Reads the first two bytes of a frame.
    *
+   * @return {Boolean} `true` if the operation is successful, else `false`
    * @private
    */
-  start () {
-    if (!this.hasBufferedBytes(2)) return;
+  getInfo () {
+    if (!this.hasBufferedBytes(2)) return false;
 
     const buf = this.readBuffer(2);
 
     if ((buf[0] & 0x30) !== 0x00) {
       this.error(new Error('RSV2 and RSV3 must be clear'), 1002);
-      return;
+      return false;
     }
 
     const compressed = (buf[0] & 0x40) === 0x40;
 
     if (compressed && !this.extensions[PerMessageDeflate.extensionName]) {
       this.error(new Error('RSV1 must be clear'), 1002);
-      return;
+      return false;
     }
 
     this.fin = (buf[0] & 0x80) === 0x80;
@@ -176,76 +189,75 @@ class Receiver {
     if (this.opcode === 0x00) {
       if (compressed) {
         this.error(new Error('RSV1 must be clear'), 1002);
-        return;
+        return false;
       }
 
       if (!this.fragmented) {
         this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
-        return;
+        return false;
       } else {
         this.opcode = this.fragmented;
       }
     } else if (this.opcode === 0x01 || this.opcode === 0x02) {
       if (this.fragmented) {
         this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
-        return;
+        return false;
       }
 
       this.compressed = compressed;
     } else if (this.opcode > 0x07 && this.opcode < 0x0b) {
       if (!this.fin) {
         this.error(new Error('FIN must be set'), 1002);
-        return;
+        return false;
       }
 
       if (compressed) {
         this.error(new Error('RSV1 must be clear'), 1002);
-        return;
+        return false;
       }
 
       if (this.payloadLength > 0x7d) {
         this.error(new Error('invalid payload length'), 1002);
-        return;
+        return false;
       }
     } else {
       this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
-      return;
+      return false;
     }
 
     if (!this.fin && !this.fragmented) this.fragmented = this.opcode;
 
     this.masked = (buf[1] & 0x80) === 0x80;
 
-    if (this.payloadLength === 126) {
-      this.state = GET_PAYLOAD_LENGTH_16;
-      this.getPayloadLength16();
-    } else if (this.payloadLength === 127) {
-      this.state = GET_PAYLOAD_LENGTH_64;
-      this.getPayloadLength64();
-    } else {
-      this.haveLength();
-    }
+    if (this.payloadLength === 126) this.state = GET_PAYLOAD_LENGTH_16;
+    else if (this.payloadLength === 127) this.state = GET_PAYLOAD_LENGTH_64;
+    else this.state = HAVE_LENGTH;
+
+    return true;
   }
 
   /**
    * Gets extended payload length (7+16).
    *
+   * @return {Boolean} `true` if payload length has been read, else `false`
    * @private
    */
   getPayloadLength16 () {
-    if (!this.hasBufferedBytes(2)) return;
+    if (!this.hasBufferedBytes(2)) return false;
 
     this.payloadLength = this.readBuffer(2).readUInt16BE(0, true);
-    this.haveLength();
+    this.state = HAVE_LENGTH;
+    return true;
   }
 
   /**
    * Gets extended payload length (7+64).
    *
+   * @return {Boolean} `true` if payload length has been read, else `false`
    * @private
    */
   getPayloadLength64 () {
-    if (!this.hasBufferedBytes(8)) return;
+    if (!this.hasBufferedBytes(8)) return false;
 
     const buf = this.readBuffer(8);
     const num = buf.readUInt32BE(0, true);
@@ -256,68 +268,72 @@ class Receiver {
     //
     if (num > Math.pow(2, 53 - 32) - 1) {
       this.error(new Error('max payload size exceeded'), 1009);
-      return;
+      return false;
     }
 
     this.payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4, true);
-    this.haveLength();
+    this.state = HAVE_LENGTH;
+    return true;
   }
 
   /**
    * Payload length has been read.
    *
+   * @return {Boolean} `false` if payload length exceeds `maxPayload`, else `true`
    * @private
    */
   haveLength () {
     if (this.opcode < 0x08 && this.maxPayloadExceeded(this.payloadLength)) {
-      return;
+      return false;
     }
 
-    if (this.masked) {
-      this.state = GET_MASK;
-      this.getMask();
-    } else {
-      this.state = GET_DATA;
-      this.getData();
-    }
+    if (this.masked) this.state = GET_MASK;
+    else this.state = GET_DATA;
+    return true;
   }
 
   /**
    * Reads mask bytes.
    *
+   * @return {Boolean} `true` if the mask has been read, else `false`
    * @private
    */
   getMask () {
-    if (!this.hasBufferedBytes(4)) return;
+    if (!this.hasBufferedBytes(4)) return false;
 
     this.mask = this.readBuffer(4);
     this.state = GET_DATA;
-    this.getData();
+    return true;
   }
 
   /**
    * Reads data bytes.
    *
+   * @return {Boolean} `true` if the data bytes have been read, else `false`
    * @private
    */
   getData () {
     var data = EMPTY_BUFFER;
 
     if (this.payloadLength) {
-      if (!this.hasBufferedBytes(this.payloadLength)) return;
+      if (!this.hasBufferedBytes(this.payloadLength)) return false;
 
       data = this.readBuffer(this.payloadLength);
       if (this.masked) bufferUtil.unmask(data, this.mask);
     }
 
+    this.state = HANDLE_DATA;
+
     if (this.opcode > 0x07) {
       this.controlMessage(data);
     } else if (this.compressed) {
-      this.state = HANDLE_DATA;
+      this.state = INFLATING;
       this.decompress(data);
     } else if (this.pushFragment(data)) {
       this.dataMessage();
     }
+
+    return true;
   }
 
   /**
@@ -336,6 +352,7 @@ class Receiver {
       }
 
       if (this.pushFragment(buf)) this.dataMessage();
+      if (this.state === GET_INFO) this.startLoop();
     });
   }
 
@@ -369,8 +386,7 @@ class Receiver {
       }
     }
 
-    this.state = START;
-    this.start();
+    this.state = GET_INFO;
   }
 
   /**
@@ -413,8 +429,7 @@ class Receiver {
     if (this.opcode === 0x09) this.onping(data, flags);
     else this.onpong(data, flags);
 
-    this.state = START;
-    this.start();
+    this.state = GET_INFO;
   }
 
   /**
@@ -482,7 +497,7 @@ class Receiver {
   cleanup (cb) {
     this.dead = true;
 
-    if (!this.hadError && this.state === HANDLE_DATA) {
+    if (!this.hadError && this.state === INFLATING) {
       this.cleanupCallback = cb;
     } else {
       this.extensions = null;

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -307,6 +307,25 @@ describe('Receiver', function () {
     });
   });
 
+  it('can parse a buffer with thousands of frames', function (done) {
+    const buf = Buffer.allocUnsafe(40000);
+
+    for (let i = 0; i < buf.length; i += 2) {
+      buf[i] = 0x81;
+      buf[i + 1] = 0x00;
+    }
+
+    const p = new Receiver();
+    let counter = 0;
+
+    p.onmessage = function (data) {
+      assert.strictEqual(data, '');
+      if (++counter === 20000) done();
+    };
+
+    p.add(buf);
+  });
+
   it('resets `totalPayloadLength` only on final frame (unfragmented)', function () {
     const p = new Receiver({}, 10);
     let message;
@@ -699,7 +718,7 @@ describe('Receiver', function () {
       p.add(frame);
       p.add(frame);
 
-      assert.strictEqual(p.state, 5);
+      assert.strictEqual(p.state, 7);
       assert.strictEqual(p.bufferedBytes, frame.length);
 
       p.cleanup(() => {
@@ -731,7 +750,7 @@ describe('Receiver', function () {
       p.add(textFrame);
       p.add(closeFrame);
 
-      assert.strictEqual(p.state, 5);
+      assert.strictEqual(p.state, 7);
       assert.strictEqual(p.bufferedBytes, textFrame.length + closeFrame.length);
 
       p.cleanup(() => {
@@ -763,7 +782,7 @@ describe('Receiver', function () {
       p.add(textFrame);
       p.add(invalidFrame);
 
-      assert.strictEqual(p.state, 5);
+      assert.strictEqual(p.state, 7);
       assert.strictEqual(p.bufferedBytes, textFrame.length + invalidFrame.length);
 
       p.cleanup(() => {
@@ -798,7 +817,7 @@ describe('Receiver', function () {
       p.add(textFrame);
       p.add(incompleteFrame);
 
-      assert.strictEqual(p.state, 5);
+      assert.strictEqual(p.state, 7);
       assert.strictEqual(p.bufferedBytes, incompleteFrame.length);
 
       p.cleanup(() => {


### PR DESCRIPTION
This makes the parser work with buffers containing thousands of frames.

Fixes #990.

cc: @Nibbler999 