### PR TITLE
verifyClient callback now accepts "headers" parameter

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -53,6 +53,9 @@ if `verifyClient` is provided with two arguments then those are:
     error status code to be sent to the client.
   - `name` {String} When `result` is `false` this field determines the HTTP
     reason phrase.
+  - `headers` {Object} When `result` is `false` this field determines additional 
+    HTTP headers to be sent to the client. 
+    For example, `{ 'Set-Cookie': 'abortReason=tooManyConnections' }`.
 
 
 `handleProtocols` takes two arguments:

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -53,9 +53,8 @@ if `verifyClient` is provided with two arguments then those are:
     error status code to be sent to the client.
   - `name` {String} When `result` is `false` this field determines the HTTP
     reason phrase.
-  - `headers` {Object} When `result` is `false` this field determines additional 
-    HTTP headers to be sent to the client. 
-    For example, `{ 'Set-Cookie': 'abortReason=tooManyConnections' }`.
+  - `headers` {Object} When `result` is `false` this field determines additional
+    HTTP headers to be sent to the client. For example, `{ 'Retry-After': 120 }`.
 
 
 `handleProtocols` takes two arguments:

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -204,8 +204,10 @@ class WebSocketServer extends EventEmitter {
       };
 
       if (this.options.verifyClient.length === 2) {
-        this.options.verifyClient(info, (verified, code, message) => {
-          if (!verified) return abortHandshake(socket, code || 401, message);
+        this.options.verifyClient(info, (verified, code, message, headers) => {
+          if (!verified) {
+            return abortHandshake(socket, code || 401, message, headers);
+          }
 
           this.completeUpgrade(extensions, req, socket, head, cb);
         });
@@ -330,17 +332,22 @@ function socketOnError () {
  * @param {net.Socket} socket The socket of the upgrade request
  * @param {Number} code The HTTP response status code
  * @param {String} [message] The HTTP response body
+ * @param {Object} [headers] Additional HTTP response headers
  * @private
  */
-function abortHandshake (socket, code, message) {
+function abortHandshake (socket, code, message, headers) {
   if (socket.writable) {
     message = message || http.STATUS_CODES[code];
+    headers = Object.assign({
+      'Connection': 'close',
+      'Content-type': 'text/html',
+      'Content-Length': Buffer.byteLength(message)
+    }, headers);
+
     socket.write(
       `HTTP/1.1 ${code} ${http.STATUS_CODES[code]}\r\n` +
-      'Connection: close\r\n' +
-      'Content-type: text/html\r\n' +
-      `Content-Length: ${Buffer.byteLength(message)}\r\n` +
-      '\r\n' +
+      Object.keys(headers).map(h => `${h}: ${headers[h]}`).join('\r\n') +
+      '\r\n\r\n' +
       message
     );
   }

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -551,7 +551,7 @@ describe('WebSocketServer', function () {
         });
       });
 
-      it('can reject client asynchronously with status code', function (done) {
+      it('can reject client asynchronously w/ status code', function (done) {
         const wss = new WebSocket.Server({
           verifyClient: (info, cb) => process.nextTick(cb, false, 404),
           port: 0
@@ -577,11 +577,11 @@ describe('WebSocketServer', function () {
         });
       });
 
-      it('can reject client asynchronously with your headers', function (done) {
+      it('can reject client asynchronously w/ custom headers', function (done) {
         const wss = new WebSocket.Server({
-          verifyClient: (info, cb) => process.nextTick(cb, false, 401, '', {
-            'Set-Cookie': 'abortReason=tooManyConnections'
-          }),
+          verifyClient: (info, cb) => {
+            process.nextTick(cb, false, 503, '', { 'Retry-After': 120 });
+          },
           port: 0
         }, () => {
           const req = http.get({
@@ -595,10 +595,8 @@ describe('WebSocketServer', function () {
           });
 
           req.on('response', (res) => {
-            assert.deepStrictEqual(
-              res.headers['set-cookie'],
-              ['abortReason=tooManyConnections']
-            );
+            assert.strictEqual(res.statusCode, 503);
+            assert.strictEqual(res.headers['retry-after'], '120');
             wss.close(done);
           });
         });


### PR DESCRIPTION
Which is passed to abortHandshake().

Fixes: https://github.com/websockets/ws/issues/695
Fixes: https://github.com/websockets/ws/issues/728