### PR TITLE
Drop support for Node.js < 4.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ node_js:
   - "8"
   - "6"
   - "4"
-  - "4.2.2"
 after_success:
   - "npm install coveralls@3 && nyc report --reporter=text-lcov | coveralls"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "6"
     - nodejs_version: "4"
-    - nodejs_version: "4.2.2"
 platform:
   - x86
   - x64

--- a/bench/parser.benchmark.js
+++ b/bench/parser.benchmark.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const benchmark = require('benchmark');
 const crypto = require('crypto');
 
@@ -8,7 +7,6 @@ const WebSocket = require('..');
 
 const Receiver = WebSocket.Receiver;
 const Sender = WebSocket.Sender;
-const Buffer = safeBuffer.Buffer;
 
 const options = {
   fin: true,

--- a/bench/speed.js
+++ b/bench/speed.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const cluster = require('cluster');
 
 const WebSocket = require('..');
 
-const Buffer = safeBuffer.Buffer;
 const port = 8181;
 
 if (cluster.isMaster) {

--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
-
-const Buffer = safeBuffer.Buffer;
-
 /**
  * Merges an array of buffers into a new buffer.
  *

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
-
-const Buffer = safeBuffer.Buffer;
-
 module.exports = {
   BINARY_TYPES: ['nodebuffer', 'arraybuffer', 'fragments'],
   GUID: '258EAFA5-E914-47DA-95CA-C5AB0DC85B11',

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -1,13 +1,10 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const Limiter = require('async-limiter');
 const zlib = require('zlib');
 
 const bufferUtil = require('./buffer-util');
 const constants = require('./constants');
-
-const Buffer = safeBuffer.Buffer;
 
 const TRAILER = Buffer.from([0x00, 0x00, 0xff, 0xff]);
 const EMPTY_BLOCK = Buffer.from([0x00]);

--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -1,14 +1,11 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const stream = require('stream');
 
 const PerMessageDeflate = require('./permessage-deflate');
 const bufferUtil = require('./buffer-util');
 const validation = require('./validation');
 const constants = require('./constants');
-
-const Buffer = safeBuffer.Buffer;
 
 const GET_INFO = 0;
 const GET_PAYLOAD_LENGTH_16 = 1;

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,14 +1,11 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const crypto = require('crypto');
 
 const PerMessageDeflate = require('./permessage-deflate');
 const bufferUtil = require('./buffer-util');
 const validation = require('./validation');
 const constants = require('./constants');
-
-const Buffer = safeBuffer.Buffer;
 
 /**
  * HyBi Sender implementation.

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const EventEmitter = require('events');
 const crypto = require('crypto');
 const http = require('http');
@@ -10,8 +9,6 @@ const PerMessageDeflate = require('./permessage-deflate');
 const extension = require('./extension');
 const constants = require('./constants');
 const WebSocket = require('./websocket');
-
-const Buffer = safeBuffer.Buffer;
 
 /**
  * Class representing a WebSocket server.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "async-limiter": "~1.0.0",
-    "safe-buffer": "~5.1.0"
+    "async-limiter": "~1.0.0"
   },
   "devDependencies": {
     "benchmark": "~2.1.2",

--- a/test/permessage-deflate.test.js
+++ b/test/permessage-deflate.test.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 
 const PerMessageDeflate = require('../lib/permessage-deflate');
 const extension = require('../lib/extension');
-
-const Buffer = safeBuffer.Buffer;
 
 describe('PerMessageDeflate', function () {
   describe('#offer', function () {

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 const crypto = require('crypto');
 
@@ -10,7 +9,6 @@ const Receiver = require('../lib/receiver');
 const Sender = require('../lib/sender');
 
 const kStatusCode = constants.kStatusCode;
-const Buffer = safeBuffer.Buffer;
 
 describe('Receiver', function () {
   it('parses an unmasked text message', function (done) {

--- a/test/sender.test.js
+++ b/test/sender.test.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 
 const PerMessageDeflate = require('../lib/permessage-deflate');
 const Sender = require('../lib/sender');
-
-const Buffer = safeBuffer.Buffer;
 
 describe('Sender', function () {
   describe('.frame', function () {

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 const crypto = require('crypto');
 const https = require('https');
@@ -11,8 +10,6 @@ const net = require('net');
 const fs = require('fs');
 
 const WebSocket = require('..');
-
-const Buffer = safeBuffer.Buffer;
 
 describe('WebSocketServer', function () {
   describe('#ctor', function () {

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const safeBuffer = require('safe-buffer');
 const assert = require('assert');
 const crypto = require('crypto');
 const https = require('https');
@@ -13,8 +12,6 @@ const os = require('os');
 
 const constants = require('../lib/constants');
 const WebSocket = require('..');
-
-const Buffer = safeBuffer.Buffer;
 
 class CustomAgent extends http.Agent {
   addRequest () {}


### PR DESCRIPTION
Node.js 4.x will go EOL at the end of April and all versions below 4.8.7 have at least one security vulnerability. I see no reason to keep supporting versions in the range 4.0.0 - 4.4.7.

I actually want to drop support for all 4.x versions but maybe it's better to wait a little more.