### PR TITLE
[fix] Allow close code 1014

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -21,7 +21,7 @@ try {
 exports.isValidStatusCode = (code) => {
   return (
     (code >= 1000 &&
-      code <= 1013 &&
+      code <= 1014 &&
       code !== 1004 &&
       code !== 1005 &&
       code !== 1006) ||

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -1532,6 +1532,19 @@ describe('WebSocket', () => {
       wss.on('connection', (ws) => ws.close(1013));
     });
 
+    it('allows close code 1014', (done) => {
+      const wss = new WebSocket.Server({ port: 0 }, () => {
+        const ws = new WebSocket(`ws://localhost:${wss.address().port}`);
+
+        ws.on('close', (code) => {
+          assert.strictEqual(code, 1014);
+          wss.close(done);
+        });
+      });
+
+      wss.on('connection', (ws) => ws.close(1014));
+    });
+
     it('does nothing if `readyState` is `CLOSED`', (done) => {
       const wss = new WebSocket.Server({ port: 0 }, () => {
         const ws = new WebSocket(`ws://localhost:${wss.address().port}`);


### PR DESCRIPTION
IANA has assigned 1014 as "Bad Gateway"

https://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number
https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent

ws support for 1012, and 1013 was added in b58f688bf0fa0e87a3cef87c2f5d01bf43590668