### PR TITLE
fix config error in ExpressJS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ app.use(function (req, res) {
 });
 
 const server = http.createServer(app);
-const wss = new WebSocket.Server({ server });
+const wss = new WebSocket.Server({ server: server });
 
 wss.on('connection', function connection(ws, req) {
   const location = url.parse(req.url, true);


### PR DESCRIPTION
Without this fix I get the following error when using the ExpressJS example:
```
/home/nico/src/warten/server/node_modules/ws/lib/WebSocketServer.js:63
      throw new TypeError('missing or invalid options');
      ^

TypeError: missing or invalid options
    at WebSocketServer (/home/nico/src/warten/server/node_modules/ws/lib/WebSocketServer.js:63:13)
    at Object.<anonymous> (/home/nico/src/warten/server/app.js:16:13)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:427:7)
    at startup (bootstrap_node.js:151:9)
```
