### PR TITLE
WebSocketServer path as callback function

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -133,7 +133,15 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   shouldHandle (req) {
-    if (this.options.path && url.parse(req.url).pathname !== this.options.path) {
+    if (!this.options.path) {
+      return true;
+    }
+
+    if (typeof this.options.path === 'function') {
+      return this.path(req);
+    }
+
+    if (url.parse(req.url).pathname !== this.options.path) {
       return false;
     }
 

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -327,6 +327,16 @@ describe('WebSocketServer', function () {
 
       assert.strictEqual(wss.shouldHandle({ url: '/bar' }), false);
     });
+
+    it('returns true for custom handler', function () {
+      const wss = new WebSocketServer({
+        noServer: true,
+        path: function (req) {
+          return req.url === '/bar';
+        }});
+
+      assert.strictEqual(wss.shouldHandle({ url: '/bar' }), true);
+    });
   });
 
   describe('#handleUpgrade', function () {


### PR DESCRIPTION
Hi everybody,

this pull request changes the behaviour for the path attribute on the WebSocketServer. The path can also be a callback function to check the request. In my case for example a path like `/some/:key/path` can be used to create sockets for variable resources.

For example:

```` 
  ...
    this._pattern = new require('url-patter')('/some/:key/path)
  ...
    let customShouldHandle (req) {
      const url = require('url').parse(req.url).pathname
      const match = this._pattern.match(url)

      if (!match) {
        return false
      }

      if (!req.params) {
        req.params = {}
      }
      req.params.id = match.id
      return true
  }

  ...
  let server = new WebSocket.Server({ 
    server: httpServer, 
    path: this.customShouldHandle.bind(this) 
  })
  ...
````