### PR TITLE
Honor auth option

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -449,6 +449,7 @@ function initAsClient(websocket, address, protocols, options) {
     perMessageDeflate: true,
     followRedirects: false,
     maxRedirects: 10,
+    auth: undefined,
     ...options,
     createConnection: undefined,
     socketPath: undefined,
@@ -456,7 +457,6 @@ function initAsClient(websocket, address, protocols, options) {
     protocol: undefined,
     timeout: undefined,
     method: undefined,
-    auth: undefined,
     host: undefined,
     path: undefined,
     port: undefined

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -449,7 +449,6 @@ function initAsClient(websocket, address, protocols, options) {
     perMessageDeflate: true,
     followRedirects: false,
     maxRedirects: 10,
-    auth: undefined,
     ...options,
     createConnection: undefined,
     socketPath: undefined,

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -78,43 +78,6 @@ describe('WebSocket', () => {
         );
       });
 
-      it('accepts `auth` option', (done) => {
-        const agent = new CustomAgent();
-        const auth = 'user:pass';
-
-        agent.addRequest = (req) => {
-          assert.strictEqual(
-            req.getHeader('authorization'),
-            `Basic ${Buffer.from(auth).toString('base64')}`
-          );
-          done();
-        };
-
-        new WebSocket('ws://localhost', {
-          auth,
-          agent
-        });
-      });
-
-      it('url userinfo wins over `auth` option', (done) => {
-        const agent = new CustomAgent();
-        const urlAuth = 'userUrl:passUrl';
-        const optionsAuth = 'userOptions:passOptions';
-
-        agent.addRequest = (req) => {
-          assert.strictEqual(
-            req.getHeader('authorization'),
-            `Basic ${Buffer.from(urlAuth).toString('base64')}`
-          );
-          done();
-        };
-
-        new WebSocket(`ws://${urlAuth}@localhost`, {
-          optionsAuth,
-          agent
-        });
-      });
-
       it('throws an error when using an invalid `protocolVersion`', () => {
         const options = { agent: new CustomAgent(), protocolVersion: 1000 };
 
@@ -2163,6 +2126,43 @@ describe('WebSocket', () => {
       };
 
       const ws = new WebSocket(`ws://${auth}@localhost`, { agent });
+    });
+
+    it('honors the `auth` option', (done) => {
+      const agent = new CustomAgent();
+      const auth = 'user:pass';
+
+      agent.addRequest = (req) => {
+        assert.strictEqual(
+          req.getHeader('authorization'),
+          `Basic ${Buffer.from(auth).toString('base64')}`
+        );
+        done();
+      };
+
+      new WebSocket('ws://localhost', {
+        auth,
+        agent
+      });
+    });
+
+    it('favors the url userinfo over the `auth` option', (done) => {
+      const agent = new CustomAgent();
+      const urlAuth = 'userUrl:passUrl';
+      const optionsAuth = 'userOptions:passOptions';
+
+      agent.addRequest = (req) => {
+        assert.strictEqual(
+          req.getHeader('authorization'),
+          `Basic ${Buffer.from(urlAuth).toString('base64')}`
+        );
+        done();
+      };
+
+      new WebSocket(`ws://${urlAuth}@localhost`, {
+        optionsAuth,
+        agent
+      });
     });
 
     it('adds custom headers', (done) => {

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -96,6 +96,25 @@ describe('WebSocket', () => {
         });
       });
 
+      it('url userinfo wins over `auth` option', (done) => {
+        const agent = new CustomAgent();
+        const urlAuth = 'userUrl:passUrl';
+        const optionsAuth = 'userOptions:passOptions';
+
+        agent.addRequest = (req) => {
+          assert.strictEqual(
+            req.getHeader('authorization'),
+            `Basic ${Buffer.from(urlAuth).toString('base64')}`
+          );
+          done();
+        };
+
+        new WebSocket(`ws://${urlAuth}@localhost`, {
+          optionsAuth,
+          agent
+        });
+      });
+
       it('throws an error when using an invalid `protocolVersion`', () => {
         const options = { agent: new CustomAgent(), protocolVersion: 1000 };
 

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -78,6 +78,24 @@ describe('WebSocket', () => {
         );
       });
 
+      it('accepts `auth` option', (done) => {
+        const agent = new CustomAgent();
+        const auth = 'user:pass';
+
+        agent.addRequest = (req) => {
+          assert.strictEqual(
+            req._headers.authorization,
+            `Basic ${Buffer.from(auth).toString('base64')}`
+          );
+          done();
+        };
+
+        new WebSocket('ws://localhost', {
+          auth,
+          agent
+        });
+      });
+
       it('throws an error when using an invalid `protocolVersion`', () => {
         const options = { agent: new CustomAgent(), protocolVersion: 1000 };
 

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -84,7 +84,7 @@ describe('WebSocket', () => {
 
         agent.addRequest = (req) => {
           assert.strictEqual(
-            req._headers.authorization,
+            req.getHeader('authorization'),
             `Basic ${Buffer.from(auth).toString('base64')}`
           );
           done();


### PR DESCRIPTION
#### Description

The WebSocket client [documentation](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options) states that all [standard http.request()](https://nodejs.org/api/http.html#http_http_request_options_callback) options are valid.

> Any other option allowed in http.request() or https.request().

But if you create a new WebSocket client, the `auth` property in the options `object` parameter is ignored. And the `auth` property is a valid http.request() options

#### Reproducible in:

- version: all versions

#### Steps to reproduce:

1.  Create a Websocket client with an `auth` option:
```javascript
const auth = 'user:password';
const ws = new WebSocket('ws://localhost', {auth});
```

#### Expected result:

The server should receive the `auth` header. Eg: `Authorization: Basic dXNlcjpwYXNzd29yZA==`

#### Actual result:

No `auth` header is sent.

#### Fix

When the `opts` object gets initialized, the auth property is set to `undefined`, overwriting the value passed in the options object.

A little reordering of the properties in the initialization seems to fix the bug.
