### PR TITLE
Remove unnecessary events

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -85,7 +85,6 @@ class WebSocketServer extends EventEmitter {
       this._ultron.on('error', (err) => this.emit('error', err));
       this._ultron.on('upgrade', (req, socket, head) => {
         this.handleUpgrade(req, socket, head, (client) => {
-          this.emit(`connection${req.url}`, client);
           this.emit('connection', client);
         });
       });

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -105,20 +105,6 @@ describe('WebSocketServer', function () {
       });
     });
 
-    it('emits path specific connection event', function (done) {
-      const server = http.createServer();
-
-      server.listen(++port, () => {
-        const wss = new WebSocketServer({ server });
-        const ws = new WebSocket(`ws://localhost:${port}/endpointName`);
-
-        wss.on('connection/endpointName', (ws) => {
-          wss.close();
-          server.close(done);
-        });
-      });
-    });
-
     it('will not crash when it receives an unhandled opcode', function (done) {
       const wss = new WebSocketServer({ port: ++port });
 


### PR DESCRIPTION
The canonical `connection` event is sufficient as the URL is exposed via `ws.upgradeReq.url`.