### PR TITLE
Receiver support binaryType ‘fragments’ …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 npm-debug.log
+.vscode/

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -277,7 +277,10 @@ Register an event listener emulating the `EventTarget` interface.
 - {String}
 
 A string indicating the type of binary data being transmitted by the connection.
-This should be either "nodebuffer" or "arraybuffer". Defaults to "nodebuffer".
+This should be either "nodebuffer" or "arraybuffer" or "fragments". Defaults to "nodebuffer".
+Type "fragments" will emit the array of fragments as received from the sender,
+without copyfull concatenation, which is useful for the performance of binary protocols 
+transfering large messages with multiple fragments.
 
 ### websocket.bufferedAmount
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -3,3 +3,5 @@
 exports.GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 exports.EMPTY_BUFFER = Buffer.alloc(0);
 exports.NOOP = () => {};
+
+exports.BINARY_TYPES = ['nodebuffer', 'arraybuffer', 'fragments'];

--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -28,7 +28,7 @@ class MessageEvent extends Event {
   /**
    * Create a new `MessageEvent`.
    *
-   * @param {(String|Buffer|ArrayBuffer)} data The received data
+   * @param {(String|Buffer|ArrayBuffer|Buffer[])} data The received data
    * @param {Boolean} isBinary Specifies if `data` is binary
    * @param {WebSocket} target A reference to the target to which the event was dispatched
    */
@@ -100,9 +100,6 @@ const EventTarget = {
     if (typeof listener !== 'function') return;
 
     function onMessage (data, flags) {
-      if (flags.binary && this.binaryType === 'arraybuffer') {
-        data = new Uint8Array(data).buffer;
-      }
       listener.call(this, new MessageEvent(data, !!flags.binary, this));
     }
 

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -28,10 +28,12 @@ class Receiver {
    *
    * @param {Object} extensions An object containing the negotiated extensions
    * @param {Number} maxPayload The maximum allowed message length
+   * @param {String} binaryType The type for binary data, see constants.BINARY_TYPES
    */
-  constructor (extensions, maxPayload) {
+  constructor (extensions, maxPayload, binaryType) {
     this.extensions = extensions || {};
     this.maxPayload = maxPayload | 0;
+    this.binaryType = binaryType || constants.BINARY_TYPES[0];
 
     this.bufferedBytes = 0;
     this.buffers = [];
@@ -352,20 +354,28 @@ class Receiver {
    */
   dataMessage () {
     if (this.fin) {
-      const buf = this.fragments.length > 1
-        ? Buffer.concat(this.fragments, this.messageLength)
-        : this.fragments.length === 1
-          ? this.fragments[0]
-          : constants.EMPTY_BUFFER;
-
+      const fragments = this.fragments;
+      const messageLength = this.messageLength;
       this.totalPayloadLength = 0;
-      this.fragments.length = 0;
+      this.fragments = [];
       this.messageLength = 0;
       this.fragmented = 0;
 
       if (this.opcode === 2) {
-        this.onmessage(buf, { masked: this.masked, binary: true });
+        var data;
+
+        if (this.binaryType === 'nodebuffer') {
+          data = bufferFromFragments(fragments, messageLength);
+        } else if (this.binaryType === 'arraybuffer') {
+          data = new Uint8Array(bufferFromFragments(fragments, messageLength)).buffer;
+        } else {
+          data = fragments;
+        }
+
+        this.onmessage(data, { masked: this.masked, binary: true });
       } else {
+        const buf = bufferFromFragments(fragments, messageLength);
+
         if (!isValidUTF8(buf)) {
           this.error(new Error('invalid utf8 sequence'), 1007);
           return;
@@ -507,6 +517,22 @@ class Receiver {
       if (cb) cb();
     }
   }
+}
+
+/**
+ * Make a buffer from a list of fragments.
+ * Optimized for the common case of a single fragment in order to
+ * avoid copyfull concat and simply return the fragment buffer.
+ *
+ * @param {Buffer[]} fragments
+ * @param {Number} messageLength
+ * @return {Buffer}
+ * @private
+ */
+function bufferFromFragments (fragments, messageLength) {
+  if (fragments.length === 1) return fragments[0];
+  if (fragments.length > 1) return Buffer.concat(fragments, messageLength);
+  return constants.EMPTY_BUFFER;
 }
 
 module.exports = Receiver;

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -53,7 +53,7 @@ class WebSocket extends EventEmitter {
     this.protocol = '';
 
     this._finalize = this.finalize.bind(this);
-    this._binaryType = 'nodebuffer';
+    this._binaryType = constants.BINARY_TYPES[0];
     this._finalizeCalled = false;
     this._closeMessage = null;
     this._closeTimer = null;
@@ -98,10 +98,17 @@ class WebSocket extends EventEmitter {
   }
 
   set binaryType (type) {
-    if (type === 'arraybuffer' || type === 'nodebuffer') {
-      this._binaryType = type;
-    } else {
-      throw new SyntaxError('unsupported binaryType: must be either "nodebuffer" or "arraybuffer"');
+    // silently ignore unsupported types
+    if (constants.BINARY_TYPES.indexOf(type) < 0) {
+      return;
+    }
+
+    this._binaryType = type;
+
+    // update the receiver if already created,
+    // if not then it will take the value once created
+    if (this._receiver) {
+      this._receiver.binaryType = type;
     }
   }
 
@@ -116,7 +123,7 @@ class WebSocket extends EventEmitter {
     socket.setTimeout(0);
     socket.setNoDelay();
 
-    this._receiver = new Receiver(this.extensions, this.maxPayload);
+    this._receiver = new Receiver(this.extensions, this.maxPayload, this.binaryType);
     this._sender = new Sender(socket, this.extensions);
     this._ultron = new Ultron(socket);
     this._socket = socket;


### PR DESCRIPTION
- emit message fragments array to avoid copyfull concat

Note:
binaryType used to affect before only in WHATWG API emulation
and the optional conversion to ArrayBuffer was done inside MessageEvent.
However in this change the receiver emits messages according to binaryType
so now also EventEmitter listeners added with on(‘message’, data => {})
will get the data according to binaryType.