### PR TITLE
refactor stream implementation

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -2,39 +2,13 @@
 
 const { Duplex } = require('stream');
 
-/**
- * Emits the `'close'` event on a stream.
- *
- * @param {stream.Duplex} The stream.
- * @private
- */
-function emitClose(stream) {
-  stream.emit('close');
-}
-
-/**
- * The listener of the `'end'` event.
- *
- * @private
- */
-function duplexOnEnd() {
-  if (!this.destroyed && this._writableState.finished) {
-    this.destroy();
-  }
-}
-
-/**
- * The listener of the `'error'` event.
- *
- * @private
- */
-function duplexOnError(err) {
-  this.removeListener('error', duplexOnError);
-  this.destroy();
-  if (this.listenerCount('error') === 0) {
-    // Do not suppress the throwing behavior.
-    this.emit('error', err);
-  }
+function once(cb) {
+  let called = false;
+  return (...args) => {
+    if (called) return;
+    called = true;
+    cb(...args);
+  };
 }
 
 /**
@@ -46,71 +20,54 @@ function duplexOnError(err) {
  * @public
  */
 function createWebSocketStream(ws, options) {
-  let resumeOnReceiverDrain = true;
-
-  function receiverOnDrain() {
-    if (resumeOnReceiverDrain) ws._socket.resume();
-  }
-
-  if (ws.readyState === ws.CONNECTING) {
-    ws.once('open', function open() {
-      ws._receiver.removeAllListeners('drain');
-      ws._receiver.on('drain', receiverOnDrain);
-    });
-  } else {
-    ws._receiver.removeAllListeners('drain');
-    ws._receiver.on('drain', receiverOnDrain);
-  }
-
   const duplex = new Duplex({
     ...options,
-    autoDestroy: false,
-    emitClose: false,
+    autoDestroy: true,
+    emitClose: true,
     objectMode: false,
     writableObjectMode: false
   });
 
+  function destroy(err) {
+    duplex.destroy(err);
+  }
+
   ws.on('message', function message(msg) {
     if (!duplex.push(msg)) {
-      resumeOnReceiverDrain = false;
       ws._socket.pause();
     }
   });
 
-  ws.once('error', function error(err) {
-    if (duplex.destroyed) return;
-
-    duplex.destroy(err);
-  });
+  ws.once('error', destroy);
 
   ws.once('close', function close() {
-    if (duplex.destroyed) return;
-
     duplex.push(null);
   });
 
   duplex._destroy = function(err, callback) {
+    callback = once(callback);
+
+    ws.off('error', destroy);
+    ws.once('error', callback);
+
     if (ws.readyState === ws.CLOSED) {
       callback(err);
-      process.nextTick(emitClose, duplex);
       return;
     }
 
-    let called = false;
-
-    ws.once('error', function error(err) {
-      called = true;
+    ws.once('close', function close() {
       callback(err);
     });
 
-    ws.once('close', function close() {
-      if (!called) callback(err);
-      process.nextTick(emitClose, duplex);
-    });
     ws.terminate();
   };
 
   duplex._final = function(callback) {
+    callback = once(callback);
+
+    ws.off('error', destroy);
+    ws.once('error', callback);
+
     if (ws.readyState === ws.CONNECTING) {
       ws.once('open', function open() {
         duplex._final(callback);
@@ -125,23 +82,16 @@ function createWebSocketStream(ws, options) {
     if (ws._socket === null) return;
 
     if (ws._socket._writableState.finished) {
-      if (duplex._readableState.endEmitted) duplex.destroy();
       callback();
     } else {
-      ws._socket.once('finish', function finish() {
-        // `duplex` is not destroyed here because the `'end'` event will be
-        // emitted on `duplex` after this `'finish'` event. The EOF signaling
-        // `null` chunk is, in fact, pushed when the websocket emits `'close'`.
-        callback();
-      });
+      ws._socket.once('finish', callback);
       ws.close();
     }
   };
 
   duplex._read = function() {
-    if (ws.readyState === ws.OPEN && !resumeOnReceiverDrain) {
-      resumeOnReceiverDrain = true;
-      if (!ws._receiver._writableState.needDrain) ws._socket.resume();
+    if (ws.readyState === ws.OPEN) {
+      ws._socket.resume();
     }
   };
 
@@ -156,8 +106,6 @@ function createWebSocketStream(ws, options) {
     ws.send(chunk, callback);
   };
 
-  duplex.on('end', duplexOnEnd);
-  duplex.on('error', duplexOnError);
   return duplex;
 }
 

--- a/test/create-websocket-stream.test.js
+++ b/test/create-websocket-stream.test.js
@@ -306,19 +306,16 @@ describe('createWebSocketStream', () => {
 
         duplex.on('end', () => {
           events.push('end');
-          assert.ok(duplex.destroyed);
         });
 
         duplex.on('close', () => {
           assert.deepStrictEqual(events, ['finish', 'end']);
+          assert.ok(duplex.destroyed);
           wss.close(done);
         });
 
         duplex.on('finish', () => {
           events.push('finish');
-          assert.ok(!duplex.destroyed);
-          assert.ok(duplex.readable);
-
           duplex.resume();
         });
 
@@ -341,20 +338,17 @@ describe('createWebSocketStream', () => {
 
         duplex.on('end', () => {
           events.push('end');
-          assert.ok(!duplex.destroyed);
-          assert.ok(duplex.writable);
-
           duplex.end();
         });
 
         duplex.on('close', () => {
           assert.deepStrictEqual(events, ['end', 'finish']);
+          assert.ok(duplex.destroyed);
           wss.close(done);
         });
 
         duplex.on('finish', () => {
           events.push('finish');
-          assert.ok(duplex.destroyed);
         });
 
         duplex.resume();


### PR DESCRIPTION
This tries (and fails) to refactor the stream implementation to be more inline with node core streams.

Unfortunately `handles backpressure 3/3` still fails which I haven't been able to figure out. I don't quite understand the test implementations.

Opening this in case someone has any suggestions or comments...