### PR TITLE
fixed "cannot read property aborted of null bug"

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -643,7 +643,7 @@ function initAsClient (address, protocols, options) {
   }
 
   this._req.on('error', (error) => {
-    if (this._req.aborted) return;
+    if (this._req == null || this._req.aborted) return;
 
     this._req = null;
     this.emit('error', error);


### PR DESCRIPTION
Hi all,

when I try to connect to an invalid host (one who does not listen for WebSocket connections) I get the following exception I can't handle in any way:

```
Uncaught TypeError: Cannot read property 'aborted' of null
    at ClientRequest._req.on (/develop/node-statwolf/packages/statwolf-debugger-client/node_modules/ws/lib/WebSocket.js:646)
    at emitOne (events.js:96)
    at ClientRequest.emit (events.js:188)
    at Socket.socketCloseListener (_http_client.js:285)
    at emitOne (events.js:101)
    at Socket.emit (events.js:188)
    at TCP._handle.close [as _onclose] (net.js:501)
```

It looks to be an invalid access to `this._req` variable.

In this merge-request, I just added a check that should fix the issue.
I hope it will be helpful.