### PR TITLE
Added options.maxPayload for websocket clients

### DIFF
--- a/bench/speed.js
+++ b/bench/speed.js
@@ -54,7 +54,9 @@ if (cluster.isMaster) {
 
   const runConfig = (useBinary, roundtrips, size, cb) => {
     const data = randomBytes.slice(0, size);
-    const ws = new WebSocket(`ws://localhost:${port}`);
+    const ws = new WebSocket(`ws://localhost:${port}`, {
+      maxPayload: 600 * 1024 * 1024
+    });
     var roundtrip = 0;
     var time;
 

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -199,6 +199,7 @@ This class represents a WebSocket. It extends the `EventEmitter`.
   - `protocolVersion` {Number} Value of the `Sec-WebSocket-Version` header.
   - `origin` {String} Value of the `Origin` or `Sec-WebSocket-Origin` header
     depending on the `protocolVersion`.
+  - `maxPayload` {Number} The maximum allowed message size in bytes.
   - Any other option allowed in [http.request()][] or [https.request()][].
 
 `perMessageDeflate` default value is `true`. When using an object, parameters

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -411,12 +411,14 @@ module.exports = WebSocket;
  * @param {Number} options.handshakeTimeout Timeout in milliseconds for the handshake request
  * @param {Number} options.protocolVersion Value of the `Sec-WebSocket-Version` header
  * @param {String} options.origin Value of the `Origin` or `Sec-WebSocket-Origin` header
+ * @param {Number} options.maxPayload The maximum allowed message size
  * @private
  */
 function initAsClient (address, protocols, options) {
   options = Object.assign({
     protocolVersion: protocolVersions[1],
-    perMessageDeflate: true
+    perMessageDeflate: true,
+    maxPayload: 100 * 1024 * 1024,
   }, options, {
     createConnection: undefined,
     socketPath: undefined,
@@ -599,7 +601,7 @@ function initAsClient (address, protocols, options) {
       }
     }
 
-    this.setSocket(socket, head, 0);
+    this.setSocket(socket, head, options.maxPayload);
   });
 }
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -481,7 +481,8 @@ function initAsClient (address, protocols, options) {
   if (options.perMessageDeflate) {
     perMessageDeflate = new PerMessageDeflate(
       options.perMessageDeflate !== true ? options.perMessageDeflate : {},
-      false
+      false,
+      options.maxPayload
     );
     options.headers['Sec-WebSocket-Extensions'] = extension.format({
       [PerMessageDeflate.extensionName]: perMessageDeflate.offer()

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -418,7 +418,7 @@ function initAsClient (address, protocols, options) {
   options = Object.assign({
     protocolVersion: protocolVersions[1],
     perMessageDeflate: true,
-    maxPayload: 100 * 1024 * 1024,
+    maxPayload: 100 * 1024 * 1024
   }, options, {
     createConnection: undefined,
     socketPath: undefined,

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -65,6 +65,28 @@ describe('WebSocket', function () {
         assert.strictEqual(count, 3);
       });
 
+      it('accepts the `maxPayload` option', function (done) {
+        const maxPayload = 20480;
+        const wss = new WebSocket.Server({
+          perMessageDeflate: true,
+          port: 0
+        }, () => {
+          const ws = new WebSocket(`ws://localhost:${wss.address().port}`, {
+            perMessageDeflate: true,
+            maxPayload
+          });
+
+          ws.on('open', () => {
+            assert.strictEqual(ws._receiver._maxPayload, maxPayload);
+            assert.strictEqual(
+              ws._receiver._extensions['permessage-deflate']._maxPayload,
+              maxPayload
+            );
+            wss.close(done);
+          });
+        });
+      });
+
       it('throws an error when using an invalid `protocolVersion`', function () {
         const options = { agent: new CustomAgent(), protocolVersion: 1000 };
 


### PR DESCRIPTION
I came across a situation where a websocket client instance needs to be protected against large messages. This pull request makes the option.maxPayload option available for client instances. 