### PR TITLE
Fix typos in API docs

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -136,7 +136,7 @@ when the HTTP server is passed via the `server` option, this method is called
 automatically. When operating in "noServer" mode, this method must be called
 manually.
 
-If the upgrade is successfull, the `callback` is called with a `WebSocket`
+If the upgrade is successful, the `callback` is called with a `WebSocket`
 object as parameter.
 
 ### server.shouldHandle(request)
@@ -149,7 +149,7 @@ against the `path` option if provided.
 The return value, `true` or `false`, determines whether or not to accept the
 handshake.
 
-This method can be overriden when a custom handling logic is required.
+This method can be overridden when a custom handling logic is required.
 
 ## Class: WebSocket
 
@@ -285,7 +285,7 @@ A string indicating the type of binary data being transmitted by the connection.
 This should be one of "nodebuffer", "arraybuffer" or "fragments". Defaults to
 "nodebuffer". Type "fragments" will emit the array of fragments as received from
 the sender, without copyfull concatenation, which is useful for the performance
-of binary protocols transfering large messages with multiple fragments.
+of binary protocols transferring large messages with multiple fragments.
 
 ### websocket.bufferedAmount
 


### PR DESCRIPTION
Hi! I spotted a few typos when reading through the documentation