### PR TITLE
[feature] allow changing maxPayload of open socket

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -321,6 +321,13 @@ Initiate a closing handshake.
 
 An object containing the negotiated extensions.
 
+### websocket.maxPayload
+
+- {Number}
+
+The maximum allowed size (in bytes) for received messages. Defaults to the value
+of the `maxPayload` option, or 100 MiB if none was provided.
+
 ### websocket.onclose
 
 - {Function}

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -192,8 +192,7 @@ class WebSocketServer extends EventEmitter {
     if (this.options.perMessageDeflate) {
       const perMessageDeflate = new PerMessageDeflate(
         this.options.perMessageDeflate,
-        true,
-        this.options.maxPayload
+        true
       );
 
       try {
@@ -302,7 +301,8 @@ class WebSocketServer extends EventEmitter {
     socket.write(headers.concat('\r\n').join('\r\n'));
     socket.removeListener('error', socketOnError);
 
-    ws.setSocket(socket, head, this.options.maxPayload);
+    ws.maxPayload = this.options.maxPayload;
+    ws.setSocket(socket, head);
 
     if (this.clients) {
       this.clients.add(ws);

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -47,6 +47,7 @@ class WebSocket extends EventEmitter {
     this._closeCode = 1006;
     this._extensions = {};
     this._isServer = true;
+    this._maxPayload = 0;
     this._receiver = null;
     this._sender = null;
     this._socket = null;
@@ -100,6 +101,23 @@ class WebSocket extends EventEmitter {
   /**
    * @type {Number}
    */
+  get maxPayload() {
+    return this._maxPayload;
+  }
+
+  set maxPayload(value) {
+    this._maxPayload = value | 0;
+
+    if (this._receiver) this._receiver._maxPayload = value | 0;
+
+    if (this._extensions[PerMessageDeflate.extensionName]) {
+      this._extensions[PerMessageDeflate.extensionName]._maxPayload = value | 0;
+    }
+  }
+
+  /**
+   * @type {Number}
+   */
   get bufferedAmount() {
     if (!this._socket) return 0;
 
@@ -121,14 +139,13 @@ class WebSocket extends EventEmitter {
    *
    * @param {net.Socket} socket The network socket between the server and client
    * @param {Buffer} head The first packet of the upgraded stream
-   * @param {Number} maxPayload The maximum allowed message size
    * @private
    */
-  setSocket(socket, head, maxPayload) {
+  setSocket(socket, head) {
     const receiver = new Receiver(
       this._binaryType,
       this._extensions,
-      maxPayload
+      this._maxPayload
     );
 
     this._sender = new Sender(socket, this._extensions);
@@ -457,6 +474,7 @@ function initAsClient(address, protocols, options) {
   }
 
   this._isServer = false;
+  this.maxPayload = options.maxPayload;
 
   var parsedUrl;
 
@@ -505,8 +523,7 @@ function initAsClient(address, protocols, options) {
   if (options.perMessageDeflate) {
     perMessageDeflate = new PerMessageDeflate(
       options.perMessageDeflate !== true ? options.perMessageDeflate : {},
-      false,
-      options.maxPayload
+      false
     );
     options.headers['Sec-WebSocket-Extensions'] = extension.format({
       [PerMessageDeflate.extensionName]: perMessageDeflate.offer()
@@ -606,6 +623,7 @@ function initAsClient(address, protocols, options) {
 
         if (extensions[PerMessageDeflate.extensionName]) {
           perMessageDeflate.accept(extensions[PerMessageDeflate.extensionName]);
+          perMessageDeflate._maxPayload = this._maxPayload;
           this._extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
         }
       } catch (err) {
@@ -614,7 +632,7 @@ function initAsClient(address, protocols, options) {
       }
     }
 
-    this.setSocket(socket, head, options.maxPayload);
+    this.setSocket(socket, head);
   });
 }
 


### PR DESCRIPTION
This enables using a small maxPayload by default and then switching to a large value after the client has been authenticated in some way.