### PR TITLE
Remove unreachable code

### DIFF
--- a/lib/PerMessageDeflate.js
+++ b/lib/PerMessageDeflate.js
@@ -394,28 +394,27 @@ class PerMessageDeflate {
         flush: zlib.Z_SYNC_FLUSH,
         windowBits
       });
+
+      this._deflate.totalLength = 0;
+      this._deflate.buffers = [];
+
+      //
+      // `zlib.DeflateRaw` emits an `'error'` event only when an attempt to use
+      // it is made after it has already been closed. This cannot happen here,
+      // so we only add a listener for the `'data'` event.
+      //
+      this._deflate.on('data', deflateOnData);
     }
+
     this._deflate.writeInProgress = true;
 
-    var totalLength = 0;
-    const buffers = [];
-
-    const onData = (data) => {
-      totalLength += data.length;
-      buffers.push(data);
-    };
-
-    const onError = (err) => {
-      cleanup();
-      callback(err);
-    };
-
-    const cleanup = () => {
-      if (!this._deflate) return;
-
-      this._deflate.removeListener('error', onError);
-      this._deflate.removeListener('data', onData);
-      this._deflate.writeInProgress = false;
+    this._deflate.write(data);
+    this._deflate.flush(zlib.Z_SYNC_FLUSH, () => {
+      var data = bufferUtil.concat(
+        this._deflate.buffers,
+        this._deflate.totalLength
+      );
+      if (fin) data = data.slice(0, data.length - 4);
 
       if (
         (fin && this.params[`${endpoint}_no_context_takeover`]) ||
@@ -423,18 +422,26 @@ class PerMessageDeflate {
       ) {
         this._deflate.close();
         this._deflate = null;
+      } else {
+        this._deflate.writeInProgress = false;
+        this._deflate.totalLength = 0;
+        this._deflate.buffers = [];
       }
-    };
 
-    this._deflate.on('error', onError).on('data', onData);
-    this._deflate.write(data);
-    this._deflate.flush(zlib.Z_SYNC_FLUSH, () => {
-      cleanup();
-      var data = bufferUtil.concat(buffers, totalLength);
-      if (fin) data = data.slice(0, data.length - 4);
       callback(null, data);
     });
   }
 }
 
 module.exports = PerMessageDeflate;
+
+/**
+ * The listener of the `zlib.DeflateRaw` stream `'data'` event.
+ *
+ * @param {Buffer} chunk A chunk of data
+ * @private
+ */
+function deflateOnData (chunk) {
+  this.buffers.push(chunk);
+  this.totalLength += chunk.length;
+}

--- a/lib/Sender.js
+++ b/lib/Sender.js
@@ -35,8 +35,6 @@ class Sender {
     this._bufferedBytes = 0;
     this._deflating = false;
     this._queue = [];
-
-    this.onerror = null;
   }
 
   /**
@@ -331,13 +329,7 @@ class Sender {
     const perMessageDeflate = this._extensions[PerMessageDeflate.extensionName];
 
     this._deflating = true;
-    perMessageDeflate.compress(data, options.fin, (err, buf) => {
-      if (err) {
-        if (cb) cb(err);
-        else this.onerror(err);
-        return;
-      }
-
+    perMessageDeflate.compress(data, options.fin, (_, buf) => {
       options.readOnly = false;
       this.sendFrame(Sender.frame(buf, options), cb);
       this._deflating = false;

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -157,12 +157,6 @@ class WebSocket extends EventEmitter {
       this.emit('error', error);
     };
 
-    // sender event handlers
-    this._sender.onerror = (error) => {
-      this.close(1002, '');
-      this.emit('error', error);
-    };
-
     this.readyState = WebSocket.OPEN;
     this.emit('open');
   }
@@ -198,17 +192,12 @@ class WebSocket extends EventEmitter {
       if (!error) this._socket.end();
       else this._socket.destroy();
 
+      this._receiver.cleanup(() => this.emitClose());
+
+      this._receiver = null;
+      this._sender = null;
       this._socket = null;
       this._ultron = null;
-    }
-
-    if (this._sender) {
-      this._sender = this._sender.onerror = null;
-    }
-
-    if (this._receiver) {
-      this._receiver.cleanup(() => this.emitClose());
-      this._receiver = null;
     } else {
       this.emitClose();
     }


### PR DESCRIPTION
`zlib.DeflateRaw` emits an `'error'` event only when an attempt to use it is made after it has already been closed and this cannot happen in our case.