### PR TITLE
[Experiment] [feature] Add batch writes mode for Sender

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -18,8 +18,9 @@ class Sender {
    *
    * @param {net.Socket} socket The connection socket
    * @param {Object} extensions An object containing the negotiated extensions
+   * @param {Boolean} batchWrites Enable/disable batch write mode
    */
-  constructor(socket, extensions) {
+  constructor(socket, extensions, batchWrites) {
     this._extensions = extensions || {};
     this._socket = socket;
 
@@ -29,6 +30,9 @@ class Sender {
     this._bufferedBytes = 0;
     this._deflating = false;
     this._queue = [];
+
+    this._batchWrites = batchWrites || false;
+    this._corked = false;
   }
 
   /**
@@ -378,6 +382,15 @@ class Sender {
    * @private
    */
   sendFrame(list, cb) {
+    if (this._batchWrites && !this._corked) {
+      this._socket.cork();
+      this._corked = true;
+      process.nextTick(() => {
+        this._socket.uncork();
+        this._corked = false;
+      });
+    }
+
     if (list.length === 2) {
       this._socket.cork();
       this._socket.write(list[0]);

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -132,9 +132,10 @@ class WebSocket extends EventEmitter {
    * @param {net.Socket} socket The network socket between the server and client
    * @param {Buffer} head The first packet of the upgraded stream
    * @param {Number} maxPayload The maximum allowed message size
+   * @param {Boolean} batchWrites Enable/disable batch write mode
    * @private
    */
-  setSocket(socket, head, maxPayload) {
+  setSocket(socket, head, maxPayload, batchWrites) {
     const receiver = new Receiver(
       this._binaryType,
       this._extensions,
@@ -142,7 +143,7 @@ class WebSocket extends EventEmitter {
       maxPayload
     );
 
-    this._sender = new Sender(socket, this._extensions);
+    this._sender = new Sender(socket, this._extensions, batchWrites);
     this._receiver = receiver;
     this._socket = socket;
 
@@ -437,6 +438,7 @@ module.exports = WebSocket;
  * @param {Number} options.maxPayload The maximum allowed message size
  * @param {Boolean} options.followRedirects Whether or not to follow redirects
  * @param {Number} options.maxRedirects The maximum number of redirects allowed
+ * @param {Boolean} options.batchWrites Enable/disable batch writes mode
  * @private
  */
 function initAsClient(websocket, address, protocols, options) {
@@ -640,7 +642,7 @@ function initAsClient(websocket, address, protocols, options) {
       }
     }
 
-    websocket.setSocket(socket, head, opts.maxPayload);
+    websocket.setSocket(socket, head, opts.maxPayload, opts.batchWrites);
   });
 }
 


### PR DESCRIPTION
Adds `batchWrites` option which enables wrap with `socket.cork()`/`.uncork()` calls behavior in `Sender`. When this option is in use, we get better throughput for relatively small messages (something around 1 KiB).

**Note**. This is an experiment and it's very unlikely to get into the library, so I didn't bother with proper documentation and tests. My intent is to demonstrate one of possible approaches (probably, the simplest one) to having batch writes in the library.

### More context

On *nix OSes, on each `socket.write()` node tries to call libuv's `uv_try_write` function. For a ready-to-write TCP socket that function does the write immediately. So, for small messages this leads to certain overhead due to large amount of sys calls and other factors.

On the other hand, `socket.cork()`/`.uncork()` calls (and the underlying `_writev()` implementation) have a certain overhead, which may sometimes impact the latency for individual messages and, in general, makes almost no sense for larger messages. Having this option enabled also makes no sense in case of large/medium amount of open WS connections with infrequent communication happening over each socket.

### Benchmark results

Existing benchmarks were considering latency of individual round-trips, so I've added a new one which measures throughput with different levels of concurrency.

Here is the result (10 runs, Node.js v14.10.0):
```
                                                                        confidence improvement accuracy (*)    (**)   (***)
 throughput.js concurrency=1 roundtrips=10000 size=128 KiB data=binary                -12.79 %      ±14.82% ±20.73% ±29.19%
 throughput.js concurrency=1 roundtrips=10000 size=128 KiB data=text                    3.54 %       ±4.62%  ±6.45%  ±9.08%
 throughput.js concurrency=1 roundtrips=100000 size=1 KiB data=binary          ***     -5.60 %       ±1.73%  ±2.37%  ±3.25%
 throughput.js concurrency=1 roundtrips=100000 size=1 KiB data=text            ***     -6.18 %       ±1.82%  ±2.54%  ±3.57%
 throughput.js concurrency=1 roundtrips=100000 size=64 B data=binary           ***     -6.15 %       ±1.21%  ±1.67%  ±2.31%
 throughput.js concurrency=1 roundtrips=100000 size=64 B data=text             ***     -6.28 %       ±1.79%  ±2.49%  ±3.45%
 throughput.js concurrency=32 roundtrips=10000 size=128 KiB data=binary               -10.20 %      ±11.71% ±16.06% ±21.92%
 throughput.js concurrency=32 roundtrips=10000 size=128 KiB data=text                   0.21 %       ±2.99%  ±4.11%  ±5.64%
 throughput.js concurrency=32 roundtrips=100000 size=1 KiB data=binary         ***     33.70 %       ±4.64%  ±6.42%  ±8.89%
 throughput.js concurrency=32 roundtrips=100000 size=1 KiB data=text           ***     14.04 %       ±5.03%  ±7.01%  ±9.81%
 throughput.js concurrency=32 roundtrips=100000 size=64 B data=binary          ***     36.32 %       ±3.95%  ±5.47%  ±7.56%
 throughput.js concurrency=32 roundtrips=100000 size=64 B data=text            ***     20.05 %       ±3.88%  ±5.36%  ±7.43%
 throughput.js concurrency=64 roundtrips=10000 size=128 KiB data=binary                -3.83 %       ±8.38% ±11.57% ±15.95%
 throughput.js concurrency=64 roundtrips=10000 size=128 KiB data=text                   0.53 %       ±3.13%  ±4.28%  ±5.84%
 throughput.js concurrency=64 roundtrips=100000 size=1 KiB data=binary         ***     34.95 %       ±5.03%  ±7.00%  ±9.79%
 throughput.js concurrency=64 roundtrips=100000 size=1 KiB data=text           ***     13.02 %       ±3.86%  ±5.30%  ±7.25%
 throughput.js concurrency=64 roundtrips=100000 size=64 B data=binary          ***     47.02 %       ±4.76%  ±6.57%  ±9.05%
 throughput.js concurrency=64 roundtrips=100000 size=64 B data=text            ***     20.34 %       ±3.85%  ±5.29%  ±7.24%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case there are 18 comparisons, you can thus
expect the following amount of false-positive results:
  0.90 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.18 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```

Plot for 64 B messages
![compare-ws-64-b-plot](https://user-images.githubusercontent.com/37772591/92739877-fa137300-f385-11ea-9463-8f4dd13ce9ac.png)

Plot for 1 KiB messages
![compare-ws-1-kb-plot](https://user-images.githubusercontent.com/37772591/92739948-07306200-f386-11ea-8ba8-8d36b1d8c687.png)
