### PR TITLE
[minor] add zlibOptions to perMessageDeflate init

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,16 @@ The extension is disabled by default on the server and enabled by default on
 the client. It adds a significant overhead in terms of performance and memory
 consumption so we suggest to enable it only if it is really needed.
 
-Note that NodeJS has a variety of issues with high-performance compression,
+Note that Node.js has a variety of issues with high-performance compression,
 where increased concurrency, especially on Linux, can lead to
 [catastrophic memory fragmentation][node-zlib-bug] and slow performance.
 If you intend to use `permessage-deflate` in production, it is worthwhile
-to set up a test representative of your workload and ensure Node/zlib will
+to set up a test representative of your workload and ensure Node.js/zlib will
 handle it with acceptable performance and memory usage.
 
-Tuning of `permessage-deflate` can be done via the `zlibOptions` option,
-which is passed directly into [zlib.createDeflateRaw()][node-zlib-deflaterawdocs].
+Tuning of `permessage-deflate` can be done via the options defined below.
+You can also use `zlibOptions`, which is passed directly into
+[zlib.createDeflateRaw()][node-zlib-deflaterawdocs].
 Do not set `windowBits`, which is set dynamically by the client.
 
 See [the docs][ws-server-options] for more options.
@@ -108,7 +109,7 @@ const wss = new WebSocket.Server({
     // Other options settable:
     clientNoContextTakeover: true, // defaults to negotiated value
     serverNoContextTakeover: true, // defaults to negotiated value
-    clientMaxWindowBits: true,     // defaults to negotiated value
+    clientMaxWindowBits: 10,       // defaults to negotiated value
     serverMaxWindowBits: 10,       // defaults to negotiated value
     // Below options specified as default values
     concurrencyLimit: 10,          // limits zlib concurrency for perf

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ to set up a test representative of your workload and ensure Node.js/zlib will
 handle it with acceptable performance and memory usage.
 
 Tuning of `permessage-deflate` can be done via the options defined below.
-You can also use `zlibOptions`, which is passed directly into
-[zlib.createDeflateRaw()][node-zlib-deflaterawdocs].
-Do not set `windowBits`, which is set dynamically by the client.
+You can also use `zlibDeflateOptions` and `zlibInflateOptions`, which is passed
+directly into the creation of
+[raw deflate/inflate streams][node-zlib-deflaterawdocs].
 
 See [the docs][ws-server-options] for more options.
 
@@ -101,10 +101,13 @@ const WebSocket = require('ws');
 const wss = new WebSocket.Server({
   port: 8080,
   perMessageDeflate: {
-    zlibOptions: { // See zlib defaults
-      chunkSize: 128,
+    zlibDeflateOptions: { // See zlib defaults
+      chunkSize: 1024,
       memLevel: 7,
       level: 3,
+    },
+    zlibInflateOptions: {
+      chunkSize: 10 * 1024
     },
     // Other options settable:
     clientNoContextTakeover: true, // defaults to negotiated value

--- a/README.md
+++ b/README.md
@@ -81,6 +81,43 @@ The extension is disabled by default on the server and enabled by default on
 the client. It adds a significant overhead in terms of performance and memory
 consumption so we suggest to enable it only if it is really needed.
 
+Note that NodeJS has a variety of issues with high-performance compression,
+where increased concurrency, especially on Linux, can lead to
+[catastrophic memory fragmentation][node-zlib-bug] and slow performance.
+If you intend to use `permessage-deflate` in production, it is worthwhile
+to set up a test representative of your workload and ensure Node/zlib will
+handle it with acceptable performance and memory usage.
+
+Tuning of `permessage-deflate` can be done via the `zlibOptions` option,
+which is passed directly into [zlib.createDeflateRaw()][node-zlib-deflaterawdocs].
+Do not set `windowBits`, which is set dynamically by the client.
+
+See [the docs][ws-server-options] for more options.
+
+```js
+const WebSocket = require('ws');
+
+const wss = new WebSocket.Server({
+  port: 8080,
+  perMessageDeflate: {
+    zlibOptions: { // See zlib defaults
+      chunkSize: 128,
+      memLevel: 7,
+      level: 3,
+    },
+    // Other options settable:
+    clientNoContextTakeover: true, // defaults to negotiated value
+    serverNoContextTakeover: true, // defaults to negotiated value
+    clientMaxWindowBits: true,     // defaults to negotiated value
+    serverMaxWindowBits: 10,       // defaults to negotiated value
+    // Below options specified as default values
+    concurrencyLimit: 10,          // limits zlib concurrency for perf
+    threshold: 1024,               // Size (in bytes) below which messages
+                                   // should not be compressed
+  }
+});
+```
+
 The client will only use the extension if it is supported and enabled on the
 server. To always disable the extension on the client set the
 `perMessageDeflate` option to `false`.
@@ -344,3 +381,6 @@ We're using the GitHub [releases][changelog] for changelog entries.
 [server-report]: http://websockets.github.io/ws/autobahn/servers/
 [permessage-deflate]: https://tools.ietf.org/html/rfc7692
 [changelog]: https://github.com/websockets/ws/releases
+[node-zlib-bug]: https://github.com/nodejs/node/issues/8871
+[node-zlib-deflaterawdocs]: https://nodejs.org/api/zlib.html#zlib_zlib_createdeflateraw_options
+[ws-server-options]: https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -71,8 +71,8 @@ provided then that is extension parameters:
   takeover.
 - `serverMaxWindowBits` {Number} The value of `windowBits`.
 - `clientMaxWindowBits` {Number} Request a custom client window size.
-- `level` {Number} The value of zlib's `level` param (0-9, default 8).
-- `memLevel` {Number} The value of zlib's `memLevel` param (1-9, default 8).
+- `zlibOptions` {Object} [Additional options][zlib-options] to pass to zlib
+  on deflate.
 - `threshold` {Number} Payloads smaller than this will not be compressed.
   Defaults to 1024 bytes.
 - `concurrencyLimit` {Number} The number of concurrent calls to zlib.
@@ -420,3 +420,4 @@ The URL of the WebSocket server. Server clients don't have this attribute.
 
 [concurrency-limit]: https://github.com/websockets/ws/issues/1202
 [permessage-deflate]: https://tools.ietf.org/html/draft-ietf-hybi-permessage-compression-19
+[zlib-options]: https://nodejs.org/api/zlib.html#zlib_class_options

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -344,7 +344,13 @@ class PerMessageDeflate {
         ? zlib.Z_DEFAULT_WINDOWBITS
         : this.params[key];
 
-      this._inflate = zlib.createInflateRaw({ windowBits });
+      this._inflate = zlib.createInflateRaw(
+        Object.assign(
+          {},
+          this._options.zlibOptions,
+          { windowBits }
+        )
+      );
       this._inflate[kTotalLength] = 0;
       this._inflate[kBuffers] = [];
       this._inflate[kOwner] = this;

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -44,8 +44,7 @@ class PerMessageDeflate {
    *     use of a custom server window size
    * @param {(Boolean|Number)} options.clientMaxWindowBits Advertise support
    *     for, or request, a custom client window size
-   * @param {Number} options.level The value of zlib's `level` param
-   * @param {Number} options.memLevel The value of zlib's `memLevel` param
+   * @param {Number} options.zlibOptions Options to pass to zlib on deflate
    * @param {Number} options.threshold Size (in bytes) below which messages
    *     should not be compressed
    * @param {Number} options.concurrencyLimit The number of concurrent calls to
@@ -412,12 +411,20 @@ class PerMessageDeflate {
         ? zlib.Z_DEFAULT_WINDOWBITS
         : this.params[key];
 
-      this._deflate = zlib.createDeflateRaw({
+      const zlibOptions = {
+        // TODO deprecate memLevel/level and recommend zlibOptions instead
         memLevel: this._options.memLevel,
         level: this._options.level,
-        flush: zlib.Z_SYNC_FLUSH,
         windowBits
-      });
+      };
+      if (this._options.zlibOptions != null) {
+        if (typeof this._options.zlibOptions === 'number') {
+          throw new Error('Do not set `windowBits` on `zlibOptions`!');
+        }
+        Object.assign(zlibOptions, this._options.zlibOptions);
+      }
+
+      this._deflate = zlib.createDeflateRaw(zlibOptions);
 
       this._deflate[kTotalLength] = 0;
       this._deflate[kBuffers] = [];
@@ -434,7 +441,7 @@ class PerMessageDeflate {
 
     this._deflate.write(data);
     this._deflate.flush(zlib.Z_SYNC_FLUSH, () => {
-      var data = bufferUtil.concat(
+      let data = bufferUtil.concat(
         this._deflate[kBuffers],
         this._deflate[kTotalLength]
       );

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -44,7 +44,8 @@ class PerMessageDeflate {
    *     use of a custom server window size
    * @param {(Boolean|Number)} options.clientMaxWindowBits Advertise support
    *     for, or request, a custom client window size
-   * @param {Object} options.zlibOptions Options to pass to zlib on deflate
+   * @param {Object} options.zlibDeflateOptions Options to pass to zlib on deflate
+   * @param {Object} options.zlibInflateOptions Options to pass to zlib on inflate
    * @param {Number} options.threshold Size (in bytes) below which messages
    *     should not be compressed
    * @param {Number} options.concurrencyLimit The number of concurrent calls to
@@ -347,7 +348,7 @@ class PerMessageDeflate {
       this._inflate = zlib.createInflateRaw(
         Object.assign(
           {},
-          this._options.zlibOptions,
+          this._options.zlibInflateOptions,
           { windowBits }
         )
       );
@@ -419,12 +420,12 @@ class PerMessageDeflate {
 
       this._deflate = zlib.createDeflateRaw(
         Object.assign(
-          // TODO deprecate memLevel/level and recommend zlibOptions instead
+          // TODO deprecate memLevel/level and recommend zlibDeflateOptions instead
           {
             memLevel: this._options.memLevel,
             level: this._options.level
           },
-          this._options.zlibOptions,
+          this._options.zlibDeflateOptions,
           { windowBits }
         )
       );

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -411,20 +411,17 @@ class PerMessageDeflate {
         ? zlib.Z_DEFAULT_WINDOWBITS
         : this.params[key];
 
-      const zlibOptions = {
-        // TODO deprecate memLevel/level and recommend zlibOptions instead
-        memLevel: this._options.memLevel,
-        level: this._options.level,
-        windowBits
-      };
-      if (this._options.zlibOptions != null) {
-        if (typeof this._options.zlibOptions === 'number') {
-          throw new Error('Do not set `windowBits` on `zlibOptions`!');
-        }
-        Object.assign(zlibOptions, this._options.zlibOptions);
-      }
-
-      this._deflate = zlib.createDeflateRaw(zlibOptions);
+      this._deflate = zlib.createDeflateRaw(
+        Object.assign(
+          // TODO deprecate memLevel/level and recommend zlibOptions instead
+          {
+            memLevel: this._options.memLevel,
+            level: this._options.level
+          },
+          this._options.zlibOptions,
+          { windowBits }
+        )
+      );
 
       this._deflate[kTotalLength] = 0;
       this._deflate[kBuffers] = [];

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -44,7 +44,7 @@ class PerMessageDeflate {
    *     use of a custom server window size
    * @param {(Boolean|Number)} options.clientMaxWindowBits Advertise support
    *     for, or request, a custom client window size
-   * @param {Number} options.zlibOptions Options to pass to zlib on deflate
+   * @param {Object} options.zlibOptions Options to pass to zlib on deflate
    * @param {Number} options.threshold Size (in bytes) below which messages
    *     should not be compressed
    * @param {Number} options.concurrencyLimit The number of concurrent calls to
@@ -441,7 +441,7 @@ class PerMessageDeflate {
 
     this._deflate.write(data);
     this._deflate.flush(zlib.Z_SYNC_FLUSH, () => {
-      let data = bufferUtil.concat(
+      var data = bufferUtil.concat(
         this._deflate[kBuffers],
         this._deflate[kTotalLength]
       );

--- a/test/permessage-deflate.test.js
+++ b/test/permessage-deflate.test.js
@@ -352,8 +352,8 @@ describe('PerMessageDeflate', function () {
     });
 
     it('honors the `level` option', function (done) {
-      const lev9 = new PerMessageDeflate({ threshold: 0, level: 9 });
       const lev0 = new PerMessageDeflate({ threshold: 0, level: 0 });
+      const lev9 = new PerMessageDeflate({ threshold: 0, level: 9 });
       const extensionStr = (
         'permessage-deflate; server_no_context_takeover; ' +
         'client_no_context_takeover; server_max_window_bits=10; ' +
@@ -390,9 +390,27 @@ describe('PerMessageDeflate', function () {
       });
     });
 
-    it('honors the `zlibOptions` option', function (done) {
-      const lev9 = new PerMessageDeflate({ threshold: 0, zlibOptions: {level: 9, chunkSize: 128} });
-      const lev0 = new PerMessageDeflate({ threshold: 0, zlibOptions: {level: 0, chunkSize: 128} });
+    it('honors the `zlib{Deflate,Inflate}Options` option', function (done) {
+      const lev0 = new PerMessageDeflate({
+        threshold: 0,
+        zlibDeflateOptions: {
+          level: 0,
+          chunkSize: 256
+        },
+        zlibInflateOptions: {
+          chunkSize: 2048
+        }
+      });
+      const lev9 = new PerMessageDeflate({
+        threshold: 0,
+        zlibDeflateOptions: {
+          level: 9,
+          chunkSize: 128
+        },
+        zlibInflateOptions: {
+          chunkSize: 1024
+        }
+      });
 
       // Note no context takeover so we can get a hold of the raw streams after we do the dance
       const extensionStr = (
@@ -426,12 +444,10 @@ describe('PerMessageDeflate', function () {
               // Assert options were set.
               assert.ok(lev0._deflate._level === 0);
               assert.ok(lev9._deflate._level === 9);
-              assert.ok(lev0._inflate._level === 0);
-              assert.ok(lev9._inflate._level === 9);
-              assert.ok(lev0._deflate._chunkSize === 128);
+              assert.ok(lev0._deflate._chunkSize === 256);
               assert.ok(lev9._deflate._chunkSize === 128);
-              assert.ok(lev0._inflate._chunkSize === 128);
-              assert.ok(lev9._inflate._chunkSize === 128);
+              assert.ok(lev0._inflate._chunkSize === 2048);
+              assert.ok(lev9._inflate._chunkSize === 1024);
               done();
             });
           });


### PR DESCRIPTION
It can be useful to adjust other options, and rather than support and document every single one, it is simpler to allow passing on an object wholesale.

`level` and `memLevel` are still supported but should be removed in 4.x.

I'm still working on solutions to https://github.com/nodejs/node/issues/8871 (tracked in https://github.com/nodejs/node/issues/15301). In the meantime, depending on workload, memory fragmentation can be greatly reduced by adjusting `chunkSize`.