### PR TITLE
op speed

### DIFF
--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -120,19 +120,17 @@ function viewToBuffer(view) {
 
 try {
   const bufferUtil = require('bufferutil');
-  const bu = bufferUtil.BufferUtil || bufferUtil;
+  const { mask: bu_mask, unmask: bu_unmask } = bufferUtil.BufferUtil || bufferUtil;
 
   module.exports = {
     concat,
     mask(source, mask, output, offset, length) {
-      if (length < 48) _mask(source, mask, output, offset, length);
-      else bu.mask(source, mask, output, offset, length);
+      (length < 48 ? _mask : bu_mask)(source, mask, output, offset, length);
     },
     toArrayBuffer,
     toBuffer,
     unmask(buffer, mask) {
-      if (buffer.length < 32) _unmask(buffer, mask);
-      else bu.unmask(buffer, mask);
+      (buffer.length < 32 ? _unmask : bu_unmask)(buffer, mask);
     }
   };
 } catch (e) /* istanbul ignore next */ {

--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -125,12 +125,12 @@ try {
   module.exports = {
     concat,
     mask(source, mask, output, offset, length) {
-      (length < 48 ? _mask : bu_mask)(source, mask, output, offset, length);
+      ( length < 48 ? _mask : bu_mask )(source, mask, output, offset, length);
     },
     toArrayBuffer,
     toBuffer,
     unmask(buffer, mask) {
-      (buffer.length < 32 ? _unmask : bu_unmask)(buffer, mask);
+      ( buffer.length < 32 ? _unmask : bu_unmask )(buffer, mask);
     }
   };
 } catch (e) /* istanbul ignore next */ {


### PR DESCRIPTION
1. cache static methods of bufferutil exports.
2. from `if/else` to `?:`, which more faster (by <https://jsperf.com/switch-vs-two-if>), and reduce source code repeat.