### PR TITLE
[fix] remove buffer `noAssert` argument

### DIFF
--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -235,7 +235,7 @@ class Receiver extends stream.Writable {
       return;
     }
 
-    this._payloadLength = this.consume(2).readUInt16BE(0, true);
+    this._payloadLength = this.consume(2).readUInt16BE(0);
     return this.haveLength();
   }
 
@@ -252,7 +252,7 @@ class Receiver extends stream.Writable {
     }
 
     const buf = this.consume(8);
-    const num = buf.readUInt32BE(0, true);
+    const num = buf.readUInt32BE(0);
 
     //
     // The maximum safe integer in JavaScript is 2^53 - 1. An error is returned
@@ -268,7 +268,7 @@ class Receiver extends stream.Writable {
       );
     }
 
-    this._payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4, true);
+    this._payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4);
     return this.haveLength();
   }
 
@@ -435,7 +435,7 @@ class Receiver extends stream.Writable {
       } else if (data.length === 1) {
         return error(RangeError, 'invalid payload length 1', true, 1002);
       } else {
-        const code = data.readUInt16BE(0, true);
+        const code = data.readUInt16BE(0);
 
         if (!validation.isValidStatusCode(code)) {
           return error(RangeError, `invalid status code ${code}`, true, 1002);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -61,10 +61,10 @@ class Sender {
     if (options.rsv1) target[0] |= 0x40;
 
     if (payloadLength === 126) {
-      target.writeUInt16BE(data.length, 2, true);
+      target.writeUInt16BE(data.length, 2);
     } else if (payloadLength === 127) {
-      target.writeUInt32BE(0, 2, true);
-      target.writeUInt32BE(data.length, 6, true);
+      target.writeUInt32BE(0, 2);
+      target.writeUInt32BE(data.length, 6);
     }
 
     if (!options.mask) {
@@ -112,10 +112,10 @@ class Sender {
       throw new TypeError('First argument must be a valid error code number');
     } else if (data === undefined || data === '') {
       buf = Buffer.allocUnsafe(2);
-      buf.writeUInt16BE(code, 0, true);
+      buf.writeUInt16BE(code, 0);
     } else {
       buf = Buffer.allocUnsafe(2 + Buffer.byteLength(data));
-      buf.writeUInt16BE(code, 0, true);
+      buf.writeUInt16BE(code, 0);
       buf.write(data, 2);
     }
 


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
10.x release. This removes it to make sure everything still works as
it should by already validating the input right away.

Refs: https://github.com/nodejs/node/pull/18395