### PR TITLE
[doc] improve authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,7 @@ wss.on('connection', function connection(ws, request, client) {
 });
 
 server.on('upgrade', function upgrade(request, socket, head) {
-  /**
-   * NOTE:
-   *  The `authenticate` function not implemented! Please replace that by your auth logic!
-   */
+  // This function is not defined on purpose. Implement it with your own logic.
   authenticate(request, (err, client) => {
     if (err || !client) {
       socket.end('HTTP/1.1 401 Unauthorized');

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ server.on('upgrade', function upgrade(request, socket, head) {
   // This function is not defined on purpose. Implement it with your own logic.
   authenticate(request, (err, client) => {
     if (err || !client) {
-      socket.end('HTTP/1.1 401 Unauthorized');
+      socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      socket.destroy();
       return;
     }
 

--- a/README.md
+++ b/README.md
@@ -266,9 +266,13 @@ wss.on('connection', function connection(ws, request, client) {
 });
 
 server.on('upgrade', function upgrade(request, socket, head) {
+  /**
+   * NOTE:
+   *  The `authenticate` function not implemented! Please replace that by your auth logic!
+   */
   authenticate(request, (err, client) => {
     if (err || !client) {
-      socket.destroy();
+      socket.end('HTTP/1.1 401 Unauthorized');
       return;
     }
 


### PR DESCRIPTION
1. The remind about 'authenticate' function implementing
2. Sending 401 HTTP response instead socket destroying