### PR TITLE
Write to the socket as soon as possible

### DIFF
--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -288,7 +288,8 @@ class PerMessageDeflate {
 
   compress (data, fin, callback) {
     if (!data || data.length === 0) {
-      return callback(null, EMPTY_BLOCK);
+      process.nextTick(callback, null, EMPTY_BLOCK);
+      return;
     }
 
     var endpoint = this._isServer ? 'server' : 'client';

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -29,8 +29,8 @@ class Sender {
     this.firstFragment = true;
     this.compress = false;
 
-    this.processing = false;
     this.bufferedBytes = 0;
+    this.deflating = false;
     this.queue = [];
 
     this.onerror = null;
@@ -78,8 +78,6 @@ class Sender {
       fin: true,
       mask
     }, cb);
-
-    if (this.perMessageDeflate) this.continue();
   }
 
   /**
@@ -126,8 +124,6 @@ class Sender {
       readOnly,
       mask
     });
-
-    if (this.perMessageDeflate) this.continue();
   }
 
   /**
@@ -174,8 +170,6 @@ class Sender {
       readOnly,
       mask
     });
-
-    if (this.perMessageDeflate) this.continue();
   }
 
   /**
@@ -256,10 +250,10 @@ class Sender {
   dispatch (data, options, cb) {
     if (!options.compress) {
       this.frameAndSend(data, options, cb);
-      this.continue();
       return;
     }
 
+    this.deflating = true;
     this.perMessageDeflate.compress(data, options.fin, (err, buf) => {
       if (err) {
         if (cb) cb(err);
@@ -269,7 +263,8 @@ class Sender {
 
       options.readOnly = false;
       this.frameAndSend(buf, options, cb);
-      this.continue();
+      this.deflating = false;
+      this.dequeue();
     });
   }
 
@@ -349,32 +344,17 @@ class Sender {
   }
 
   /**
-   * Executes a queued send operation.
+   * Executes queued send operations.
    *
    * @private
    */
   dequeue () {
-    if (this.processing) return;
+    while (!this.deflating && this.queue.length) {
+      const params = this.queue.shift();
 
-    const params = this.queue.shift();
-    if (!params) return;
-
-    if (params[1]) this.bufferedBytes -= params[1].length;
-    this.processing = true;
-
-    params[0].apply(this, params.slice(1));
-  }
-
-  /**
-   * Signals the completion of a send operation.
-   *
-   * @private
-   */
-  continue () {
-    process.nextTick(() => {
-      this.processing = false;
-      this.dequeue();
-    });
+      if (params[1]) this.bufferedBytes -= params[1].length;
+      params[0].apply(this, params.slice(1));
+    }
   }
 
   /**

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -55,7 +55,7 @@ class Sender {
     buf.writeUInt16BE(code || 1000, 0, true);
     if (buf.length > 2) buf.write(data, 2);
 
-    if (this.perMessageDeflate) {
+    if (this.deflating) {
       this.enqueue([this.doClose, buf, mask, cb]);
     } else {
       this.doClose(buf, mask, cb);
@@ -101,7 +101,7 @@ class Sender {
       }
     }
 
-    if (this.perMessageDeflate) {
+    if (this.deflating) {
       this.enqueue([this.doPing, data, mask, readOnly]);
     } else {
       this.doPing(data, mask, readOnly);
@@ -147,7 +147,7 @@ class Sender {
       }
     }
 
-    if (this.perMessageDeflate) {
+    if (this.deflating) {
       this.enqueue([this.doPong, data, mask, readOnly]);
     } else {
       this.doPong(data, mask, readOnly);
@@ -214,14 +214,20 @@ class Sender {
     if (options.fin) this.firstFragment = true;
 
     if (this.perMessageDeflate) {
-      this.enqueue([this.dispatch, data, {
+      const opts = {
         compress: this.compress,
         mask: options.mask,
         fin: options.fin,
         readOnly,
         opcode,
         rsv1
-      }, cb]);
+      };
+
+      if (this.deflating) {
+        this.enqueue([this.dispatch, data, opts, cb]);
+      } else {
+        this.dispatch(data, opts, cb);
+      }
     } else {
       this.frameAndSend(data, {
         mask: options.mask,
@@ -366,7 +372,6 @@ class Sender {
   enqueue (params) {
     if (params[1]) this.bufferedBytes += params[1].length;
     this.queue.push(params);
-    this.dequeue();
   }
 }
 

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -143,7 +143,9 @@ describe('WebSocket', function () {
 
       it('takes into account the data in the sender queue', function (done) {
         const wss = new WebSocketServer({ port: ++port }, () => {
-          const ws = new WebSocket(`ws://localhost:${port}`);
+          const ws = new WebSocket(`ws://localhost:${port}`, {
+            perMessageDeflate: { threshold: 0 }
+          });
 
           ws.on('open', () => {
             ws.send('foo');


### PR DESCRIPTION
When permessage-deflate is enabled the outbound throughput performance is throttled by `process.nextTick()`. If the are `n` messages in the queue, it will take `n` ticks before all messages are dispatched even when compression is skipped.

This patch prevents `process.nextTick()` from being used by slightly changing the handling logic of the queued messages.