### PR TITLE
Update websocket.js

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -56,6 +56,7 @@ class WebSocket extends EventEmitter {
     this._receiver = null;
     this._sender = null;
     this._socket = null;
+    this._id = null;
 
     if (address !== null) {
       this._bufferedAmount = 0;
@@ -108,6 +109,19 @@ class WebSocket extends EventEmitter {
     // Allow to change `binaryType` on the fly.
     //
     if (this._receiver) this._receiver._binaryType = type;
+  }
+
+   /**
+   * This allows a socket to have a id bound to it so it can be used to identify the socket
+   *
+   * @type {String}
+   */
+  get id(){
+    return this._id;
+  }
+
+  set id(id){
+    this._id = id;
   }
 
   /**


### PR DESCRIPTION
Added support for id to be saved against the socket, allow a unique identifier to be specified.

This is due to class security, as an object can't have data written to it from outside the class for a persistent state.

For example
class obj{
this._id = "something"; // inside the object is valid
}
let o = new obj();
o._id = "something"; only updates o for the scope o is in not the actuall object's internal data
