### PR TITLE
Remove the `flags` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ ws.on('open', function open() {
   ws.send('something');
 });
 
-ws.on('message', function incoming(data, flags) {
-  // flags.binary will be set if a binary data is received.
-  // flags.masked will be set if the data was masked.
+ws.on('message', function incoming(data) {
+  console.log(data);
 });
 ```
 
@@ -232,8 +231,8 @@ ws.on('close', function close() {
   console.log('disconnected');
 });
 
-ws.on('message', function incoming(data, flags) {
-  console.log(`Roundtrip time: ${Date.now() - data} ms`, flags);
+ws.on('message', function incoming(data) {
+  console.log(`Roundtrip time: ${Date.now() - data} ms`);
 
   setTimeout(function timeout() {
     ws.send(Date.now());

--- a/bench/speed.js
+++ b/bench/speed.js
@@ -17,7 +17,7 @@ if (cluster.isMaster) {
   }, () => cluster.fork());
 
   wss.on('connection', (ws) => {
-    ws.on('message', (data, flags) => ws.send(data, { binary: flags.binary || false }));
+    ws.on('message', (data) => ws.send(data));
   });
 
   cluster.on('exit', () => wss.close());

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -238,9 +238,6 @@ handshake.  This allows you to read headers from the server, for example
 ### Event: 'message'
 
 - `data` {String|Buffer}
-- `flags` {Object}
-  - `binary` {Boolean} Specifies if `data` is binary.
-  - `masked` {Boolean} Specifies if `data` was masked.
 
 Emitted when a message is received from the server.
 
@@ -251,18 +248,12 @@ Emitted when the connection is established.
 ### Event: 'ping'
 
 - `data` {Buffer}
-- `flags` {Object}
-  - `binary` {Boolean} Specifies if `data` is binary.
-  - `masked` {Boolean} Specifies if `data` was masked.
 
 Emitted when a ping is received from the server.
 
 ### Event: 'pong'
 
 - `data` {Buffer}
-- `flags` {Object}
-  - `binary` {Boolean} Specifies if `data` is binary.
-  - `masked` {Boolean} Specifies if `data` was masked.
 
 Emitted when a pong is received from the server.
 

--- a/examples/fileapi/server.js
+++ b/examples/fileapi/server.js
@@ -60,8 +60,8 @@ wss.on('connection', function (ws) {
 
   var filesReceived = 0;
   var currentFile = null;
-  ws.on('message', function (data, flags) {
-    if (!flags.binary) {
+  ws.on('message', function (data) {
+    if (typeof data === 'string') {
       currentFile = JSON.parse(data);
       // note: a real-world app would want to sanity check the data
     } else {

--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -29,13 +29,11 @@ class MessageEvent extends Event {
    * Create a new `MessageEvent`.
    *
    * @param {(String|Buffer|ArrayBuffer|Buffer[])} data The received data
-   * @param {Boolean} isBinary Specifies if `data` is binary
    * @param {WebSocket} target A reference to the target to which the event was dispatched
    */
-  constructor (data, isBinary, target) {
+  constructor (data, target) {
     super('message', target);
 
-    this.binary = isBinary; // non-standard.
     this.data = data;
   }
 }
@@ -99,8 +97,8 @@ const EventTarget = {
   addEventListener (method, listener) {
     if (typeof listener !== 'function') return;
 
-    function onMessage (data, flags) {
-      listener.call(this, new MessageEvent(data, !!flags.binary, this));
+    function onMessage (data) {
+      listener.call(this, new MessageEvent(data, this));
     }
 
     function onClose (code, message) {

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -377,7 +377,7 @@ class Receiver {
           data = fragments;
         }
 
-        this.onmessage(data, { masked: this.masked, binary: true });
+        this.onmessage(data);
       } else {
         const buf = toBuffer(fragments, messageLength);
 
@@ -386,7 +386,7 @@ class Receiver {
           return;
         }
 
-        this.onmessage(buf.toString(), { masked: this.masked });
+        this.onmessage(buf.toString());
       }
     }
 
@@ -402,7 +402,7 @@ class Receiver {
   controlMessage (data) {
     if (this.opcode === 0x08) {
       if (data.length === 0) {
-        this.onclose(1000, '', { masked: this.masked });
+        this.onclose(1000, '');
         this.loop = false;
         this.cleanup(this.cleanupCallback);
       } else if (data.length === 1) {
@@ -422,7 +422,7 @@ class Receiver {
           return;
         }
 
-        this.onclose(code, buf.toString(), { masked: this.masked });
+        this.onclose(code, buf.toString());
         this.loop = false;
         this.cleanup(this.cleanupCallback);
       }
@@ -430,10 +430,8 @@ class Receiver {
       return;
     }
 
-    const flags = { masked: this.masked, binary: true };
-
-    if (this.opcode === 0x09) this.onping(data, flags);
-    else this.onpong(data, flags);
+    if (this.opcode === 0x09) this.onping(data);
+    else this.onpong(data);
 
     this.state = GET_INFO;
   }

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -143,12 +143,12 @@ class WebSocket extends EventEmitter {
     });
 
     // receiver event handlers
-    this._receiver.onmessage = (data, flags) => this.emit('message', data, flags);
-    this._receiver.onping = (data, flags) => {
+    this._receiver.onmessage = (data) => this.emit('message', data);
+    this._receiver.onping = (data) => {
       this.pong(data, !this._isServer, true);
-      this.emit('ping', data, flags);
+      this.emit('ping', data);
     };
-    this._receiver.onpong = (data, flags) => this.emit('pong', data, flags);
+    this._receiver.onpong = (data) => this.emit('pong', data);
     this._receiver.onclose = (code, reason) => {
       this._closeMessage = reason;
       this._closeCode = code;

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -674,8 +674,7 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.on('open', () => ws.send(array, { compress: false }));
-        ws.on('message', (msg, flags) => {
-          assert.ok(flags.binary);
+        ws.on('message', (msg) => {
           assert.ok(msg.equals(Buffer.from(array.buffer)));
           wss.close(done);
         });
@@ -691,7 +690,7 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.on('open', () => ws.send('hi'));
-        ws.on('message', (message, flags) => {
+        ws.on('message', (message) => {
           assert.strictEqual(message, 'hi');
           wss.close(done);
         });
@@ -750,8 +749,7 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.on('open', () => ws.send(partial, { binary: true }));
-        ws.on('message', (message, flags) => {
-          assert.ok(flags.binary);
+        ws.on('message', (message) => {
           assert.ok(message.equals(buf));
           wss.close(done);
         });
@@ -768,8 +766,7 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.on('open', () => ws.send(buf, { binary: true }));
-        ws.on('message', (message, flags) => {
-          assert.ok(flags.binary);
+        ws.on('message', (message) => {
           assert.ok(message.equals(buf));
           wss.close(done);
         });
@@ -792,7 +789,6 @@ describe('WebSocket', function () {
 
         ws.on('open', () => ws.send(array.buffer));
         ws.onmessage = (event) => {
-          assert.ok(event.binary);
           assert.ok(event.data.equals(Buffer.from(array.buffer)));
           wss.close(done);
         };
@@ -811,7 +807,6 @@ describe('WebSocket', function () {
         ws.on('open', () => ws.send(buf));
 
         ws.onmessage = (event) => {
-          assert.ok(event.binary);
           assert.ok(event.data.equals(buf));
           wss.close(done);
         };
@@ -877,9 +872,8 @@ describe('WebSocket', function () {
       });
 
       wss.on('connection', (ws) => {
-        ws.on('message', (message, flags) => {
+        ws.on('message', (message) => {
           assert.strictEqual(message, 'hi');
-          assert.ok(!flags.masked);
           wss.close(done);
         });
       });
@@ -893,9 +887,8 @@ describe('WebSocket', function () {
       });
 
       wss.on('connection', (ws) => {
-        ws.on('message', (message, flags) => {
+        ws.on('message', (message) => {
           assert.strictEqual(message, 'hi');
-          assert.ok(flags.masked);
           wss.close(done);
         });
       });
@@ -915,9 +908,8 @@ describe('WebSocket', function () {
       });
 
       wss.on('connection', (ws) => {
-        ws.on('message', (message, flags) => {
+        ws.on('message', (message) => {
           assert.ok(message.equals(Buffer.from(array.buffer)));
-          assert.ok(flags.binary);
           wss.close(done);
         });
       });
@@ -937,10 +929,8 @@ describe('WebSocket', function () {
       });
 
       wss.on('connection', (ws) => {
-        ws.on('message', (message, flags) => {
+        ws.on('message', (message) => {
           assert.ok(message.equals(Buffer.from(array.buffer)));
-          assert.ok(flags.binary);
-          assert.ok(flags.masked);
           wss.close(done);
         });
       });
@@ -1493,13 +1483,12 @@ describe('WebSocket', function () {
       wss.on('connection', (client) => client.send('hi'));
     });
 
-    it('should pass binary data as a node.js Buffer by default', function (done) {
+    it('should pass binary data as a Node.js Buffer by default', function (done) {
       const wss = new WebSocketServer({ port: ++port }, () => {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
         ws.onmessage = (evt) => {
           assert.ok(Buffer.isBuffer(evt.data));
-          assert.ok(evt.binary);
           wss.close(done);
         };
       });
@@ -1515,7 +1504,6 @@ describe('WebSocket', function () {
 
         ws.onmessage = (evt) => {
           assert.ok(evt.data instanceof ArrayBuffer);
-          assert.ok(evt.binary);
           wss.close(done);
         };
       });
@@ -1655,7 +1643,7 @@ describe('WebSocket', function () {
       const wss = new WebSocketServer({ server });
 
       wss.on('connection', (ws) => {
-        ws.on('message', (message, flags) => {
+        ws.on('message', (message) => {
           assert.strictEqual(message, 'foobar');
           server.close(done);
           wss.close();
@@ -1691,8 +1679,7 @@ describe('WebSocket', function () {
         });
 
         ws.on('open', () => ws.send(buf));
-        ws.on('message', (message, flags) => {
-          assert.strictEqual(flags.binary, true);
+        ws.on('message', (message) => {
           assert.ok(buf.equals(message));
 
           server.close(done);

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -904,7 +904,7 @@ describe('WebSocketServer', function () {
       const wss = new WebSocketServer({ port: ++port }, () => {
         const ws = new WebSocket(`ws://localhost:${port}`);
 
-        ws.on('message', (message, flags) => ws.send(message));
+        ws.on('message', (message) => ws.send(message));
       });
 
       wss.on('connection', (client) => {


### PR DESCRIPTION
The `flags` object specifies whether the received data is binary or not and whether it was masked or not. This object is actually redundant and therefore removed in this commit as the spec requires client-sent frames to be masked and server-sent frame to be unmasked.

The `typeof` operator can be used to check whether the received data is binary or not.