### PR TITLE
[fix] Prevent type error in Duplex stream implementation on Node >=12

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,6 +1,26 @@
 'use strict';
 
-const { Duplex } = require('stream');
+const { Duplex, Readable, Writable } = require('stream');
+
+/* istanbul ignore next */
+if (!Object.getOwnPropertyDescriptor(Readable.prototype, 'readableEnded')) {
+  Object.defineProperty(Readable.prototype, 'readableEnded', {
+    enumerable: false,
+    get() {
+      return this._readableState ? this._readableState.endEmitted : false;
+    }
+  });
+}
+
+/* istanbul ignore next */
+if (!Object.getOwnPropertyDescriptor(Writable.prototype, 'writableFinished')) {
+  Object.defineProperty(Writable.prototype, 'writableFinished', {
+    enumerable: false,
+    get() {
+      return this._writableState ? this._writableState.finished : false;
+    }
+  });
+}
 
 /**
  * Emits the `'close'` event on a stream.
@@ -18,7 +38,7 @@ function emitClose(stream) {
  * @private
  */
 function duplexOnEnd() {
-  if (!this.destroyed && this._writableState.finished) {
+  if (!this.destroyed && this.writableFinished) {
     this.destroy();
   }
 }
@@ -109,8 +129,8 @@ function createWebSocketStream(ws, options) {
       return;
     }
 
-    if (ws._socket._writableState.finished) {
-      if (duplex._readableState.endEmitted) duplex.destroy();
+    if (ws._socket.writableFinished) {
+      if (duplex.readableEnded) duplex.destroy();
       callback();
     } else {
       ws._socket.once('finish', function finish() {
@@ -126,7 +146,12 @@ function createWebSocketStream(ws, options) {
   duplex._read = function() {
     if (ws.readyState === ws.OPEN && !resumeOnReceiverDrain) {
       resumeOnReceiverDrain = true;
-      if (!ws._receiver._writableState.needDrain) ws._socket.resume();
+      if (
+        ws._receiver._writableState &&
+        !ws._receiver._writableState.needDrain
+      ) {
+        ws._socket.resume();
+      }
     }
   };
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -855,8 +855,9 @@ function socketOnClose() {
   clearTimeout(websocket._closeTimer);
 
   if (
-    websocket._receiver._writableState.finished ||
-    websocket._receiver._writableState.errorEmitted
+    websocket._receiver.writableFinished ||
+    (websocket._receiver._writableState &&
+      websocket._receiver._writableState.errorEmitted)
   ) {
     websocket.emitClose();
   } else {


### PR DESCRIPTION
Recent versions of Node have added getters for some of the internal stream
properties and throws this state away when the stream is being ended. This
commit adds a polyfill for the internal properties that are now exposed
through getters, and checks for availability of properties that do not have
a corresponding getter before using them.