### PR TITLE
#1081: Add headers event to WebSocket.

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -226,6 +226,15 @@ human-readable string explaining why the connection has been closed.
 Emitted when an error occurs. Errors from the underlying `net.Socket` are
 forwarded here.
 
+### Event: 'headers'
+
+- `headers` {Object}
+- `response` {http.IncomingMessage}
+
+Emitted when response headers are received from the server as part of the
+handshake.  This allows you to read headers from the server, for example
+'set-cookie' headers.
+
 ### Event: 'message'
 
 - `data` {String|Buffer}

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -655,6 +655,8 @@ function initAsClient (address, protocols, options) {
   this._req.on('upgrade', (res, socket, head) => {
     this._req = null;
 
+    this.emit('headers', res.headers, res);
+
     const digest = crypto.createHash('sha1')
       .update(key + constants.GUID, 'binary')
       .digest('base64');

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -333,9 +333,8 @@ describe('WebSocket', function () {
       const wss = new WebSocketServer({ port: ++port }, () => {
         const ws = new WebSocket(`ws://localhost:${port}`);
         ws.on('headers', (headers, res) => {
-          assert.equal(headers, res.headers);
-          wss.close();
-          done();
+          assert.strictEqual(headers, res.headers);
+          wss.close(done);
         });
       });
     });

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -328,6 +328,17 @@ describe('WebSocket', function () {
 
       wss.on('connection', (client) => client.pong());
     });
+
+    it('emits a headers event', function (done) {
+      const wss = new WebSocketServer({ port: ++port }, () => {
+        const ws = new WebSocket(`ws://localhost:${port}`);
+        ws.on('headers', (headers, res) => {
+          assert.equal(headers, res.headers);
+          wss.close();
+          done();
+        });
+      });
+    });
   });
 
   describe('connection establishing', function () {


### PR DESCRIPTION
Adds headers event.

The only thing that's slightly weird about this is that WebSocketServer emits an array of headers, and this emits an object of headers.  We could emit the [rawHeaders](https://nodejs.org/api/http.html#http_message_rawheaders) here, and then they'd match... But most people probably want the headers object anyways.