### PR TITLE
Call the `_final()` callback before destroying the stream

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -125,8 +125,8 @@ function createWebSocketStream(ws, options) {
     if (ws._socket === null) return;
 
     if (ws._socket._writableState.finished) {
-      if (duplex._readableState.endEmitted) duplex.destroy();
       callback();
+      if (duplex._readableState.endEmitted) duplex.destroy();
     } else {
       ws._socket.once('finish', function finish() {
         // `duplex` is not destroyed here because the `'end'` event will be

--- a/test/create-websocket-stream.test.js
+++ b/test/create-websocket-stream.test.js
@@ -414,6 +414,7 @@ describe('createWebSocketStream', () => {
           ws._receiver.on('drain', () => {
             called.push('drain');
             assert.ok(!ws._socket.isPaused());
+            duplex.end();
           });
 
           const list = Sender.frame(randomBytes(16 * 1024), {
@@ -429,7 +430,6 @@ describe('createWebSocketStream', () => {
           ws._socket.push(Buffer.concat(list));
         });
 
-        duplex.on('resume', duplex.end);
         duplex.on('close', () => {
           assert.deepStrictEqual(called, ['read', 'drain']);
           wss.close(done);
@@ -450,6 +450,7 @@ describe('createWebSocketStream', () => {
           assert.ok(!ws._receiver._writableState.needDrain);
           read();
           assert.ok(!ws._socket.isPaused());
+          duplex.end();
         };
 
         ws.on('open', () => {
@@ -470,7 +471,6 @@ describe('createWebSocketStream', () => {
           ws._socket.push(Buffer.concat(list));
         });
 
-        duplex.on('resume', duplex.end);
         duplex.on('close', () => {
           assert.deepStrictEqual(called, ['drain', 'read']);
           wss.close(done);

--- a/test/create-websocket-stream.test.js
+++ b/test/create-websocket-stream.test.js
@@ -354,7 +354,6 @@ describe('createWebSocketStream', () => {
 
         duplex.on('finish', () => {
           events.push('finish');
-          assert.ok(duplex.destroyed);
         });
 
         duplex.resume();


### PR DESCRIPTION
Handle the breaking change introduced by https://github.com/nodejs/node/pull/32780.