### PR TITLE
[doc] "Multiple servers sharing...", add `request` to emit arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,11 @@ server.on('upgrade', function upgrade(request, socket, head) {
 
   if (pathname === '/foo') {
     wss1.handleUpgrade(request, socket, head, function done(ws) {
-      wss1.emit('connection', ws);
+      wss1.emit('connection', ws, request);
     });
   } else if (pathname === '/bar') {
     wss2.handleUpgrade(request, socket, head, function done(ws) {
-      wss2.emit('connection', ws);
+      wss2.emit('connection', ws, request);
     });
   } else {
     socket.destroy();


### PR DESCRIPTION
I spent 90-minutes trying to figure out why my `connection` handler `request` argument was undefined. I thought making the docs for the `noServer` configuration more idiomatic with the expected behavior of the `server` configuration might save others from frustration in the future.