### PR TITLE
[feature] socketTimeout option

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -20,6 +20,7 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `clientTracking` {Boolean} Specifies whether or not to track clients.
   - `perMessageDeflate` {Boolean|Object} Enable/disable permessage-deflate.
   - `maxPayload` {Number} The maximum allowed message size in bytes.
+  - `socketTimeout` {Number} Timeout in milliseconds for idle sockets.
 - `callback` {Function}
 
 Create a new server instance. One of `port`, `server` or `noServer` must be

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -30,6 +30,7 @@ class WebSocketServer extends EventEmitter {
    * @param {(Boolean|Object)} options.perMessageDeflate Enable/disable permessage-deflate
    * @param {Number} options.maxPayload The maximum allowed message size
    * @param {Function} callback A listener for the `listening` event
+   * @param {Number} options.socketTimeout Timeout in milliseconds for idle sockets
    */
   constructor(options, callback) {
     super();
@@ -46,7 +47,8 @@ class WebSocketServer extends EventEmitter {
         server: null,
         host: null,
         path: null,
-        port: null
+        port: null,
+        socketTimeout: 120000
       },
       options
     );
@@ -67,6 +69,7 @@ class WebSocketServer extends EventEmitter {
         });
         res.end(body);
       });
+      this._server.timeout = options.socketTimeout;
       this._server.listen(
         options.port,
         options.host,


### PR DESCRIPTION
When you connect to the websocket server and don't send any data and idle, the socket on the server keeps being opened for default timeout (12 minutes)
`$ nc localhost 8080`
I think for some people default 12 minutes timeout feels too long.
And this timeout seems enough to exhaust available sockets on the server if some malicious user commits DDOS attack.
I think it would be great if socketTimeout option is supported.