### PR TITLE
Ensure that concat() never returns uninitialized data

### DIFF
--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -23,6 +23,8 @@ function concat(list, totalLength) {
     offset += buf.length;
   }
 
+  if (offset < totalLength) return target.slice(0, offset);
+
   return target;
 }
 

--- a/test/buffer-util.test.js
+++ b/test/buffer-util.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const assert = require('assert');
+
+const { concat } = require('../lib/buffer-util');
+
+describe('bufferUtil', () => {
+  describe('concat', () => {
+    it('never returns uninitialized data', () => {
+      const buf = concat([Buffer.from([1, 2]), Buffer.from([3, 4])], 6);
+
+      assert.ok(buf.equals(Buffer.from([1, 2, 3, 4])));
+    });
+  });
+});


### PR DESCRIPTION
_There are no known to me occurrences of returning uninitialized data, I am adding this as a safeguard._

---

This is just a safeguard that ensures that for cases if totalLength is by some mistake gets miscalculated, no uninitialized memory would be leaked.

This should not introduce any performance impact as in a normal case (which should be all the cases) this is just a single comparison.