### PR TITLE
Add `req` argument to `completeUpgrade` callback

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -267,7 +267,7 @@ class WebSocketServer extends EventEmitter {
     }
 
     socket.removeListener('error', socketError);
-    cb(client);
+    cb(client, req);
   }
 }
 

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -321,7 +321,11 @@ describe('WebSocketServer', function () {
         const wss = new WebSocketServer({ noServer: true });
 
         server.on('upgrade', (req, socket, head) => {
-          wss.handleUpgrade(req, socket, head, (client) => client.send('hello'));
+          wss.handleUpgrade(req, socket, head, (client, req) => {
+            assert.strictEqual(req.method, 'GET');
+            assert.strictEqual(req.url, '/');
+            client.send('hello');
+          });
         });
 
         const ws = new WebSocket(`ws://localhost:${port}`);


### PR DESCRIPTION
When working with `noServer` and `handleUpgrade` from an extenal server, we must receive `req` parameter on `handleUpgrade` callback.

```
const http = require('http')
const WebSocket = require('ws')
const url = require('url')
const wss1 = new WebSocket.Server({ noServer: true })
const wss2 = new WebSocket.Server({ noServer: true })
const server = http.createServer()

server.on('upgrade', (request, socket, head) => {
  const pathname = url.parse(request.url).pathname

  if (pathname === '/foo') {
    wss1.handleUpgrade(request, socket, head, (ws, req) => {
      // req must exist
      wss1.emit('connection', ws, req)
    })
  } else if (pathname === '/bar') {
    wss2.handleUpgrade(request, socket, head, (ws, req) => {
      // req must exist
      wss2.emit('connection', ws, req)
    })
  } else {
    socket.destroy()
  }
})
const port = 3055
server.listen(port, () => {
  console.log(`Server listening on port ${port}`)
})
```

On last 3.x version (from https://github.com/websockets/ws/pull/885 discussion).