### PR TITLE
Prevent `Sender.frame()` from being deoptimized

### DIFF
--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -140,11 +140,11 @@ class Sender {
    */
   doClose (data, mask, cb) {
     this.sendFrame(Sender.frame(data, {
-      readOnly: false,
-      opcode: 0x08,
-      rsv1: false,
       fin: true,
-      mask
+      rsv1: false,
+      opcode: 0x08,
+      mask,
+      readOnly: false
     }), cb);
   }
 
@@ -186,11 +186,11 @@ class Sender {
    */
   doPing (data, mask, readOnly) {
     this.sendFrame(Sender.frame(data, {
-      opcode: 0x09,
-      rsv1: false,
       fin: true,
-      readOnly,
-      mask
+      rsv1: false,
+      opcode: 0x09,
+      mask,
+      readOnly
     }));
   }
 
@@ -232,11 +232,11 @@ class Sender {
    */
   doPong (data, mask, readOnly) {
     this.sendFrame(Sender.frame(data, {
-      opcode: 0x0a,
-      rsv1: false,
       fin: true,
-      readOnly,
-      mask
+      rsv1: false,
+      opcode: 0x0a,
+      mask,
+      readOnly
     }));
   }
 
@@ -283,26 +283,25 @@ class Sender {
 
     if (this.perMessageDeflate) {
       const opts = {
-        compress: this.compress,
-        mask: options.mask,
         fin: options.fin,
-        readOnly,
+        rsv1,
         opcode,
-        rsv1
+        mask: options.mask,
+        readOnly
       };
 
       if (this.deflating) {
-        this.enqueue([this.dispatch, data, opts, cb]);
+        this.enqueue([this.dispatch, data, this.compress, opts, cb]);
       } else {
-        this.dispatch(data, opts, cb);
+        this.dispatch(data, this.compress, opts, cb);
       }
     } else {
       this.sendFrame(Sender.frame(data, {
-        mask: options.mask,
         fin: options.fin,
         rsv1: false,
-        readOnly,
-        opcode
+        opcode,
+        mask: options.mask,
+        readOnly
       }), cb);
     }
   }
@@ -311,18 +310,18 @@ class Sender {
    * Dispatches a data message.
    *
    * @param {Buffer} data The message to send
+   * @param {Boolean} compress Specifies whether or not to compress `data`
    * @param {Object} options Options object
    * @param {Number} options.opcode The opcode
    * @param {Boolean} options.readOnly Specifies whether `data` can be modified
    * @param {Boolean} options.fin Specifies whether or not to set the FIN bit
-   * @param {Boolean} options.compress Specifies whether or not to compress `data`
    * @param {Boolean} options.mask Specifies whether or not to mask `data`
    * @param {Boolean} options.rsv1 Specifies whether or not to set the RSV1 bit
    * @param {Function} cb Callback
    * @private
    */
-  dispatch (data, options, cb) {
-    if (!options.compress) {
+  dispatch (data, compress, options, cb) {
+    if (!compress) {
       this.sendFrame(Sender.frame(data, options), cb);
       return;
     }


### PR DESCRIPTION
`Sender.frame()` is deoptimized on both Node.js 7.9.0 (V8 5.5) and Node.js master (V8 5.7):

```
[deoptimizing (DEOPT eager): begin 0x18d18fffc341 <JS Function frame (SharedFunctionInfo 0x363deeaa5fd9)> (opt #47) @6, FP to SP delta: 152, caller sp: 0x7fff5fbf5fb8]
            ;;; deoptimize at 1690: wrong map
  reading input frame frame => node=30, args=3, height=7; inputs:
      0: 0x18d18fffc341 ; [fp - 16] 0x18d18fffc341 <JS Function frame (SharedFunctionInfo 0x363deeaa5fd9)>
      1: 0x2a9eba4c7501 ; [fp + 32] 0x2a9eba4c7501 <JS Function Sender (SharedFunctionInfo 0x363deeaa5f11)>
      2: 0x3f42cc2561c9 ; rbx 0x3f42cc2561c9 <an Uint8Array with map 0x271baad2c9f1>
      3: 0x3f42cc256451 ; r8 0x3f42cc256451 <an Object with map 0x271baad5ba11>
      4: 0x18d18fffaa19 ; [fp - 24] 0x18d18fffaa19 <FixedArray[5]>
      5: 0x29b138d02351 ; (literal 13) 0x29b138d02351 <the hole>
      6: 0x29b138d02311 ; (literal 14) 0x29b138d02311 <undefined>
      7: 0x29b138d02311 ; (literal 14) 0x29b138d02311 <undefined>
      8: 0x29b138d02351 ; (literal 13) 0x29b138d02351 <the hole>
      9: 0x29b138d02351 ; (literal 13) 0x29b138d02351 <the hole>
     10: 0x29b138d023b1 ; rcx 0x29b138d023b1 <true>
  translating frame frame => node=30, height=48
    0x7fff5fbf5fb0: [top + 96] <- 0x2a9eba4c7501 ;  0x2a9eba4c7501 <JS Function Sender (SharedFunctionInfo 0x363deeaa5f11)>  (input #1)
    0x7fff5fbf5fa8: [top + 88] <- 0x3f42cc2561c9 ;  0x3f42cc2561c9 <an Uint8Array with map 0x271baad2c9f1>  (input #2)
    0x7fff5fbf5fa0: [top + 80] <- 0x3f42cc256451 ;  0x3f42cc256451 <an Object with map 0x271baad5ba11>  (input #3)
    -------------------------
    0x7fff5fbf5f98: [top + 72] <- 0x19af8f30f671 ;  caller's pc
    0x7fff5fbf5f90: [top + 64] <- 0x7fff5fbf5fe0 ;  caller's fp
    0x7fff5fbf5f88: [top + 56] <- 0x18d18fffaa19 ;  context    0x18d18fffaa19 <FixedArray[5]>  (input #4)
    0x7fff5fbf5f80: [top + 48] <- 0x18d18fffc341 ;  function    0x18d18fffc341 <JS Function frame (SharedFunctionInfo 0x363deeaa5fd9)>  (input #0)
    -------------------------
    0x7fff5fbf5f78: [top + 40] <- 0x29b138d02351 ;  0x29b138d02351 <the hole>  (input #5)
    0x7fff5fbf5f70: [top + 32] <- 0x29b138d02311 ;  0x29b138d02311 <undefined>  (input #6)
    0x7fff5fbf5f68: [top + 24] <- 0x29b138d02311 ;  0x29b138d02311 <undefined>  (input #7)
    0x7fff5fbf5f60: [top + 16] <- 0x29b138d02351 ;  0x29b138d02351 <the hole>  (input #8)
    0x7fff5fbf5f58: [top + 8] <- 0x29b138d02351 ;  0x29b138d02351 <the hole>  (input #9)
    0x7fff5fbf5f50: [top + 0] <- 0x29b138d023b1 ;  0x29b138d023b1 <true>  (input #10)
```

This patch seems to fix the issue.