### PR TITLE
Use js version of `{un,}mask()` for very small frames

### DIFF
--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -8,7 +8,7 @@
  * @return {Buffer} The resulting buffer
  * @public
  */
-const concat = (list, totalLength) => {
+function concat (list, totalLength) {
   const target = Buffer.allocUnsafe(totalLength);
   var offset = 0;
 
@@ -19,43 +19,54 @@ const concat = (list, totalLength) => {
   }
 
   return target;
-};
+}
+
+/**
+ * Masks a buffer using the given mask.
+ *
+ * @param {Buffer} source The buffer to mask
+ * @param {Buffer} mask The mask to use
+ * @param {Buffer} output The buffer where to store the result
+ * @param {Number} offset The offset at which to start writing
+ * @param {Number} length The number of bytes to mask.
+ * @public
+ */
+function _mask (source, mask, output, offset, length) {
+  for (var i = 0; i < length; i++) {
+    output[offset + i] = source[i] ^ mask[i & 3];
+  }
+}
+
+/**
+ * Unmasks a buffer using the given mask.
+ *
+ * @param {Buffer} buffer The buffer to unmask
+ * @param {Buffer} mask The mask to use
+ * @public
+ */
+function _unmask (buffer, mask) {
+  // Required until https://github.com/nodejs/node/issues/9006 is resolved.
+  const length = buffer.length;
+  for (var i = 0; i < length; i++) {
+    buffer[i] ^= mask[i & 3];
+  }
+}
 
 try {
   const bufferUtil = require('bufferutil');
+  const bu = bufferUtil.BufferUtil || bufferUtil;
 
-  module.exports = Object.assign({ concat }, bufferUtil.BufferUtil || bufferUtil);
+  module.exports = {
+    mask (source, mask, output, offset, length) {
+      if (length < 48) _mask(source, mask, output, offset, length);
+      else bu.mask(source, mask, output, offset, length);
+    },
+    unmask (buffer, mask) {
+      if (buffer.length < 32) _unmask(buffer, mask);
+      else bu.unmask(buffer, mask);
+    },
+    concat
+  };
 } catch (e) /* istanbul ignore next */ {
-  /**
-   * Masks a buffer using the given mask.
-   *
-   * @param {Buffer} source The buffer to mask
-   * @param {Buffer} mask The mask to use
-   * @param {Buffer} output The buffer where to store the result
-   * @param {Number} offset The offset at which to start writing
-   * @param {Number} length The number of bytes to mask.
-   * @public
-   */
-  const mask = (source, mask, output, offset, length) => {
-    for (var i = 0; i < length; i++) {
-      output[offset + i] = source[i] ^ mask[i & 3];
-    }
-  };
-
-  /**
-   * Unmasks a buffer using the given mask.
-   *
-   * @param {Buffer} buffer The buffer to unmask
-   * @param {Buffer} mask The mask to use
-   * @public
-   */
-  const unmask = (buffer, mask) => {
-    // Required until https://github.com/nodejs/node/issues/9006 is resolved.
-    const length = buffer.length;
-    for (var i = 0; i < length; i++) {
-      buffer[i] ^= mask[i & 3];
-    }
-  };
-
-  module.exports = { concat, mask, unmask };
+  module.exports = { concat, mask: _mask, unmask: _unmask };
 }


### PR DESCRIPTION
Prefer the pure JS version of `mask()` and `unmask()` when working with very small buffers.

```
$ node mask.js 16
mask 16 bytes (JS) x 21,724,086 ops/sec ±0.77% (93 runs sampled)
mask 16 bytes (addon) x 6,730,729 ops/sec ±2.49% (94 runs sampled)
```

```
node unmask.js 16 
unmask 16 bytes (JS) x 21,601,809 ops/sec ±0.28% (88 runs sampled)
unmask 16 bytes (addon) x 9,842,054 ops/sec ±0.29% (89 runs sampled)
```