### PR TITLE
Setting the servername to an empty string '' should disable sending the SNI extension.

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -668,7 +668,8 @@ function netConnect(options) {
  */
 function tlsConnect(options) {
   options.path = undefined;
-  options.servername = options.servername || options.host;
+  if (!options.servername && options.servername !== '') 
+    options.servername = options.host;
   return tls.connect(options);
 }
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -668,8 +668,11 @@ function netConnect(options) {
  */
 function tlsConnect(options) {
   options.path = undefined;
-  if (!options.servername && options.servername !== '')
+
+  if (!options.servername && options.servername !== '') {
     options.servername = options.host;
+  }
+
   return tls.connect(options);
 }
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -668,7 +668,7 @@ function netConnect(options) {
  */
 function tlsConnect(options) {
   options.path = undefined;
-  if (!options.servername && options.servername !== '') 
+  if (!options.servername && options.servername !== '')
     options.servername = options.host;
   return tls.connect(options);
 }

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const https = require('https');
 const http = require('http');
+const tls = require('tls');
 const fs = require('fs');
 const { URL } = require('url');
 
@@ -2040,6 +2041,29 @@ describe('WebSocket', () => {
         });
       });
     }).timeout(4000);
+
+    describe('tls connect options', () => {
+      const tlsConnect = tls.connect;
+      let tlsConnectOptions;
+
+      beforeEach(() => {
+        tlsConnectOptions = {};
+        tls.connect = (options) => {
+          Object.assign(tlsConnectOptions, options);
+        };
+      });
+
+      afterEach(() => {
+        tls.connect = tlsConnect;
+      });
+
+      it('allows to use empty string to disable sending the SNI extension', () => {
+        const ws = new WebSocket('wss://127.0.0.1', {
+          servername: ''
+        });
+        assert.strictEqual(tlsConnectOptions.servername, '');
+      });
+    });
   });
 
   describe('Request headers', () => {

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -2042,27 +2042,16 @@ describe('WebSocket', () => {
       });
     }).timeout(4000);
 
-    describe('tls connect options', () => {
-      const tlsConnect = tls.connect;
-      let tlsConnectOptions;
+    it('allows to disable sending the SNI extension', (done) => {
+      const original = tls.connect;
 
-      beforeEach(() => {
-        tlsConnectOptions = {};
-        tls.connect = (options) => {
-          Object.assign(tlsConnectOptions, options);
-        };
-      });
+      tls.connect = (options) => {
+        assert.strictEqual(options.servername, '');
+        tls.connect = original;
+        done();
+      };
 
-      afterEach(() => {
-        tls.connect = tlsConnect;
-      });
-
-      it('allows to use empty string to disable sending the SNI extension', () => {
-        const ws = new WebSocket('wss://127.0.0.1', {
-          servername: ''
-        });
-        assert.strictEqual(tlsConnectOptions.servername, '');
-      });
+      const ws = new WebSocket('wss://127.0.0.1', { servername: '' });
     });
   });
 


### PR DESCRIPTION
The option `servername` in [`tls.connect(options[, callback])`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) is the name of the host being connected to, and must be a host name, and not an IP address. If the server is not a multi-homed server and I want to connect with the IP address it is not possible to disable sending the SNI extension by setting the servername to empty string `''`. This PR implements the defaulting of the `servername` in the same way as it is done in the [node](https://github.com/nodejs/node/blob/master/lib/_http_agent.js#L161-L162). 

This PR is related to #1347 .

**Example**
In node v12 with the following code
```js
new WebSocket('wss://127.0.0.1', {
  ca: fs.readFileSync('ssl/ca.pem'),
  servername: '',
})
```
I get the deprecation warning [`[DEP0123]`](https://nodejs.org/api/deprecations.html#deprecations_dep0123_setting_the_tls_servername_to_an_ip_address)
```bash
(node:71346) [DEP0123] DeprecationWarning: Setting the TLS ServerName to an IP address 
is not permitted by RFC 6066. This will be ignored in a future version.
```
