### PR TITLE
Added a 'browser' field in package.json to ignore unused modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "mocha": "~3.2.0",
     "nyc": "~10.2.0",
     "utf-8-validate": "~3.0.0"
+  },
+  "browser": {
+    "utf-8-validate": false,
+    "bufferutil": false
   }
 }


### PR DESCRIPTION
I was having warnings when using webpack to bundle some code that used `ws` in the client. I checked that `ws` was causing the warnings and I also found the issues #659, #719 and #985 closed in the repo. At least one of them was using webpack and other browserify.

Searching about how to ignore a specific module when bundling, I found [this post][1], and it just solved the issues. There are no warnings after including those lines in the package.json

[1]: https://github.com/defunctzombie/package-browser-field-spec