### PR TITLE
Ignore callbacks when clearing the send queue

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -27,20 +27,6 @@ class Sender {
     this._bufferedBytes = 0;
     this._deflating = false;
     this._queue = [];
-
-    if (this._extensions[PerMessageDeflate.extensionName]) {
-      this._socket.once('close', () => {
-        const err = new Error('WebSocket is not open: readyState 2 (CLOSING)');
-
-        while (this._queue.length) {
-          const params = this._queue.shift();
-          const cb = params[params.length - 1];
-
-          this._bufferedBytes -= params[1].length;
-          if (typeof cb === 'function') cb(err);
-        }
-      });
-    }
   }
 
   /**
@@ -346,9 +332,19 @@ class Sender {
 
     this._deflating = true;
     perMessageDeflate.compress(data, options.fin, (_, buf) => {
+      this._deflating = false;
+
+      if (!this._socket.readable && !this._socket.writable) {
+        //
+        // The socket is closed. Clear the queue and bail out.
+        //
+        this._bufferedBytes = 0;
+        this._queue.length = 0;
+        return;
+      }
+
       options.readOnly = false;
       this.sendFrame(Sender.frame(buf, options), cb);
-      this._deflating = false;
       this.dequeue();
     });
   }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -123,11 +123,6 @@ class WebSocket extends EventEmitter {
       maxPayload
     );
 
-    //
-    // `Sender` must be instantiated before adding the `socketOnClose` listener.
-    // This allows the sender queue, when used, to be emptied before
-    // `socketOnClose` is called.
-    //
     this._sender = new Sender(socket, this._extensions);
     this._receiver = receiver;
     this._socket = socket;


### PR DESCRIPTION
Do not invoke callbacks when clearing the send queue due to premature
socket closure.

Refs: https://github.com/websockets/ws/pull/1464#issuecomment-435578571
Fixes #1226