### PR TITLE
feat(perMessageDeflate): Allow 'level' option

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -72,7 +72,8 @@ provided then that is extension parameters:
 - `serverMaxWindowBits` {Number} The value of windowBits.
 - `clientMaxWindowBits` {Number} The value of max windowBits to be requested
   to clients.
-- `memLevel` {Number} The value of memLevel.
+- `level` {Number} The value of zlib's `level` param (0-9, default 8).
+- `memLevel` {Number} The value of zlib's `memLevel` param (1-9, default 8).
 - `threshold` {Number} Payloads smaller than this will not be compressed.
   Defaults to 1024 bytes.
 

--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -340,6 +340,7 @@ class PerMessageDeflate {
 
       this._deflate = zlib.createDeflateRaw({
         memLevel: this._options.memLevel,
+        level: this._options.level,
         flush: zlib.Z_SYNC_FLUSH,
         windowBits
       });


### PR DESCRIPTION
This corresponds to the zlib level as described
in https://nodejs.org/api/zlib.html#zlib_class_zlib_deflateraw

This could be used, along with `threshold` to tune CPU usage and size. The default level in `zlib` is 6, which could be too high, but some users may find that 1 is worth the CPU savings for a quick pass.

For example, on some JSON sample data:

```
Running zlib.deflateRawSync for 1000 iterations.
Uncompressed Data Size: 137063 bytes

-----

Level 0: 550.879ms
Size: 137083 bytes
Level 1: 836.332ms
Size: 11379 bytes
Level 2: 825.474ms
Size: 10717 bytes
Level 3: 847.320ms
Size: 10397 bytes
Level 4: 1187.744ms
Size: 8388 bytes
Level 5: 1286.184ms
Size: 7761 bytes
Level 6: 1489.151ms
Size: 7372 bytes
Level 7: 1657.936ms
Size: 7301 bytes
Level 8: 1828.456ms
Size: 7187 bytes
Level 9: 1896.402ms
Size: 7181 bytes
```