### PR TITLE
Have permessage-deflate disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,23 +73,13 @@ enables the client and server to negotiate a compression algorithm and its
 parameters, and then selectively apply it to the data payloads of each
 WebSocket message.
 
-The extension is enabled by default but adds a significant overhead in terms of
-performance and memory comsumption. We suggest to use WebSocket compression
-only if it is really needed.
+The extension is disabled by default on the server and enabled by default on
+the client. It adds a significant overhead in terms of performance and memory
+comsumption so we suggest to enable it only if it is really needed.
 
-To disable the extension you can set the `perMessageDeflate` option to `false`.
-On the server:
-
-```js
-const WebSocket = require('ws');
-
-const wss = new WebSocket.Server({
-  perMessageDeflate: false,
-  port: 8080
-});
-```
-
-On the client:
+The client will only use the extension if it is supported and enabled on the
+server. To always disable the extension on the client set the
+`perMessageDeflate` option to `false`.
 
 ```js
 const WebSocket = require('ws');

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -63,7 +63,7 @@ status code, otherwise the returned value sets the value of the
 
 `perMessageDeflate` can be used to control the behavior of
 [permessage-deflate extension][permessage-deflate].
-The extension is disabled when `false`. Defaults to `true`. If an object is
+The extension is disabled when `false` (default value). If an object is
 provided then that is extension parameters:
 
 - `serverNoContextTakeover` {Boolean} Whether to use context take over or not.
@@ -189,9 +189,9 @@ This class represents a WebSocket. It extends the `EventEmitter`.
   - `pfx` {String|Buffer} The private key, certificate, and CA certs.
   - `ca` {Array} Trusted certificates.
 
-`perMessageDeflate` parameters are the same of the server, the only difference
-is the direction of requests (e.g. `serverNoContextTakeover` is the value to be
-requested to the server).
+`perMessageDeflate` default value is `true`. When using an object, parameters
+are the same of the server. The only difference is the direction of requests
+(e.g. `serverNoContextTakeover` is the value to be requested to the server).
 
 Create a new WebSocket instance.
 

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -47,7 +47,7 @@ class WebSocketServer extends EventEmitter {
 
     options = Object.assign({
       maxPayload: 100 * 1024 * 1024,
-      perMessageDeflate: true,
+      perMessageDeflate: false,
       handleProtocols: null,
       clientTracking: true,
       verifyClient: null,

--- a/test/WebSocket.test.js
+++ b/test/WebSocket.test.js
@@ -105,7 +105,7 @@ describe('WebSocket', function () {
   describe('properties', function () {
     it('#bytesReceived exposes number of bytes received', function (done) {
       const wss = new WebSocketServer({ port: ++port }, () => {
-        const ws = new WebSocket(`ws://localhost:${port}`, { perMessageDeflate: false });
+        const ws = new WebSocket(`ws://localhost:${port}`);
         ws.on('message', () => {
           assert.strictEqual(ws.bytesReceived, 8);
           wss.close(done);
@@ -150,7 +150,10 @@ describe('WebSocket', function () {
       });
 
       it('takes into account the data in the sender queue', function (done) {
-        const wss = new WebSocketServer({ port: ++port }, () => {
+        const wss = new WebSocketServer({
+          perMessageDeflate: true,
+          port: ++port
+        }, () => {
           const ws = new WebSocket(`ws://localhost:${port}`, {
             perMessageDeflate: { threshold: 0 }
           });
@@ -170,9 +173,7 @@ describe('WebSocket', function () {
 
       it('takes into account the data in the socket queue', function (done) {
         const wss = new WebSocketServer({ port: ++port }, () => {
-          const ws = new WebSocket(`ws://localhost:${port}`, {
-            perMessageDeflate: false
-          });
+          const ws = new WebSocket(`ws://localhost:${port}`);
         });
 
         wss.on('connection', (ws) => {

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -283,9 +283,11 @@ describe('WebSocketServer', function () {
     it('maxpayload is passed on to permessage-deflate', function (done) {
       const PerMessageDeflate = require('../lib/PerMessageDeflate');
       const maxPayload = 20480;
-      const wss = new WebSocketServer({ port: ++port, maxPayload }, () => {
-        const ws = new WebSocket(`ws://localhost:${port}`);
-      });
+      const wss = new WebSocketServer({
+        perMessageDeflate: true,
+        port: ++port,
+        maxPayload
+      }, () => new WebSocket(`ws://localhost:${port}`));
 
       wss.on('connection', (client) => {
         assert.strictEqual(
@@ -930,7 +932,10 @@ describe('WebSocketServer', function () {
 
   describe('permessage-deflate', function () {
     it('accept connections with permessage-deflate extension', function (done) {
-      const wss = new WebSocketServer({ port: ++port }, () => {
+      const wss = new WebSocketServer({
+        perMessageDeflate: true,
+        port: ++port
+      }, () => {
         const req = http.request({
           headers: {
             'Connection': 'Upgrade',
@@ -950,7 +955,10 @@ describe('WebSocketServer', function () {
     });
 
     it('does not accept connections with not defined extension parameter', function (done) {
-      const wss = new WebSocketServer({ port: ++port }, () => {
+      const wss = new WebSocketServer({
+        perMessageDeflate: true,
+        port: ++port
+      }, () => {
         const req = http.request({
           headers: {
             'Connection': 'Upgrade',
@@ -977,7 +985,10 @@ describe('WebSocketServer', function () {
     });
 
     it('does not accept connections with invalid extension parameter', function (done) {
-      const wss = new WebSocketServer({ port: ++port }, () => {
+      const wss = new WebSocketServer({
+        perMessageDeflate: true,
+        port: ++port
+      }, () => {
         const req = http.request({
           headers: {
             'Connection': 'Upgrade',


### PR DESCRIPTION
This patch disables permessage-deflate by default on the server.