### PR TITLE
Add support for Node.js 4.1.0 - 4.4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ node_js:
   - "7"
   - "6"
   - "4"
+  - "4.1.0"
 after_success:
   - "npm install coveralls@2 && nyc report --reporter=text-lcov | coveralls"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
     - nodejs_version: "7"
     - nodejs_version: "6"
     - nodejs_version: "4"
+    - nodejs_version: "4.1.0"
 platform:
   - x86
   - x64

--- a/bench/parser.benchmark.js
+++ b/bench/parser.benchmark.js
@@ -6,11 +6,15 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const benchmark = require('benchmark');
 const crypto = require('crypto');
 
 const util = require('../test/hybi-util');
-const Receiver = require('../').Receiver;
+const WebSocket = require('..');
+
+const Receiver = WebSocket.Receiver;
+const Buffer = safeBuffer.Buffer;
 
 //
 // Override the `cleanup` method to make the "close message" test work as

--- a/bench/speed.js
+++ b/bench/speed.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const cluster = require('cluster');
 
-const WebSocket = require('../');
+const WebSocket = require('..');
 
+const Buffer = safeBuffer.Buffer;
 const port = 8181;
 
 if (cluster.isMaster) {

--- a/lib/BufferUtil.js
+++ b/lib/BufferUtil.js
@@ -1,10 +1,14 @@
-'use strict';
-
 /*!
  * ws: a node.js websocket client
  * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
  * MIT Licensed
  */
+
+'use strict';
+
+const safeBuffer = require('safe-buffer');
+
+const Buffer = safeBuffer.Buffer;
 
 /**
  * Merges an array of buffers into a new buffer.

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
+
+const Buffer = safeBuffer.Buffer;
+
 exports.BINARY_TYPES = ['nodebuffer', 'arraybuffer', 'fragments'];
 exports.GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 exports.EMPTY_BUFFER = Buffer.alloc(0);

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -1,14 +1,17 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const zlib = require('zlib');
 
 const bufferUtil = require('./BufferUtil');
 
+const Buffer = safeBuffer.Buffer;
+
 const AVAILABLE_WINDOW_BITS = [8, 9, 10, 11, 12, 13, 14, 15];
-const DEFAULT_WINDOW_BITS = 15;
-const DEFAULT_MEM_LEVEL = 8;
 const TRAILER = Buffer.from([0x00, 0x00, 0xff, 0xff]);
 const EMPTY_BLOCK = Buffer.from([0x00]);
+const DEFAULT_WINDOW_BITS = 15;
+const DEFAULT_MEM_LEVEL = 8;
 
 /**
  * Per-message Deflate implementation.

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -6,11 +6,15 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
+
 const PerMessageDeflate = require('./PerMessageDeflate');
 const isValidUTF8 = require('./Validation');
 const bufferUtil = require('./BufferUtil');
 const ErrorCodes = require('./ErrorCodes');
 const constants = require('./Constants');
+
+const Buffer = safeBuffer.Buffer;
 
 const GET_INFO = 0;
 const GET_PAYLOAD_LENGTH_16 = 1;

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -6,11 +6,14 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const crypto = require('crypto');
 
 const PerMessageDeflate = require('./PerMessageDeflate');
 const bufferUtil = require('./BufferUtil');
 const ErrorCodes = require('./ErrorCodes');
+
+const Buffer = safeBuffer.Buffer;
 
 /**
  * HyBi Sender implementation.

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const EventEmitter = require('events');
 const crypto = require('crypto');
 const Ultron = require('ultron');
@@ -16,6 +17,8 @@ const PerMessageDeflate = require('./PerMessageDeflate');
 const Extensions = require('./Extensions');
 const constants = require('./Constants');
 const WebSocket = require('./WebSocket');
+
+const Buffer = safeBuffer.Buffer;
 
 /**
  * Class representing a WebSocket server.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "safe-buffer": "~5.0.1",
     "ultron": "~1.1.0"
   },
   "devDependencies": {

--- a/test/PerMessageDeflate.test.js
+++ b/test/PerMessageDeflate.test.js
@@ -1,9 +1,12 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 
 const PerMessageDeflate = require('../lib/PerMessageDeflate');
 const Extensions = require('../lib/Extensions');
+
+const Buffer = safeBuffer.Buffer;
 
 describe('PerMessageDeflate', function () {
   describe('#offer', function () {

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 const crypto = require('crypto');
 
@@ -7,6 +8,8 @@ const PerMessageDeflate = require('../lib/PerMessageDeflate');
 const Receiver = require('../lib/Receiver');
 const Sender = require('../lib/Sender');
 const util = require('./hybi-util');
+
+const Buffer = safeBuffer.Buffer;
 
 describe('Receiver', function () {
   it('can parse unmasked text message', function (done) {

--- a/test/Sender.test.js
+++ b/test/Sender.test.js
@@ -1,9 +1,12 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 
 const PerMessageDeflate = require('../lib/PerMessageDeflate');
 const Sender = require('../lib/Sender');
+
+const Buffer = safeBuffer.Buffer;
 
 describe('Sender', function () {
   describe('.frame', function () {

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 
 const isValidUTF8 = require('../lib/Validation');
+
+const Buffer = safeBuffer.Buffer;
 
 describe('Validation', function () {
   describe('isValidUTF8', function () {

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 const crypto = require('crypto');
 const https = require('https');
@@ -11,6 +12,7 @@ const fs = require('fs');
 const constants = require('../lib/Constants');
 const WebSocket = require('..');
 
+const Buffer = safeBuffer.Buffer;
 const WebSocketServer = WebSocket.Server;
 let port = 20000;
 

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 const crypto = require('crypto');
 const https = require('https');
@@ -11,6 +12,7 @@ const fs = require('fs');
 
 const WebSocket = require('..');
 
+const Buffer = safeBuffer.Buffer;
 const WebSocketServer = WebSocket.Server;
 let port = 8000;
 

--- a/test/hybi-util.js
+++ b/test/hybi-util.js
@@ -6,6 +6,10 @@
 
 'use strict';
 
+const safeBuffer = require('safe-buffer');
+
+const Buffer = safeBuffer.Buffer;
+
 /**
  * Performs hybi07+ type masking.
  */


### PR DESCRIPTION
It seems that in some cases upgrading to v2 is not possible due to the minimum required Node.js version (v4.5.0). See for example the discussions in https://github.com/maxogden/websocket-stream/pull/106 and https://github.com/maxogden/websocket-stream/issues/108.

This patch makes `ws@2` works with all v4 versions.

It is tested in v4.1.0 because the previous release v4.0.0 has known bugs and tests fail.