### PR TITLE
Make all hooks have access to the upgrade request

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -51,10 +51,11 @@ if `verifyClient` is provided with two arguments then those are:
 
 
 If `handleProtocols` is not set then the handshake is automatically accepted,
-otherwise the function takes a single argument:
+otherwise the function takes two arguments:
 
 - `protocols` {Array} The list of WebSocket subprotocols indicated by the
   client in the `Sec-WebSocket-Protocol` header.
+- `request` {http.IncomingMessage} The client HTTP GET request.
 
 If returned value is `false` then the handshake is rejected with the HTTP 401
 status code, otherwise the returned value sets the value of the
@@ -100,6 +101,7 @@ Emitted when an error occurs on the underlying server.
 ### Event: 'headers'
 
 - `headers` {Array}
+- `request` {http.IncomingMessage}
 
 Emitted before the response headers are written to the socket as part of the
 handshake. This allows you to inspect/modify the headers before they are sent.

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -168,7 +168,7 @@ class WebSocketServer extends EventEmitter {
     // Optionally call external protocol selection handler.
     //
     if (this.options.handleProtocols) {
-      protocol = this.options.handleProtocols(protocol);
+      protocol = this.options.handleProtocols(protocol, req);
       if (protocol === false) return abortConnection(socket, 401);
     } else {
       protocol = protocol[0];
@@ -252,11 +252,11 @@ class WebSocketServer extends EventEmitter {
     //
     // Allow external modification/inspection of handshake headers.
     //
-    this.emit('headers', headers);
+    this.emit('headers', headers, req);
 
     socket.write(headers.concat('', '').join('\r\n'));
 
-    const client = new WebSocket([req, socket, head], {
+    const client = new WebSocket([req, socket, head], null, {
       maxPayload: this.options.maxPayload,
       protocolVersion: version,
       extensions,


### PR DESCRIPTION
This adds the upgrade request to the argument list when emitting the `headers` event and also pass it as second argument to the `handleProtocols()` hook.

Closes #787
Fixes #783
Fixes #683
Fixes #525