### PR TITLE
Change "const client of" to "let client of"

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -104,7 +104,7 @@ class WebSocketServer extends EventEmitter {
     // Terminate all associated clients.
     //
     if (this.clients) {
-      for (const client of this.clients) client.terminate();
+      for (let client of this.clients) client.terminate();
     }
 
     const server = this._server;


### PR DESCRIPTION
All but the most recent versions of firefox explode on the
use of for (const variable of ...). Switching declaration to
let solves it.

My team discovered this after updating npm modules of a
project which makes use of Autobahn.js.