### PR TITLE
[doc] Remove duplicate 'is' in doc.

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -27,7 +27,7 @@ provided or an error is thrown.
 
 
 If `verifyClient` is not set then the handshake is automatically accepted. If
-it is is provided with a single argument then that is:
+it is provided with a single argument then that is:
 
 - `info` {Object}
   - `origin` {String} The value in the Origin header indicated by the client.


### PR DESCRIPTION
Remove duplicate 'is' in doc.

before:
If it **is is** provided with a single argument then that is:

after:
If it **is** provided with a single argument then that is: