### PR TITLE
Remove the `upgradeReq` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ app.use(function (req, res) {
 const server = http.createServer(app);
 const wss = new WebSocket.Server({ server });
 
-wss.on('connection', function connection(ws) {
-  const location = url.parse(ws.upgradeReq.url, true);
+wss.on('connection', function connection(ws, req) {
+  const location = url.parse(req.url, true);
   // You might use location.query.access_token to authenticate or share sessions
-  // or ws.upgradeReq.headers.cookie (see http://stackoverflow.com/a/16395220/151312)
+  // or req.headers.cookie (see http://stackoverflow.com/a/16395220/151312)
 
   ws.on('message', function incoming(message) {
     console.log('received: %s', message);
@@ -280,8 +280,8 @@ const WebSocket = require('ws');
 
 const wss = new WebSocket.Server({ port: 8080 });
 
-wss.on('connection', function connection(ws) {
-  const ip = ws.upgradeReq.connection.remoteAddress;
+wss.on('connection', function connection(ws, req) {
+  const ip = req.connection.remoteAddress;
 });
 ```
 
@@ -289,8 +289,8 @@ When the server runs behing a proxy like NGINX, the de-facto standard is to use
 the `X-Forwarded-For` header.
 
 ```js
-wss.on('connection', function connection(ws) {
-  const ip = ws.upgradeReq.headers['x-forwarded-for'];
+wss.on('connection', function connection(ws, req) {
+  const ip = req.headers['x-forwarded-for'];
 });
 ```
 

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -89,8 +89,11 @@ provided.
 ### Event: 'connection'
 
 - `socket` {WebSocket}
+- `request` {http.IncomingMessage}
 
-Emitted when the handshake is complete. `socket` is an instance of `WebSocket`.
+Emitted when the handshake is complete. `request` is the http GET request sent
+by the client. Useful for parsing authority headers, cookie headers, and other
+information.
 
 ### Event: 'error'
 
@@ -422,13 +425,6 @@ Send `data` through the connection.
 ### websocket.terminate()
 
 Forcibly close the connection.
-
-### websocket.upgradeReq
-
-- {http.IncomingMessage}
-
-The http GET request sent by the client. Useful for parsing authority headers,
-cookie headers, and other information. This is only available for server clients.
 
 ### websocket.url
 

--- a/examples/express-session-parse/index.js
+++ b/examples/express-session-parse/index.js
@@ -63,14 +63,12 @@ const wss = new WebSocket.Server({
   server
 });
 
-wss.on('connection', (ws) => {
+wss.on('connection', (ws, req) => {
   ws.on('message', (message) => {
-    const session = ws.upgradeReq.session;
-
     //
     // Here we can now use session parameters.
     //
-    console.log(`WS message ${message} from user ${session.userId}`);
+    console.log(`WS message ${message} from user ${req.session.userId}`);
   });
 });
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -65,7 +65,7 @@ class WebSocket extends EventEmitter {
     this._ultron = null;
 
     if (Array.isArray(address)) {
-      initAsServerClient.call(this, address[0], address[1], address[2], options);
+      initAsServerClient.call(this, address[0], address[1], options);
     } else {
       initAsClient.call(this, address, protocols, options);
     }
@@ -455,13 +455,12 @@ module.exports = WebSocket;
  * @param {String} options.protocol The chosen subprotocol
  * @private
  */
-function initAsServerClient (req, socket, head, options) {
+function initAsServerClient (socket, head, options) {
   this.protocolVersion = options.protocolVersion;
   this.extensions = options.extensions;
   this.maxPayload = options.maxPayload;
   this.protocol = options.protocol;
 
-  this.upgradeReq = req;
   this._isServer = true;
 
   this.setSocket(socket, head);

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -85,7 +85,7 @@ class WebSocketServer extends EventEmitter {
       this._ultron.on('error', (err) => this.emit('error', err));
       this._ultron.on('upgrade', (req, socket, head) => {
         this.handleUpgrade(req, socket, head, (client) => {
-          this.emit('connection', client);
+          this.emit('connection', client, req);
         });
       });
     }
@@ -255,7 +255,7 @@ class WebSocketServer extends EventEmitter {
 
     socket.write(headers.concat('', '').join('\r\n'));
 
-    const client = new WebSocket([req, socket, head], null, {
+    const client = new WebSocket([socket, head], null, {
       maxPayload: this.options.maxPayload,
       protocolVersion: version,
       extensions,

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -77,8 +77,8 @@ describe('WebSocket', function () {
         });
       });
 
-      wss.on('connection', (ws) => {
-        assert.strictEqual(ws.upgradeReq.connection.remoteAddress, '127.0.0.2');
+      wss.on('connection', (ws, req) => {
+        assert.strictEqual(req.connection.remoteAddress, '127.0.0.2');
         wss.close(done);
       });
     });
@@ -95,8 +95,8 @@ describe('WebSocket', function () {
         const ws = new WebSocket(`ws://localhost:${port}`, { family: 6 });
       });
 
-      wss.on('connection', (ws) => {
-        assert.strictEqual(ws.upgradeReq.connection.remoteAddress, '::1');
+      wss.on('connection', (ws, req) => {
+        assert.strictEqual(req.connection.remoteAddress, '::1');
         wss.close(done);
       });
     });

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -90,11 +90,11 @@ describe('WebSocketServer', function () {
       server.listen(sockPath, () => {
         const wss = new WebSocketServer({ server });
 
-        wss.on('connection', (ws) => {
+        wss.on('connection', (ws, req) => {
           if (wss.clients.size === 1) {
-            assert.strictEqual(ws.upgradeReq.url, '/foo?bar=bar');
+            assert.strictEqual(req.url, '/foo?bar=bar');
           } else {
-            assert.strictEqual(ws.upgradeReq.url, '/');
+            assert.strictEqual(req.url, '/');
             wss.close();
             server.close(done);
           }
@@ -923,17 +923,6 @@ describe('WebSocketServer', function () {
 
       wss.on('connection', (client) => {
         assert.strictEqual(client.protocolVersion, 8);
-        wss.close(done);
-      });
-    });
-
-    it('upgradeReq is the original request object', function (done) {
-      const wss = new WebSocketServer({ port: ++port }, () => {
-        const ws = new WebSocket(`ws://localhost:${port}`, { protocolVersion: 8 });
-      });
-
-      wss.on('connection', (client) => {
-        assert.strictEqual(client.upgradeReq.httpVersion, '1.1');
         wss.close(done);
       });
     });


### PR DESCRIPTION
This removes the `upgradeReq` property from the `WebSocket` object. The `http.IncomingMessage` object is instead passed as the second argument to the `connection` event.

In this way most of the memory retained by the `http.IncomingMessage` object can be GC'ed reducing memory usage by ~20%.

Developers can save only the required info or the whole `http.IncomingMessage` object, if they have to, when the event is emitted.

See discussion in #1099.