### PR TITLE
Make server accept connections from multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,25 @@ server.on('upgrade', function upgrade(request, socket, head) {
 server.listen(8080);
 ```
 
+### Server that accepts connections only at whitelisted paths
+
+```js
+const WebSocket = require('ws');
+
+const path = '/foo';
+// const path = ['/foo', '/bar'];
+// const path = /^\/(foo|bar)$/;
+const wss = new WebSocket.Server({ port: 8080, path: path });
+
+wss.on('connection', function connection(ws) {
+  ws.on('message', function incoming(message) {
+    console.log('received: %s', message);
+  });
+
+  ws.send('something');
+});
+```
+
 ### Client authentication
 
 ```js

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -169,21 +169,22 @@ class WebSocketServer extends EventEmitter {
    */
   shouldHandle(req) {
     const whitelist = this.options.path;
+    let isMatch = true;
 
     if (whitelist) {
       const index = req.url.indexOf('?');
       const pathname = index !== -1 ? req.url.slice(0, index) : req.url;
 
       if (whitelist instanceof RegExp) {
-        if (!whitelist.test(pathname)) return false;
+        isMatch = whitelist.test(pathname);
       } else if (whitelist instanceof Array) {
-        if (!whitelist.includes(pathname)) return false;
+        isMatch = whitelist.includes(pathname);
       } else {
-        if (pathname !== whitelist) return false;
+        isMatch = pathname === whitelist;
       }
     }
 
-    return true;
+    return isMatch;
   }
 
   /**

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -30,7 +30,7 @@ class WebSocketServer extends EventEmitter {
    * @param {String} options.host The hostname where to bind the server
    * @param {Number} options.maxPayload The maximum allowed message size
    * @param {Boolean} options.noServer Enable no server mode
-   * @param {String} options.path Accept only connections matching this path
+   * @param {(String | String[] | RegExp)} options.path Accept only connections matching this path
    * @param {(Boolean|Object)} options.perMessageDeflate Enable/disable
    *     permessage-deflate
    * @param {Number} options.port The port where to bind the server
@@ -168,11 +168,19 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   shouldHandle(req) {
-    if (this.options.path) {
+    const whitelist = this.options.path;
+
+    if (whitelist) {
       const index = req.url.indexOf('?');
       const pathname = index !== -1 ? req.url.slice(0, index) : req.url;
 
-      if (pathname !== this.options.path) return false;
+      if (whitelist instanceof RegExp) {
+        if (!whitelist.test(pathname)) return false;
+      } else if (whitelist instanceof Array) {
+        if (!whitelist.includes(pathname)) return false;
+      } else {
+        if (pathname !== whitelist) return false;
+      }
     }
 
     return true;

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -325,16 +325,70 @@ describe('WebSocketServer', () => {
   });
 
   describe('#shouldHandle', () => {
-    it('returns true when the path matches', () => {
-      const wss = new WebSocket.Server({ noServer: true, path: '/foo' });
+    describe('when path whitelist is string', () => {
+      it('returns true when the path matches', () => {
+        const wss = new WebSocket.Server({ noServer: true, path: '/foo' });
 
-      assert.strictEqual(wss.shouldHandle({ url: '/foo' }), true);
+        assert.strictEqual(wss.shouldHandle({ url: '/foo' }), true);
+      });
+
+      it("returns false when the path doesn't match", () => {
+        const wss = new WebSocket.Server({ noServer: true, path: '/foo' });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/bar' }), false);
+      });
     });
 
-    it("returns false when the path doesn't match", () => {
-      const wss = new WebSocket.Server({ noServer: true, path: '/foo' });
+    describe('when path whitelist is RegExp', () => {
+      it('returns true when the path prefix matches', () => {
+        const wss = new WebSocket.Server({ noServer: true, path: /^\/fo/ });
 
-      assert.strictEqual(wss.shouldHandle({ url: '/bar' }), false);
+        assert.strictEqual(wss.shouldHandle({ url: '/foo' }), true);
+      });
+
+      it('returns true when the path matches partially', () => {
+        const wss = new WebSocket.Server({ noServer: true, path: /oo/ });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/foo' }), true);
+      });
+
+      it('returns true when the path matches completely', () => {
+        const wss = new WebSocket.Server({ noServer: true, path: /^\/foo$/ });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/foo' }), true);
+      });
+
+      it("returns false when the path doesn't match", () => {
+        const wss = new WebSocket.Server({ noServer: true, path: /^\/fo/ });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/not_foo' }), false);
+      });
+    });
+
+    describe('when path whitelist is string array', () => {
+      it('returns true when the path matches', () => {
+        const wss = new WebSocket.Server({
+          noServer: true,
+          path: ['/bar', '/foo']
+        });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/foo' }), true);
+      });
+
+      it('returns false when the path whitelist is empty', () => {
+        const wss = new WebSocket.Server({ noServer: true, path: [] });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/zoo' }), false);
+      });
+
+      it("returns false when the path doesn't match", () => {
+        const wss = new WebSocket.Server({
+          noServer: true,
+          path: ['/bar', '/foo']
+        });
+
+        assert.strictEqual(wss.shouldHandle({ url: '/zoo' }), false);
+      });
     });
   });
 


### PR DESCRIPTION
Currently, `path` option is single string.  This PR allows it to be RegExp or string[] in the [style of Express](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5bd5b28/types/express-serve-static-core/index.d.ts#L138).

This would allow Apollo Server to use single WebSocket server to service multiple paths.

It creates the WebSocket server via:
https://github.com/apollographql/apollo-server/blob/apollo-server-express@2.8.1/packages/apollo-server/src/index.ts#L117
-> https://github.com/apollographql/apollo-server/blob/apollo-server-express@2.8.1/packages/apollo-server-core/src/ApolloServer.ts#L602-L612
-> https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.16/src/server.ts#L135