### PR TITLE
Security: Use crypto.randomBytes, not Math.random

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -6,6 +6,7 @@
 
 var events = require('events')
   , util = require('util')
+  , crypto = require('crypto')
   , EventEmitter = events.EventEmitter
   , ErrorCodes = require('./ErrorCodes')
   , bufferUtil = require('./BufferUtil').BufferUtil
@@ -315,5 +316,5 @@ function getArrayBuffer(data) {
 }
 
 function getRandomMask() {
-  return require('crypto').randomBytes(4);
+  return crypto.randomBytes(4);
 }

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -315,10 +315,5 @@ function getArrayBuffer(data) {
 }
 
 function getRandomMask() {
-  return new Buffer([
-    ~~(Math.random() * 255),
-    ~~(Math.random() * 255),
-    ~~(Math.random() * 255),
-    ~~(Math.random() * 255)
-  ]);
+  return require('crypto').randomBytes(4);
 }


### PR DESCRIPTION
This is a backport of https://github.com/websockets/ws/pull/832/files to v1.x, so that projects that still need to support Node < 4 can get the security patch.