### PR TITLE
Do not waste time compressing when socket is closed

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -28,7 +28,7 @@ class Sender {
     this._deflating = false;
     this._queue = [];
 
-    this._socket.once('close', () => {
+    this._socket.prependOnceListener('close', () => {
       const err = new Error(
         `WebSocket is not open: readyState ${this._socket.readyState} `
       );

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -30,7 +30,7 @@ class Sender {
 
     this._socket.once('close', () => {
       const err = new Error(
-        `WebSocket is not open: readyState CLOSING`
+        `WebSocket is not open: readyState 2 (CLOSING)`
       );
 
       while (this._queue.length) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -28,23 +28,19 @@ class Sender {
     this._deflating = false;
     this._queue = [];
 
-    this._socket.once('close', () => {
-      const err = new Error(
-        `WebSocket is not open: readyState 2 (CLOSING)`
-      );
+    if (this._extensions[PerMessageDeflate.extensionName]) {
+      this._socket.once('close', () => {
+        const err = new Error('WebSocket is not open: readyState 2 (CLOSING)');
 
-      while (this._queue.length) {
-        const params = this._queue.shift();
+        while (this._queue.length) {
+          const params = this._queue.shift();
+          const cb = params[params.length - 1];
 
-        this._bufferedBytes -= params[1].length;
-
-        const cb = params[params.length - 1];
-
-        if (typeof cb === 'function') {
-          cb(err);
+          this._bufferedBytes -= params[1].length;
+          if (typeof cb === 'function') cb(err);
         }
-      }
-    });
+      });
+    }
   }
 
   /**

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -38,7 +38,11 @@ class Sender {
 
         this._bufferedBytes -= params[1].length;
 
-        params[params.length - 1](err);
+        const cb = params[params.length - 1];
+
+        if (typeof cb === 'function') {
+          cb(err);
+        }
       }
     });
   }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -30,7 +30,7 @@ class Sender {
 
     this._socket.once('close', () => {
       const err = new Error(
-        `WebSocket is not open: readyState ${this._socket.readyState} `
+        `WebSocket is not open: readyState CLOSING`
       );
 
       while (this._queue.length) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -363,7 +363,6 @@ class Sender {
       const params = this._queue.shift();
 
       this._bufferedBytes -= params[1].length;
-
       params[0].apply(this, params.slice(1));
     }
   }

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -28,7 +28,7 @@ class Sender {
     this._deflating = false;
     this._queue = [];
 
-    this._socket.on('close', () => {
+    this._socket.once('close', () => {
       const err = new Error(
         `WebSocket is not open: readyState ${this._socket.readyState} `
       );

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -28,7 +28,7 @@ class Sender {
     this._deflating = false;
     this._queue = [];
 
-    this._socket.prependOnceListener('close', () => {
+    this._socket.once('close', () => {
       const err = new Error(
         `WebSocket is not open: readyState ${this._socket.readyState} `
       );

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,6 +27,20 @@ class Sender {
     this._bufferedBytes = 0;
     this._deflating = false;
     this._queue = [];
+
+    this._socket.on('close', () => {
+      const err = new Error(
+        `WebSocket is not open: readyState ${this._socket.readyState} `
+      );
+
+      while (this._queue.length) {
+        const params = this._queue.shift();
+
+        this._bufferedBytes -= params[1].length;
+
+        params[params.length - 1](err);
+      }
+    });
   }
 
   /**
@@ -349,6 +363,7 @@ class Sender {
       const params = this._queue.shift();
 
       this._bufferedBytes -= params[1].length;
+
       params[0].apply(this, params.slice(1));
     }
   }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -123,6 +123,8 @@ class WebSocket extends EventEmitter {
       maxPayload
     );
 
+    // Note that we must instantiate the Sender before we add socket.on('close') below
+    // because we want the Sender to empty its queue before sending our own close event.
     this._sender = new Sender(socket, this._extensions);
     this._receiver = receiver;
     this._socket = socket;

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -123,8 +123,11 @@ class WebSocket extends EventEmitter {
       maxPayload
     );
 
-    // Note that we must instantiate the Sender before we add socket.on('close') below
-    // because we want the Sender to empty its queue before sending our own close event.
+    //
+    // `Sender` must be instantiated before adding the `socketOnClose` listener.
+    // This allows the sender queue, when used, to be emptied before
+    // `socketOnClose` is called.
+    //
     this._sender = new Sender(socket, this._extensions);
     this._receiver = receiver;
     this._socket = socket;

--- a/test/sender.test.js
+++ b/test/sender.test.js
@@ -79,7 +79,7 @@ describe('Sender', function () {
           assert.strictEqual(data[0] & 0x40, 0x40);
           if (++numWritten > 1) done(new Error('Too many attempted writes'));
         },
-        prependOnceListener: (ev, cb) => {
+        once: (ev, cb) => {
           if (ev === 'close') {
             process.nextTick(cb);
           }

--- a/test/sender.test.js
+++ b/test/sender.test.js
@@ -6,15 +6,17 @@ const PerMessageDeflate = require('../lib/permessage-deflate');
 const Sender = require('../lib/sender');
 
 class MockSocket {
-  constructor ({ write, on, once } = {}) {
+  constructor ({ write, on, once, prependOnceListener } = {}) {
     if (write) this.write = write;
     if (on) this.on = on;
     if (once) this.once = once;
+    if (prependOnceListener) this.prependOnceListener = prependOnceListener;
   }
 
   write () {}
   on () {}
   once () {}
+  prependOnceListener () {}
 }
 
 describe('Sender', function () {
@@ -77,7 +79,7 @@ describe('Sender', function () {
           assert.strictEqual(data[0] & 0x40, 0x40);
           if (++numWritten > 1) done(new Error('Too many attempted writes'));
         },
-        once: (ev, cb) => {
+        prependOnceListener: (ev, cb) => {
           if (ev === 'close') {
             process.nextTick(cb);
           }

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -2041,7 +2041,6 @@ describe('WebSocket', function () {
     });
 
     it('reports the web socket as CLOSING in error callbacks when connection is terminated abnormally', function (done) {
-      console.log('================================================= START');
       const wss = new WebSocket.Server({
         perMessageDeflate: { threshold: 0 },
         port: 0


### PR DESCRIPTION
Addresses #1226 - I agree with @lpinca 's approach in general.  This has been tested with the offending code listed in the issue and it correctly short circuits while still providing a relevant error to each pending request.  I've also added a unit test that fails without the added code as it tries to write/compress too much.

Not sure how I feel about having to add the extra `on: () => {}` to the Sender unit tests for the socket object, but these are mocks anyway.  Open to suggestions if this isn't preferred.