### PR TITLE
Make `WebSocketServer#close()` emit the `'close'` event

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -101,6 +101,12 @@ to the threshold. This determines if compression is used for the entire message.
 `callback` will be added as a listener for the `listening` event on the HTTP
 server when not operating in "noServer" mode.
 
+### Event: 'close'
+
+Emitted when the server closes. This event depends on the `'close'` event of
+HTTP server only when it is created internally. In all other cases, the event
+is emitted independently.
+
 ### Event: 'connection'
 
 - `socket` {WebSocket}

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -112,6 +112,8 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   close (cb) {
+    if (cb) this.once('close', cb);
+
     //
     // Terminate all associated clients.
     //
@@ -128,10 +130,13 @@ class WebSocketServer extends EventEmitter {
       //
       // Close the http server if it was internally created.
       //
-      if (this.options.port != null) return server.close(cb);
+      if (this.options.port != null) {
+        server.close(() => this.emit('close'));
+        return;
+      }
     }
 
-    if (cb) cb();
+    process.nextTick(emitClose, this);
   }
 
   /**
@@ -315,6 +320,16 @@ function addListeners (server, map) {
       server.removeListener(event, map[event]);
     }
   };
+}
+
+/**
+ * Emit a `'close'` event on an `EventEmitter`.
+ *
+ * @param {EventEmitter} server The event emitter
+ * @private
+ */
+function emitClose (server) {
+  server.emit('close');
 }
 
 /**

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -230,6 +230,13 @@ describe('WebSocketServer', function () {
         });
       });
     });
+
+    it("emits the 'close' event", function (done) {
+      const wss = new WebSocket.Server({ noServer: true });
+
+      wss.on('close', done);
+      wss.close();
+    });
   });
 
   describe('#clients', function () {
@@ -689,7 +696,7 @@ describe('WebSocketServer', function () {
       });
     });
 
-    it('emits the `headers` event', function (done) {
+    it("emits the 'headers' event", function (done) {
       const wss = new WebSocket.Server({ port: 0 }, () => {
         const ws = new WebSocket(`ws://localhost:${wss.address().port}`);
 


### PR DESCRIPTION
As titled. Fixes #1375.