### PR TITLE
Supports dynamic  pattern in "path" option for WebSocket.Server

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -16,6 +16,11 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `handleProtocols` {Function} A function which can be used to handle the
     WebSocket subprotocols. See description below.
   - `path` {String} Accept only connections matching this path.
+    Note: `path` supports dynamic path elements like:
+    `{keyword}`, `:keyword` or `*` that matches any uri characters up to next
+    '/' path delimiter.
+    E.g.: a path like: `/foo/{foo-id}/bar/:bar-id/any/*` would match url pathes
+    like: `/foo/123/bar/456/any/789`.
   - `noServer` {Boolean} Enable no server mode.
   - `clientTracking` {Boolean} Specifies whether or not to track clients.
   - `perMessageDeflate` {Boolean|Object} Enable/disable permessage-deflate.

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -59,6 +59,16 @@ class WebSocketServer extends EventEmitter {
       );
     }
 
+    if (options.path) {
+      // transform the path to a regexp that can match the represented pattern
+      var reStr = options.path.replace(/\./g, '\\.'); // Quote dots
+      reStr = reStr.replace(/\*/g, '[^/]*'); // Replace * by wildcards
+      reStr = reStr.replace(/{[^}]*}/g, '[^/]*'); // Replaces {keyword} by wildcards
+      reStr = reStr.replace(/:[^/]*/g, '[^/]*'); // Replace :keyword by wildcards
+      reStr = '^' + reStr + '$'; // Anchore the regexp
+      options.__path_re = new RegExp(reStr);
+    }
+
     if (options.port != null) {
       this._server = http.createServer((req, res) => {
         const body = http.STATUS_CODES[426];
@@ -127,10 +137,17 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   shouldHandle (req) {
-    if (this.options.path && url.parse(req.url).pathname !== this.options.path) {
-      return false;
+    if (this.options.path) {
+      // Get the pathname part of the uri (no query part)
+      var inputPath = url.parse(req.url).pathname;
+      if (this.options.__path_re) {
+        // path has an associated RegExp, so use RegExp matching
+        return this.options.__path_re.test(inputPath);
+      } else {
+        // path has no RegExp counterpart, so use strict equality
+        return (inputPath === this.options.path);
+      }
     }
-
     return true;
   }
 

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -283,6 +283,30 @@ describe('WebSocketServer', function () {
 
       assert.strictEqual(wss.shouldHandle({ url: '/bar' }), false);
     });
+
+    it('supports dynamic urls', function () {
+      const wss = new WebSocket.Server({ noServer: true, path: '/foo/{foo-id}/bar/:bar-id/any/*/ws' });
+      const goodUrls = [
+        '/foo/1234/bar/5678/any/90/ws',
+        '/foo//bar//any//ws',
+        '/foo/foo/bar/bar/any/any/ws',
+        '/foo/AZaz09_.-~/bar/%20%%%2F/any/any/ws'
+      ];
+      const badUrls = [
+        '/bar/',
+        '/foo/1234/bar/5678/any/90',
+        '/foo/bar/any/ws'
+      ];
+      var len = goodUrls.length;
+      var i;
+      for (i = 0; i < len; i++) {
+        assert.strictEqual(wss.shouldHandle({ url: goodUrls[i] }), true);
+      }
+      len = badUrls.length;
+      for (i = 0; i < len; i++) {
+        assert.strictEqual(wss.shouldHandle({ url: badUrls[i] }), false);
+      }
+    });
   });
 
   describe('#handleUpgrade', function () {


### PR DESCRIPTION
Hello, 

Here is a minor Pull-Request to add support for "dynamic" pattern in the `path` option of the *WebSocket.Server* constructor.

### Motivation:
When using this websocket server with a user provided HTTP server, it is often useful to control where the websocket server is hooked up in the URL path tree. This is possible with the `path` option, but unfortunately only a fixed path prefix is allowed.

However it is sometime convenient to allow this path prefix to be variable, for example to let an upstream reverse proxy to use some rules based on this variable part.

### Proposal:
Simply allow to support some "REST" like URL patterns in the `path` option and use a pattern matching rule instead of a strict comparison when comparing `path`and incoming URL pathname.

The proposed code supports the following dynamic patterns: `{keyword}`, `:keyword` and `*`. All these
patterns will match any uri character up to the next `/` path delimiter or the end of the uri pathname.

E.g.: Things like:
  - `/foo/{foo-id}/bar/{bar-id}`   # Like OPENAPI of Swagger notation
  - `/foo/:foo-id/bar/:bar-id`      # Like Expressjs, ... notation
  - `/foo/*/bar/*`
are all equivalent and will match any url path like: `/foo/123/bar/456`

I have intentionaly not supported a full RegExp notation at it will be more complicated to secure it.

### Pull-Request:
- `lib/websocket-server.js` : Implementation
- `test/websocker-server.test.js` : Unit tests
- `doc/ws.md` :  Some explanations for the `path`option new format

--
Eric



