### PR TITLE
docs: Add missing dependency in code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ server.listen(8080);
 ```js
 const http = require('http');
 const WebSocket = require('ws');
+const url = require('url');
 
 const server = http.createServer();
 const wss1 = new WebSocket.Server({ noServer: true });


### PR DESCRIPTION
Hey!
In the "Multiple servers sharing a single HTTP/S server" usage example URL module is used but it's not included in the snippet. This PR is adding 
```javascript
const url = require('url');
```
line to make the snippet valid.