### PR TITLE
feat(websocket): 'emit error' if send fail and error listener is registered

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -371,6 +371,7 @@ class WebSocket extends EventEmitter {
       );
 
       if (cb) return cb(err);
+      if (this.listenerCount('error') > 0) return this.emit('error', err);
       throw err;
     }
 


### PR DESCRIPTION
Currently if the `send` method fails, and no `callback` is passed as argument, it throws.

However, it would be nice that if an `error` listener is registered, the error is "emitted" instead of thrown.

This PR is to implement this feature.