### PR TITLE
[minor] Move 'use strict' declarations on top of the file.

### DIFF
--- a/bench/parser.benchmark.js
+++ b/bench/parser.benchmark.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const safeBuffer = require('safe-buffer');

--- a/bench/sender.benchmark.js
+++ b/bench/sender.benchmark.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const benchmark = require('benchmark');

--- a/index.js
+++ b/index.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const WebSocket = require('./lib/websocket');

--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const safeBuffer = require('safe-buffer');

--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const safeBuffer = require('safe-buffer');

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const safeBuffer = require('safe-buffer');

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 try {

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const safeBuffer = require('safe-buffer');

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,9 +1,3 @@
-/*!
- * ws: a node.js websocket client
- * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
- * MIT Licensed
- */
-
 'use strict';
 
 const EventEmitter = require('events');


### PR DESCRIPTION
Some JS parsers seem to ignore it otherwise.