### PR TITLE
Make `WebSocket#terminate()` destroy the socket

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -406,11 +406,11 @@ Resume the socket
 - `callback` {Function} An optional callback which is invoked when `data` is
   written out.
 
-Sends `data` through the connection.
+Send `data` through the connection.
 
 ### websocket.terminate()
 
-Send a FIN packet to the other peer.
+Forcibly close the connection.
 
 ### websocket.upgradeReq
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -276,7 +276,7 @@ class WebSocket extends EventEmitter {
     }
 
     if (this.readyState === WebSocket.CLOSING) {
-      if (this._closeCode) this.terminate();
+      if (this._closeCode && this._socket) this._socket.end();
       return;
     }
 
@@ -284,9 +284,8 @@ class WebSocket extends EventEmitter {
     this._sender.close(code, data, !this._isServer, (err) => {
       if (err) this.emit('error', err);
 
-      if (this._closeCode) {
-        this.terminate();
-      } else {
+      if (this._socket) {
+        if (this._closeCode) this._socket.end();
         //
         // Ensure that the connection is cleaned up even when the closing
         // handshake fails.
@@ -391,17 +390,7 @@ class WebSocket extends EventEmitter {
       return;
     }
 
-    if (this._socket) {
-      this.readyState = WebSocket.CLOSING;
-      this._socket.end();
-
-      //
-      // Add a timeout to ensure that the connection is completely cleaned up
-      // within 30 seconds, even if the other peer does not send a FIN packet.
-      //
-      clearTimeout(this._closeTimer);
-      this._closeTimer = setTimeout(this._finalize, closeTimeout, true);
-    }
+    this.finalize(true);
   }
 }
 


### PR DESCRIPTION
Currently `WebSocket.prototype.terminate()` only sends a FIN packet to the other peer. If `allowHalfOpen` is `true` and the other peer does not call `socket.end()` the connection will only be closed when the timeout [expires](https://github.com/websockets/ws/blob/4a605b9853a36ce53332f3cad87127b47d4d1030/lib/WebSocket.js#L403).

This patch makes `WebSocket.prototype.terminate()` use `socket.destroy()` so the connection is closed immediately even if the other peer fails to work properly.

Fixes #891.