### PR TITLE
Server clients can have a url

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -477,7 +477,7 @@ Forcibly close the connection.
 
 - {String}
 
-The URL of the WebSocket server. Server clients don't have this attribute.
+The URL of the WebSocket server.
 
 ## WebSocket.createWebSocketStream(websocket[, options])
 

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -302,6 +302,8 @@ class WebSocketServer extends EventEmitter {
       }
     }
 
+    ws.url = req.url;
+
     if (extensions[PerMessageDeflate.extensionName]) {
       const params = extensions[PerMessageDeflate.extensionName].params;
       const value = format({


### PR DESCRIPTION
It took a little bit to find how to get the URL of a WebSocket.Server created client. The solution is simple, but it seems like it could easily be done by default. This makes the documentation a little bit shorter. I didn't see any differences when running tests.

`ws.url = req.url`