### PR TITLE
Prefix all private properties

### DIFF
--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -18,13 +18,16 @@ const DEFAULT_MEM_LEVEL = 8;
  */
 class PerMessageDeflate {
   constructor (options, isServer, maxPayload) {
+    this._maxPayload = maxPayload | 0;
     this._options = options || {};
+    this._threshold = this._options.threshold !== undefined
+      ? this._options.threshold
+      : 1024;
     this._isServer = !!isServer;
-    this._inflate = null;
     this._deflate = null;
+    this._inflate = null;
+
     this.params = null;
-    this._maxPayload = maxPayload || 0;
-    this.threshold = this._options.threshold === undefined ? 1024 : this._options.threshold;
   }
 
   static get extensionName () {

--- a/lib/Receiver.js
+++ b/lib/Receiver.js
@@ -35,29 +35,29 @@ class Receiver {
    * @param {String} binaryType The type for binary data
    */
   constructor (extensions, maxPayload, binaryType) {
-    this.binaryType = binaryType || constants.BINARY_TYPES[0];
-    this.extensions = extensions || {};
-    this.maxPayload = maxPayload | 0;
+    this._binaryType = binaryType || constants.BINARY_TYPES[0];
+    this._extensions = extensions || {};
+    this._maxPayload = maxPayload | 0;
 
-    this.bufferedBytes = 0;
-    this.buffers = [];
+    this._bufferedBytes = 0;
+    this._buffers = [];
 
-    this.compressed = false;
-    this.payloadLength = 0;
-    this.fragmented = 0;
-    this.masked = false;
-    this.fin = false;
-    this.mask = null;
-    this.opcode = 0;
+    this._compressed = false;
+    this._payloadLength = 0;
+    this._fragmented = 0;
+    this._masked = false;
+    this._fin = false;
+    this._mask = null;
+    this._opcode = 0;
 
-    this.totalPayloadLength = 0;
-    this.messageLength = 0;
-    this.fragments = [];
+    this._totalPayloadLength = 0;
+    this._messageLength = 0;
+    this._fragments = [];
 
-    this.cleanupCallback = null;
-    this.hadError = false;
-    this.dead = false;
-    this.loop = false;
+    this._cleanupCallback = null;
+    this._hadError = false;
+    this._dead = false;
+    this._loop = false;
 
     this.onmessage = null;
     this.onclose = null;
@@ -65,7 +65,7 @@ class Receiver {
     this.onping = null;
     this.onpong = null;
 
-    this.state = GET_INFO;
+    this._state = GET_INFO;
   }
 
   /**
@@ -80,28 +80,28 @@ class Receiver {
     var dst;
     var l;
 
-    this.bufferedBytes -= bytes;
+    this._bufferedBytes -= bytes;
 
-    if (bytes === this.buffers[0].length) return this.buffers.shift();
+    if (bytes === this._buffers[0].length) return this._buffers.shift();
 
-    if (bytes < this.buffers[0].length) {
-      dst = this.buffers[0].slice(0, bytes);
-      this.buffers[0] = this.buffers[0].slice(bytes);
+    if (bytes < this._buffers[0].length) {
+      dst = this._buffers[0].slice(0, bytes);
+      this._buffers[0] = this._buffers[0].slice(bytes);
       return dst;
     }
 
     dst = Buffer.allocUnsafe(bytes);
 
     while (bytes > 0) {
-      l = this.buffers[0].length;
+      l = this._buffers[0].length;
 
       if (bytes >= l) {
-        this.buffers[0].copy(dst, offset);
+        this._buffers[0].copy(dst, offset);
         offset += l;
-        this.buffers.shift();
+        this._buffers.shift();
       } else {
-        this.buffers[0].copy(dst, offset, 0, bytes);
-        this.buffers[0] = this.buffers[0].slice(bytes);
+        this._buffers[0].copy(dst, offset, 0, bytes);
+        this._buffers[0] = this._buffers[0].slice(bytes);
       }
 
       bytes -= l;
@@ -119,10 +119,10 @@ class Receiver {
    * @private
    */
   hasBufferedBytes (n) {
-    if (this.bufferedBytes >= n) return true;
+    if (this._bufferedBytes >= n) return true;
 
-    this.loop = false;
-    if (this.dead) this.cleanup(this.cleanupCallback);
+    this._loop = false;
+    if (this._dead) this.cleanup(this._cleanupCallback);
     return false;
   }
 
@@ -132,10 +132,10 @@ class Receiver {
    * @public
    */
   add (data) {
-    if (this.dead) return;
+    if (this._dead) return;
 
-    this.bufferedBytes += data.length;
-    this.buffers.push(data);
+    this._bufferedBytes += data.length;
+    this._buffers.push(data);
     this.startLoop();
   }
 
@@ -145,10 +145,10 @@ class Receiver {
    * @private
    */
   startLoop () {
-    this.loop = true;
+    this._loop = true;
 
-    while (this.loop) {
-      switch (this.state) {
+    while (this._loop) {
+      switch (this._state) {
         case GET_INFO:
           this.getInfo();
           break;
@@ -165,7 +165,7 @@ class Receiver {
           this.getData();
           break;
         default: // `INFLATING`
-          this.loop = false;
+          this._loop = false;
       }
     }
   }
@@ -187,36 +187,36 @@ class Receiver {
 
     const compressed = (buf[0] & 0x40) === 0x40;
 
-    if (compressed && !this.extensions[PerMessageDeflate.extensionName]) {
+    if (compressed && !this._extensions[PerMessageDeflate.extensionName]) {
       this.error(new Error('RSV1 must be clear'), 1002);
       return;
     }
 
-    this.fin = (buf[0] & 0x80) === 0x80;
-    this.opcode = buf[0] & 0x0f;
-    this.payloadLength = buf[1] & 0x7f;
+    this._fin = (buf[0] & 0x80) === 0x80;
+    this._opcode = buf[0] & 0x0f;
+    this._payloadLength = buf[1] & 0x7f;
 
-    if (this.opcode === 0x00) {
+    if (this._opcode === 0x00) {
       if (compressed) {
         this.error(new Error('RSV1 must be clear'), 1002);
         return;
       }
 
-      if (!this.fragmented) {
-        this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
+      if (!this._fragmented) {
+        this.error(new Error(`invalid opcode: ${this._opcode}`), 1002);
         return;
       } else {
-        this.opcode = this.fragmented;
+        this._opcode = this._fragmented;
       }
-    } else if (this.opcode === 0x01 || this.opcode === 0x02) {
-      if (this.fragmented) {
-        this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
+    } else if (this._opcode === 0x01 || this._opcode === 0x02) {
+      if (this._fragmented) {
+        this.error(new Error(`invalid opcode: ${this._opcode}`), 1002);
         return;
       }
 
-      this.compressed = compressed;
-    } else if (this.opcode > 0x07 && this.opcode < 0x0b) {
-      if (!this.fin) {
+      this._compressed = compressed;
+    } else if (this._opcode > 0x07 && this._opcode < 0x0b) {
+      if (!this._fin) {
         this.error(new Error('FIN must be set'), 1002);
         return;
       }
@@ -226,21 +226,21 @@ class Receiver {
         return;
       }
 
-      if (this.payloadLength > 0x7d) {
+      if (this._payloadLength > 0x7d) {
         this.error(new Error('invalid payload length'), 1002);
         return;
       }
     } else {
-      this.error(new Error(`invalid opcode: ${this.opcode}`), 1002);
+      this.error(new Error(`invalid opcode: ${this._opcode}`), 1002);
       return;
     }
 
-    if (!this.fin && !this.fragmented) this.fragmented = this.opcode;
+    if (!this._fin && !this._fragmented) this._fragmented = this._opcode;
 
-    this.masked = (buf[1] & 0x80) === 0x80;
+    this._masked = (buf[1] & 0x80) === 0x80;
 
-    if (this.payloadLength === 126) this.state = GET_PAYLOAD_LENGTH_16;
-    else if (this.payloadLength === 127) this.state = GET_PAYLOAD_LENGTH_64;
+    if (this._payloadLength === 126) this._state = GET_PAYLOAD_LENGTH_16;
+    else if (this._payloadLength === 127) this._state = GET_PAYLOAD_LENGTH_64;
     else this.haveLength();
   }
 
@@ -252,7 +252,7 @@ class Receiver {
   getPayloadLength16 () {
     if (!this.hasBufferedBytes(2)) return;
 
-    this.payloadLength = this.readBuffer(2).readUInt16BE(0, true);
+    this._payloadLength = this.readBuffer(2).readUInt16BE(0, true);
     this.haveLength();
   }
 
@@ -276,7 +276,7 @@ class Receiver {
       return;
     }
 
-    this.payloadLength = (num * Math.pow(2, 32)) + buf.readUInt32BE(4, true);
+    this._payloadLength = (num * Math.pow(2, 32)) + buf.readUInt32BE(4, true);
     this.haveLength();
   }
 
@@ -286,12 +286,12 @@ class Receiver {
    * @private
    */
   haveLength () {
-    if (this.opcode < 0x08 && this.maxPayloadExceeded(this.payloadLength)) {
+    if (this._opcode < 0x08 && this.maxPayloadExceeded(this._payloadLength)) {
       return;
     }
 
-    if (this.masked) this.state = GET_MASK;
-    else this.state = GET_DATA;
+    if (this._masked) this._state = GET_MASK;
+    else this._state = GET_DATA;
   }
 
   /**
@@ -302,8 +302,8 @@ class Receiver {
   getMask () {
     if (!this.hasBufferedBytes(4)) return;
 
-    this.mask = this.readBuffer(4);
-    this.state = GET_DATA;
+    this._mask = this.readBuffer(4);
+    this._state = GET_DATA;
   }
 
   /**
@@ -314,17 +314,17 @@ class Receiver {
   getData () {
     var data = constants.EMPTY_BUFFER;
 
-    if (this.payloadLength) {
-      if (!this.hasBufferedBytes(this.payloadLength)) return;
+    if (this._payloadLength) {
+      if (!this.hasBufferedBytes(this._payloadLength)) return;
 
-      data = this.readBuffer(this.payloadLength);
-      if (this.masked) bufferUtil.unmask(data, this.mask);
+      data = this.readBuffer(this._payloadLength);
+      if (this._masked) bufferUtil.unmask(data, this._mask);
     }
 
-    if (this.opcode > 0x07) {
+    if (this._opcode > 0x07) {
       this.controlMessage(data);
-    } else if (this.compressed) {
-      this.state = INFLATING;
+    } else if (this._compressed) {
+      this._state = INFLATING;
       this.decompress(data);
     } else if (this.pushFragment(data)) {
       this.dataMessage();
@@ -338,9 +338,9 @@ class Receiver {
    * @private
    */
   decompress (data) {
-    const extension = this.extensions[PerMessageDeflate.extensionName];
+    const perMessageDeflate = this._extensions[PerMessageDeflate.extensionName];
 
-    extension.decompress(data, this.fin, (err, buf) => {
+    perMessageDeflate.decompress(data, this._fin, (err, buf) => {
       if (err) {
         this.error(err, err.closeCode === 1009 ? 1009 : 1007);
         return;
@@ -357,21 +357,21 @@ class Receiver {
    * @private
    */
   dataMessage () {
-    if (this.fin) {
-      const messageLength = this.messageLength;
-      const fragments = this.fragments;
+    if (this._fin) {
+      const messageLength = this._messageLength;
+      const fragments = this._fragments;
 
-      this.totalPayloadLength = 0;
-      this.messageLength = 0;
-      this.fragmented = 0;
-      this.fragments = [];
+      this._totalPayloadLength = 0;
+      this._messageLength = 0;
+      this._fragmented = 0;
+      this._fragments = [];
 
-      if (this.opcode === 2) {
+      if (this._opcode === 2) {
         var data;
 
-        if (this.binaryType === 'nodebuffer') {
+        if (this._binaryType === 'nodebuffer') {
           data = toBuffer(fragments, messageLength);
-        } else if (this.binaryType === 'arraybuffer') {
+        } else if (this._binaryType === 'arraybuffer') {
           data = toArrayBuffer(toBuffer(fragments, messageLength));
         } else {
           data = fragments;
@@ -390,7 +390,7 @@ class Receiver {
       }
     }
 
-    this.state = GET_INFO;
+    this._state = GET_INFO;
   }
 
   /**
@@ -400,11 +400,11 @@ class Receiver {
    * @private
    */
   controlMessage (data) {
-    if (this.opcode === 0x08) {
+    if (this._opcode === 0x08) {
       if (data.length === 0) {
         this.onclose(1000, '');
-        this.loop = false;
-        this.cleanup(this.cleanupCallback);
+        this._loop = false;
+        this.cleanup(this._cleanupCallback);
       } else if (data.length === 1) {
         this.error(new Error('invalid payload length'), 1002);
       } else {
@@ -423,17 +423,17 @@ class Receiver {
         }
 
         this.onclose(code, buf.toString());
-        this.loop = false;
-        this.cleanup(this.cleanupCallback);
+        this._loop = false;
+        this.cleanup(this._cleanupCallback);
       }
 
       return;
     }
 
-    if (this.opcode === 0x09) this.onping(data);
+    if (this._opcode === 0x09) this.onping(data);
     else this.onpong(data);
 
-    this.state = GET_INFO;
+    this._state = GET_INFO;
   }
 
   /**
@@ -445,9 +445,9 @@ class Receiver {
    */
   error (err, code) {
     this.onerror(err, code);
-    this.hadError = true;
-    this.loop = false;
-    this.cleanup(this.cleanupCallback);
+    this._hadError = true;
+    this._loop = false;
+    this.cleanup(this._cleanupCallback);
   }
 
   /**
@@ -457,12 +457,12 @@ class Receiver {
    * @private
    */
   maxPayloadExceeded (length) {
-    if (length === 0 || this.maxPayload < 1) return false;
+    if (length === 0 || this._maxPayload < 1) return false;
 
-    const fullLength = this.totalPayloadLength + length;
+    const fullLength = this._totalPayloadLength + length;
 
-    if (fullLength <= this.maxPayload) {
-      this.totalPayloadLength = fullLength;
+    if (fullLength <= this._maxPayload) {
+      this._totalPayloadLength = fullLength;
       return false;
     }
 
@@ -481,11 +481,11 @@ class Receiver {
   pushFragment (fragment) {
     if (fragment.length === 0) return true;
 
-    const totalLength = this.messageLength + fragment.length;
+    const totalLength = this._messageLength + fragment.length;
 
-    if (this.maxPayload < 1 || totalLength <= this.maxPayload) {
-      this.messageLength = totalLength;
-      this.fragments.push(fragment);
+    if (this._maxPayload < 1 || totalLength <= this._maxPayload) {
+      this._messageLength = totalLength;
+      this._fragments.push(fragment);
       return true;
     }
 
@@ -500,17 +500,17 @@ class Receiver {
    * @public
    */
   cleanup (cb) {
-    this.dead = true;
+    this._dead = true;
 
-    if (!this.hadError && (this.loop || this.state === INFLATING)) {
-      this.cleanupCallback = cb;
+    if (!this._hadError && (this._loop || this._state === INFLATING)) {
+      this._cleanupCallback = cb;
     } else {
-      this.extensions = null;
-      this.fragments = null;
-      this.buffers = null;
-      this.mask = null;
+      this._extensions = null;
+      this._fragments = null;
+      this._buffers = null;
+      this._mask = null;
 
-      this.cleanupCallback = null;
+      this._cleanupCallback = null;
       this.onmessage = null;
       this.onclose = null;
       this.onerror = null;

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -26,15 +26,15 @@ class Sender {
    * @param {Object} extensions An object containing the negotiated extensions
    */
   constructor (socket, extensions) {
-    this.perMessageDeflate = (extensions || {})[PerMessageDeflate.extensionName];
+    this._extensions = extensions || {};
     this._socket = socket;
 
-    this.firstFragment = true;
-    this.compress = false;
+    this._firstFragment = true;
+    this._compress = false;
 
-    this.bufferedBytes = 0;
-    this.deflating = false;
-    this.queue = [];
+    this._bufferedBytes = 0;
+    this._deflating = false;
+    this._queue = [];
 
     this.onerror = null;
   }
@@ -123,7 +123,7 @@ class Sender {
     buf.writeUInt16BE(code || 1000, 0, true);
     if (buf.length > 2) buf.write(data, 2);
 
-    if (this.deflating) {
+    if (this._deflating) {
       this.enqueue([this.doClose, buf, mask, cb]);
     } else {
       this.doClose(buf, mask, cb);
@@ -169,7 +169,7 @@ class Sender {
       }
     }
 
-    if (this.deflating) {
+    if (this._deflating) {
       this.enqueue([this.doPing, data, mask, readOnly]);
     } else {
       this.doPing(data, mask, readOnly);
@@ -215,7 +215,7 @@ class Sender {
       }
     }
 
-    if (this.deflating) {
+    if (this._deflating) {
       this.enqueue([this.doPong, data, mask, readOnly]);
     } else {
       this.doPong(data, mask, readOnly);
@@ -268,20 +268,22 @@ class Sender {
       }
     }
 
-    if (this.firstFragment) {
-      this.firstFragment = false;
-      if (rsv1 && this.perMessageDeflate) {
-        rsv1 = data.length >= this.perMessageDeflate.threshold;
+    const perMessageDeflate = this._extensions[PerMessageDeflate.extensionName];
+
+    if (this._firstFragment) {
+      this._firstFragment = false;
+      if (rsv1 && perMessageDeflate) {
+        rsv1 = data.length >= perMessageDeflate._threshold;
       }
-      this.compress = rsv1;
+      this._compress = rsv1;
     } else {
       rsv1 = false;
       opcode = 0;
     }
 
-    if (options.fin) this.firstFragment = true;
+    if (options.fin) this._firstFragment = true;
 
-    if (this.perMessageDeflate) {
+    if (perMessageDeflate) {
       const opts = {
         fin: options.fin,
         rsv1,
@@ -290,10 +292,10 @@ class Sender {
         readOnly
       };
 
-      if (this.deflating) {
-        this.enqueue([this.dispatch, data, this.compress, opts, cb]);
+      if (this._deflating) {
+        this.enqueue([this.dispatch, data, this._compress, opts, cb]);
       } else {
-        this.dispatch(data, this.compress, opts, cb);
+        this.dispatch(data, this._compress, opts, cb);
       }
     } else {
       this.sendFrame(Sender.frame(data, {
@@ -326,8 +328,10 @@ class Sender {
       return;
     }
 
-    this.deflating = true;
-    this.perMessageDeflate.compress(data, options.fin, (err, buf) => {
+    const perMessageDeflate = this._extensions[PerMessageDeflate.extensionName];
+
+    this._deflating = true;
+    perMessageDeflate.compress(data, options.fin, (err, buf) => {
       if (err) {
         if (cb) cb(err);
         else this.onerror(err);
@@ -336,7 +340,7 @@ class Sender {
 
       options.readOnly = false;
       this.sendFrame(Sender.frame(buf, options), cb);
-      this.deflating = false;
+      this._deflating = false;
       this.dequeue();
     });
   }
@@ -347,10 +351,10 @@ class Sender {
    * @private
    */
   dequeue () {
-    while (!this.deflating && this.queue.length) {
-      const params = this.queue.shift();
+    while (!this._deflating && this._queue.length) {
+      const params = this._queue.shift();
 
-      this.bufferedBytes -= params[1].length;
+      this._bufferedBytes -= params[1].length;
       params[0].apply(this, params.slice(1));
     }
   }
@@ -362,8 +366,8 @@ class Sender {
    * @private
    */
   enqueue (params) {
-    this.bufferedBytes += params[1].length;
-    this.queue.push(params);
+    this._bufferedBytes += params[1].length;
+    this._queue.push(params);
   }
 
   /**

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -83,7 +83,7 @@ class WebSocket extends EventEmitter {
     var amount = 0;
 
     if (this._socket) {
-      amount = this._socket.bufferSize + this._sender.bufferedBytes;
+      amount = this._socket.bufferSize + this._sender._bufferedBytes;
     }
     return amount;
   }
@@ -106,7 +106,7 @@ class WebSocket extends EventEmitter {
     //
     // Allow to change `binaryType` on the fly.
     //
-    if (this._receiver) this._receiver.binaryType = type;
+    if (this._receiver) this._receiver._binaryType = type;
   }
 
   /**
@@ -120,7 +120,7 @@ class WebSocket extends EventEmitter {
     socket.setTimeout(0);
     socket.setNoDelay();
 
-    this._receiver = new Receiver(this.extensions, this.maxPayload, this.binaryType);
+    this._receiver = new Receiver(this.extensions, this._maxPayload, this.binaryType);
     this._sender = new Sender(socket, this.extensions);
     this._ultron = new Ultron(socket);
     this._socket = socket;
@@ -457,8 +457,8 @@ module.exports = WebSocket;
  */
 function initAsServerClient (socket, head, options) {
   this.protocolVersion = options.protocolVersion;
+  this._maxPayload = options.maxPayload;
   this.extensions = options.extensions;
-  this.maxPayload = options.maxPayload;
   this.protocol = options.protocol;
 
   this._isServer = true;

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -92,7 +92,6 @@ class WebSocketServer extends EventEmitter {
 
     if (options.clientTracking) this.clients = new Set();
     this.options = options;
-    this.path = options.path;
   }
 
   /**

--- a/test/Receiver.test.js
+++ b/test/Receiver.test.js
@@ -338,9 +338,9 @@ describe('Receiver', function () {
       message = msg;
     };
 
-    assert.strictEqual(p.totalPayloadLength, 0);
+    assert.strictEqual(p._totalPayloadLength, 0);
     p.add(Buffer.from('810548656c6c6f', 'hex'));
-    assert.strictEqual(p.totalPayloadLength, 0);
+    assert.strictEqual(p._totalPayloadLength, 0);
     assert.strictEqual(message, 'Hello');
   });
 
@@ -352,11 +352,11 @@ describe('Receiver', function () {
       message = msg;
     };
 
-    assert.strictEqual(p.totalPayloadLength, 0);
+    assert.strictEqual(p._totalPayloadLength, 0);
     p.add(Buffer.from('01024865', 'hex'));
-    assert.strictEqual(p.totalPayloadLength, 2);
+    assert.strictEqual(p._totalPayloadLength, 2);
     p.add(Buffer.from('80036c6c6f', 'hex'));
-    assert.strictEqual(p.totalPayloadLength, 0);
+    assert.strictEqual(p._totalPayloadLength, 0);
     assert.strictEqual(message, 'Hello');
   });
 
@@ -368,13 +368,13 @@ describe('Receiver', function () {
       data.push(buf.toString());
     };
 
-    assert.strictEqual(p.totalPayloadLength, 0);
+    assert.strictEqual(p._totalPayloadLength, 0);
     p.add(Buffer.from('02024865', 'hex'));
-    assert.strictEqual(p.totalPayloadLength, 2);
+    assert.strictEqual(p._totalPayloadLength, 2);
     p.add(Buffer.from('8900', 'hex'));
-    assert.strictEqual(p.totalPayloadLength, 2);
+    assert.strictEqual(p._totalPayloadLength, 2);
     p.add(Buffer.from('80036c6c6f', 'hex'));
-    assert.strictEqual(p.totalPayloadLength, 0);
+    assert.strictEqual(p._totalPayloadLength, 0);
     assert.deepStrictEqual(data, ['', 'Hello']);
   });
 
@@ -722,8 +722,8 @@ describe('Receiver', function () {
       p.add(frame);
       p.add(frame);
 
-      assert.strictEqual(p.state, 5);
-      assert.strictEqual(p.bufferedBytes, frame.length);
+      assert.strictEqual(p._state, 5);
+      assert.strictEqual(p._bufferedBytes, frame.length);
 
       p.cleanup(() => {
         assert.deepStrictEqual(results, ['Hello', 'Hello']);
@@ -754,8 +754,8 @@ describe('Receiver', function () {
       p.add(textFrame);
       p.add(closeFrame);
 
-      assert.strictEqual(p.state, 5);
-      assert.strictEqual(p.bufferedBytes, textFrame.length + closeFrame.length);
+      assert.strictEqual(p._state, 5);
+      assert.strictEqual(p._bufferedBytes, textFrame.length + closeFrame.length);
 
       p.cleanup(() => {
         assert.deepStrictEqual(results, ['Hello', 'Hello', 1000, '']);
@@ -786,8 +786,8 @@ describe('Receiver', function () {
       p.add(textFrame);
       p.add(invalidFrame);
 
-      assert.strictEqual(p.state, 5);
-      assert.strictEqual(p.bufferedBytes, textFrame.length + invalidFrame.length);
+      assert.strictEqual(p._state, 5);
+      assert.strictEqual(p._bufferedBytes, textFrame.length + invalidFrame.length);
 
       p.cleanup(() => {
         assert.deepStrictEqual(results, [
@@ -821,8 +821,8 @@ describe('Receiver', function () {
       p.add(textFrame);
       p.add(incompleteFrame);
 
-      assert.strictEqual(p.state, 5);
-      assert.strictEqual(p.bufferedBytes, incompleteFrame.length);
+      assert.strictEqual(p._state, 5);
+      assert.strictEqual(p._bufferedBytes, incompleteFrame.length);
 
       p.cleanup(() => {
         assert.deepStrictEqual(results, ['Hello']);
@@ -867,7 +867,7 @@ describe('Receiver', function () {
       crypto.randomBytes(623987)
     ];
 
-    p.binaryType = 'arraybuffer';
+    p._binaryType = 'arraybuffer';
     p.onmessage = (data) => {
       assert.ok(data instanceof ArrayBuffer);
       assert.ok(Buffer.from(data).equals(Buffer.concat(frags)));
@@ -895,7 +895,7 @@ describe('Receiver', function () {
       crypto.randomBytes(1)
     ];
 
-    p.binaryType = 'fragments';
+    p._binaryType = 'fragments';
     p.onmessage = (data) => {
       assert.deepStrictEqual(data, frags);
       done();

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -256,14 +256,14 @@ describe('WebSocketServer', function () {
   });
 
   describe('#maxpayload', function () {
-    it('maxpayload is passed on to clients,', function (done) {
+    it('maxpayload is passed on to clients', function (done) {
       const maxPayload = 20480;
       const wss = new WebSocketServer({ port: ++port, maxPayload }, () => {
         const ws = new WebSocket(`ws://localhost:${port}`);
       });
 
       wss.on('connection', (client) => {
-        assert.strictEqual(client.maxPayload, maxPayload);
+        assert.strictEqual(client._maxPayload, maxPayload);
         wss.close(done);
       });
     });
@@ -275,7 +275,7 @@ describe('WebSocketServer', function () {
       });
 
       wss.on('connection', (client) => {
-        assert.strictEqual(client._receiver.maxPayload, maxPayload);
+        assert.strictEqual(client._receiver._maxPayload, maxPayload);
         wss.close(done);
       });
     });
@@ -289,7 +289,7 @@ describe('WebSocketServer', function () {
 
       wss.on('connection', (client) => {
         assert.strictEqual(
-          client._receiver.extensions[PerMessageDeflate.extensionName]._maxPayload,
+          client._receiver._extensions[PerMessageDeflate.extensionName]._maxPayload,
           maxPayload
         );
         wss.close(done);


### PR DESCRIPTION
This patch prefixes all private properties with `_` in order to improve consistency in our codebase.

I wanted to use symbols for private properties but it makes testing and debugging harder. We are also still supporting Node.js 4 and symbols have a significant performance impact there.