### PR TITLE
[fix] listen to 'aborted' to mute emitting of 'aborted' error.

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -559,6 +559,11 @@ function initAsClient(websocket, address, protocols, options) {
     const location = res.headers.location;
     const statusCode = res.statusCode;
 
+    res.on('aborted', () => {
+      // Do nothing...
+      // Registering this listener mutes 'aborted' error from being emitted.
+    });
+
     if (
       location &&
       opts.followRedirects &&


### PR DESCRIPTION
Related to https://github.com/nodejs/node/pull/28677

I do appreciate this is probably not the correct way to do this. However, I'm not familiar enough with the code for a "proper" fix, i.e. how does ws handled aborted responses currently (maybe through `'close'`)? This will at least ensure that the current behaviour in maintained.