### PR TITLE
move dep to dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "eslint-plugin-promise": "~3.6.0",
     "eslint-plugin-standard": "~3.0.0",
     "mocha": "~5.0.0",
-    "nyc": "~11.4.1",
+    "nyc": "~11.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   },
   "dependencies": {
     "async-limiter": "~1.0.0",
-    "safe-buffer": "~5.1.0"
+    "bufferutil": "~3.0.0",
+    "safe-buffer": "~5.1.0",
+    "utf-8-validate": "~4.0.0"
   },
   "devDependencies": {
     "benchmark": "~2.1.2",
-    "bufferutil": "~3.0.0",
     "eslint": "~4.18.0",
     "eslint-config-standard": "~11.0.0",
     "eslint-plugin-import": "~2.9.0",
@@ -40,6 +41,5 @@
     "eslint-plugin-standard": "~3.0.0",
     "mocha": "~5.0.0",
     "nyc": "~11.4.1",
-    "utf-8-validate": "~4.0.0"
   }
 }


### PR DESCRIPTION
When using `webpack` to compile, there are two warnings saying that 
```
Module not found: Error: Can't resolve 'utf-8-validate'
Module not found: Error: Can't resolve 'bufferutil'
```
This is because these two lib are in `devDependency` not in `dependency`, so when user run `npm i`, they got ignored. I suggest to move them back to `dependency`.

---
reference to another [issue](https://github.com/coinbase/gdax-node/issues/162):