### PR TITLE
Avoid using `Buffer.concat()`

### DIFF
--- a/lib/BufferUtil.js
+++ b/lib/BufferUtil.js
@@ -6,27 +6,32 @@
  * MIT Licensed
  */
 
+/**
+ * Merges an array of buffers into a new buffer.
+ *
+ * @param {Buffer[]} list The array of buffers to concat
+ * @param {Number} totalLength The total length of buffers in the list
+ * @return {Buffer} The resulting buffer
+ * @public
+ */
+const concat = (list, totalLength) => {
+  const target = Buffer.allocUnsafe(totalLength);
+  var offset = 0;
+
+  for (var i = 0; i < list.length; i++) {
+    const buf = list[i];
+    buf.copy(target, offset);
+    offset += buf.length;
+  }
+
+  return target;
+};
+
 try {
   const bufferUtil = require('bufferutil');
 
-  module.exports = bufferUtil.BufferUtil || bufferUtil;
+  module.exports = Object.assign({ concat }, bufferUtil.BufferUtil || bufferUtil);
 } catch (e) {
-  /**
-   * Merges an array of buffers into a target buffer.
-   *
-   * @param {Buffer} target The target buffer
-   * @param {Buffer[]} buffers The array of buffers to merge
-   * @public
-   */
-  const merge = (target, buffers) => {
-    var offset = 0;
-    for (var i = 0; i < buffers.length; i++) {
-      const buf = buffers[i];
-      buf.copy(target, offset);
-      offset += buf.length;
-    }
-  };
-
   /**
    * Masks a buffer using the given mask.
    *
@@ -58,5 +63,5 @@ try {
     }
   };
 
-  module.exports = { merge, mask, unmask };
+  module.exports = { concat, mask, unmask };
 }

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -2,6 +2,8 @@
 
 const zlib = require('zlib');
 
+const bufferUtil = require('./BufferUtil');
+
 const AVAILABLE_WINDOW_BITS = [8, 9, 10, 11, 12, 13, 14, 15];
 const DEFAULT_WINDOW_BITS = 15;
 const DEFAULT_MEM_LEVEL = 8;
@@ -9,7 +11,7 @@ const TRAILER = Buffer.from([0x00, 0x00, 0xff, 0xff]);
 const EMPTY_BLOCK = Buffer.from([0x00]);
 
 /**
- * Per-message Compression Extensions implementation
+ * Per-message Deflate implementation.
  */
 class PerMessageDeflate {
   constructor (options, isServer, maxPayload) {
@@ -22,12 +24,15 @@ class PerMessageDeflate {
     this.threshold = this._options.threshold === undefined ? 1024 : this._options.threshold;
   }
 
+  static get extensionName () {
+    return 'permessage-deflate';
+  }
+
   /**
    * Create extension parameters offer
    *
-   * @api public
+   * @public
    */
-
   offer () {
     var params = {};
     if (this._options.serverNoContextTakeover) {
@@ -50,7 +55,7 @@ class PerMessageDeflate {
   /**
    * Accept extension offer
    *
-   * @api public
+   * @public
    */
   accept (paramsList) {
     paramsList = this.normalizeParams(paramsList);
@@ -69,7 +74,7 @@ class PerMessageDeflate {
   /**
    * Releases all resources used by the extension
    *
-   * @api public
+   * @public
    */
   cleanup () {
     if (this._inflate) {
@@ -93,9 +98,8 @@ class PerMessageDeflate {
   /**
    * Accept extension offer from client
    *
-   * @api private
+   * @private
    */
-
   acceptAsServer (paramsList) {
     var accepted = {};
     var result = paramsList.some((params) => {
@@ -147,9 +151,8 @@ class PerMessageDeflate {
   /**
    * Accept extension response from server
    *
-   * @api privaye
+   * @private
    */
-
   acceptAsClient (paramsList) {
     var params = paramsList[0];
     if (this._options.clientNoContextTakeover != null) {
@@ -172,9 +175,8 @@ class PerMessageDeflate {
   /**
    * Normalize extensions parameters
    *
-   * @api private
+   * @private
    */
-
   normalizeParams (paramsList) {
     return paramsList.map((params) => {
       Object.keys(params).forEach((key) => {
@@ -276,26 +278,25 @@ class PerMessageDeflate {
     this._inflate.flush(() => {
       cleanup();
       if (err) callback(err);
-      else callback(null, Buffer.concat(buffers, totalLength));
+      else callback(null, bufferUtil.concat(buffers, totalLength));
     });
   }
 
   /**
    * Compress message
    *
-   * @api public
+   * @public
    */
-
   compress (data, fin, callback) {
     if (!data || data.length === 0) {
       process.nextTick(callback, null, EMPTY_BLOCK);
       return;
     }
 
-    var endpoint = this._isServer ? 'server' : 'client';
+    const endpoint = this._isServer ? 'server' : 'client';
 
     if (!this._deflate) {
-      var maxWindowBits = this.params[endpoint + '_max_window_bits'];
+      const maxWindowBits = this.params[`${endpoint}_max_window_bits`];
       this._deflate = zlib.createDeflateRaw({
         flush: zlib.Z_SYNC_FLUSH,
         windowBits: typeof maxWindowBits === 'number' ? maxWindowBits : DEFAULT_WINDOW_BITS,
@@ -304,19 +305,30 @@ class PerMessageDeflate {
     }
     this._deflate.writeInProgress = true;
 
+    var totalLength = 0;
     const buffers = [];
 
-    const onData = (data) => buffers.push(data);
+    const onData = (data) => {
+      totalLength += data.length;
+      buffers.push(data);
+    };
+
     const onError = (err) => {
       cleanup();
       callback(err);
     };
+
     const cleanup = () => {
       if (!this._deflate) return;
+
       this._deflate.removeListener('error', onError);
       this._deflate.removeListener('data', onData);
       this._deflate.writeInProgress = false;
-      if ((fin && this.params[endpoint + '_no_context_takeover']) || this._deflate.pendingClose) {
+
+      if (
+        (fin && this.params[`${endpoint}_no_context_takeover`]) ||
+        this._deflate.pendingClose
+      ) {
         this._deflate.close();
         this._deflate = null;
       }
@@ -326,15 +338,11 @@ class PerMessageDeflate {
     this._deflate.write(data);
     this._deflate.flush(zlib.Z_SYNC_FLUSH, () => {
       cleanup();
-      var data = Buffer.concat(buffers);
-      if (fin) {
-        data = data.slice(0, data.length - 4);
-      }
+      var data = bufferUtil.concat(buffers, totalLength);
+      if (fin) data = data.slice(0, data.length - 4);
       callback(null, data);
     });
   }
 }
-
-PerMessageDeflate.extensionName = 'permessage-deflate';
 
 module.exports = PerMessageDeflate;

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -532,7 +532,7 @@ module.exports = Receiver;
  */
 function toBuffer (fragments, messageLength) {
   if (fragments.length === 1) return fragments[0];
-  if (fragments.length > 1) return Buffer.concat(fragments, messageLength);
+  if (fragments.length > 1) return bufferUtil.concat(fragments, messageLength);
   return constants.EMPTY_BUFFER;
 }
 


### PR DESCRIPTION
This patch adds a new function to merge an array of buffers and replaces all occurrences of `Buffer.concat()` with it.

The reason for this change is that `Buffer.concat()` [checks](https://github.com/nodejs/node/blob/87a039d721b7e9fd73365774ac3e27166e4e1f6e/lib/buffer.js#L333) that every element in the array is an instance of `Buffer` and this makes it perform worse.