### PR TITLE
add request property to websocket

### DIFF
--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -246,6 +246,7 @@ class WebSocketServer extends EventEmitter {
     ];
 
     const ws = new WebSocket(null);
+    ws.request = req;
     var protocol = req.headers['sec-websocket-protocol'];
 
     if (protocol) {


### PR DESCRIPTION
This adds a `.request` property to the socket.

Closes #1377