### PR TITLE
fix: List optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,18 @@
   "dependencies": {
     "async-limiter": "^1.0.0"
   },
+  "peerDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": "^5.0.2"
+  },
+  "peerDependenciesMeta": {
+    "bufferutil": {
+      "optional": true
+    },
+    "utf-8-validate": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "benchmark": "^2.1.4",
     "bufferutil": "^4.0.1",


### PR DESCRIPTION
Listing packages mentioned in https://github.com/websockets/ws#opt-in-for-performance-and-spec-compliance as optional peer dependencies.

Additional context:
* [optional peer dependencies](https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md) (implemented in `yarn@1.13.0`, `npm@6.11.0` but not [yet](https://github.com/nodejs/node/pull/29273) bundled with node and `pnpm@?`

I'm currently not using this feature myself until node bundles `npm@6.11`.  Just creating this PR now so that we can discuss any concerns you have.