### PR TITLE
Error message for unsupported protcol version

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -21,7 +21,8 @@ const Receiver = require('./Receiver');
 const Sender = require('./Sender');
 
 const closeTimeout = 30 * 1000; // Allow 30 seconds to terminate the connection cleanly.
-const protocolVersion = 13;
+const protocolVersions = [8, 13];
+const protocolVersion = protocolVersions[1];
 
 /**
  * Class representing a WebSocket.
@@ -527,8 +528,11 @@ function initAsClient (address, protocols, options) {
     ca: null
   }, options);
 
-  if (options.protocolVersion !== 8 && options.protocolVersion !== 13) {
-    throw new Error('unsupported protocol version');
+  if (protocolVersions.indexOf(options.protocolVersion) === -1) {
+    throw new Error(
+      `unsupported protocol version: ${options.protocolVersion} ` +
+      `(supported versions: ${protocolVersions.join(', ')})`
+    );
   }
 
   this.protocolVersion = options.protocolVersion;

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -51,7 +51,7 @@ describe('WebSocket', function () {
 
       assert.throws(
         () => new WebSocket('ws://localhost', options),
-        /^Error: unsupported protocol version$/
+        /^Error: unsupported protocol version: 1000 \(supported versions: 8, 13\)$/
       );
     });
 


### PR DESCRIPTION
I was playing with making a websocket server and connecting to it using `wscat`, so I did: `wscat -c ws://0.0.0.0 -p 3000` and I got:

> Error: unsupported protocol version

That made me think my webserver was wrong when in fact `-p` is the protocol version and not the port, e.g. `wscat -c ws://0.0.0.0:3000` works.

So I improved the error message:

> Error: unsupported protocol version 3000 (supported versions: 8, 13)