### PR TITLE
mocha 4 require explicit exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "eslint . && nyc --reporter=html --reporter=text mocha test/*.test.js",
+    "test": "eslint . && nyc --reporter=html --reporter=text mocha --exit test/*.test.js",
     "integration": "eslint . && mocha test/*.integration.js",
     "lint": "eslint ."
   },


### PR DESCRIPTION
https://mochajs.org/#--exit----no-exit
> Prior to version v4.0.0, by default, Mocha would force its own process to exit once it was finished executing all tests. This behavior enables a set of potential problems; it’s indicative of tests (or fixtures, harnesses, code under test, etc.) which don’t clean up after themselves properly. Ultimately, “dirty” tests can (but not always) lead to false positive or false negative results.