### PR TITLE
Use the `defaultPort` option

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -479,6 +479,7 @@ function initAsClient(address, protocols, options) {
 
   const isSecure =
     parsedUrl.protocol === 'wss:' || parsedUrl.protocol === 'https:';
+  const defaultPort = isSecure ? 443 : 80;
   const key = crypto.randomBytes(16).toString('base64');
   const httpObj = isSecure ? https : http;
   const path = parsedUrl.search
@@ -487,7 +488,8 @@ function initAsClient(address, protocols, options) {
   var perMessageDeflate;
 
   options.createConnection = isSecure ? tlsConnect : netConnect;
-  options.port = parsedUrl.port || (isSecure ? 443 : 80);
+  options.defaultPort = options.defaultPort || defaultPort;
+  options.port = parsedUrl.port || defaultPort;
   options.host = parsedUrl.hostname.startsWith('[')
     ? parsedUrl.hostname.slice(1, -1)
     : parsedUrl.hostname;


### PR DESCRIPTION
Prevent the default port from being added to the `Host` header when no
`Agent` is used.

Fixes #1505