### PR TITLE
[fix] Use dynamic require for bufferUtil and utfValidate

### DIFF
--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { EMPTY_BUFFER } = require('./constants');
+const { dynamicRequire } = require('./utils');
 
 /**
  * Merges an array of buffers into a new buffer.
@@ -102,7 +103,7 @@ function toBuffer(data) {
 }
 
 try {
-  const bufferUtil = require('bufferutil');
+  const bufferUtil = dynamicRequire(module, 'bufferutil');
   const bu = bufferUtil.BufferUtil || bufferUtil;
 
   module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * Requires a module which is protected against bundler minification.
+ *
+ * @param {NodeModule} mod
+ * @param {string} request
+ */
+function dynamicRequire(mod, request) {
+  return mod.require(request);
+}
+
+module.exports = {
+  dynamicRequire
+};

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const { dynamicRequire } = require('./utils');
+
 try {
-  const isValidUTF8 = require('utf-8-validate');
+  const isValidUTF8 = dynamicRequire(module, 'utf-8-validate');
 
   exports.isValidUTF8 =
     typeof isValidUTF8 === 'object'


### PR DESCRIPTION
Closes #1756

Upon attempting to require the utf-8-validate and bufferutil modules, Yarn PnP will detect the usage of a module that's not installed and error.

This replaces the requires with a dynamic require call that doesn't get caught by Yarn PnP (or other bundlers for that matter).