### PR TITLE
Add Windows named pipe support for client

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -466,10 +466,32 @@ function initAsClient(websocket, address, protocols, options) {
   }
 
   let parsedUrl;
+  let isWinPipe;
 
   if (address instanceof URL) {
     parsedUrl = address;
     websocket.url = address.href;
+  } else if (isWinPipe = /^ws\+unix\:\/\/\\\\[\.\?]\\pipe\\/.test(address)) {
+    let pathname = address.slice(10);
+    let index = pathname.indexOf("?", 9);
+    let search = "";
+
+    if (index !== -1) {
+      search = pathname.slice(index);
+      pathname = pathname.slice(0, index);
+    }
+
+    parsedUrl = {
+      protocol: "ws+unix:",
+      hostname: "",
+      port: "",
+      host: "",
+      pathname,
+      search,
+      hash: "",
+      username: "",
+      password: ""
+    };
   } else {
     parsedUrl = new URL(address);
     websocket.url = address;
@@ -528,7 +550,12 @@ function initAsClient(websocket, address, protocols, options) {
     opts.auth = `${parsedUrl.username}:${parsedUrl.password}`;
   }
 
-  if (isUnixSocket) {
+  if (isWinPipe) {
+    const index = opts.path.indexOf(":", 11);
+
+    opts.socketPath = index === -1 ? opts.path : opts.path.slice(0, index);
+    opts.path = index === -1 ? "" : opts.path.slice(index + 1);
+  } else if (isUnixSocket) {
     const parts = opts.path.split(':');
 
     opts.socketPath = parts[0];

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -471,10 +471,10 @@ function initAsClient(websocket, address, protocols, options) {
   if (address instanceof URL) {
     parsedUrl = address;
     websocket.url = address.href;
-  } else if (isWinPipe = /^ws\+unix\:\/\/\\\\[\.\?]\\pipe\\/.test(address)) {
+  } else if ((isWinPipe = /^ws\+unix:\/\/\\\\[.?]\\pipe\\/.test(address))) {
     let pathname = address.slice(10);
-    let index = pathname.indexOf("?", 9);
-    let search = "";
+    const index = pathname.indexOf('?', 9);
+    let search = '';
 
     if (index !== -1) {
       search = pathname.slice(index);
@@ -482,15 +482,16 @@ function initAsClient(websocket, address, protocols, options) {
     }
 
     parsedUrl = {
-      protocol: "ws+unix:",
-      hostname: "",
-      port: "",
-      host: "",
+      protocol: 'ws+unix:',
+      hostname: '',
+      port: '',
+      host: '',
+      origin: '',
       pathname,
       search,
-      hash: "",
-      username: "",
-      password: ""
+      hash: '',
+      username: '',
+      password: ''
     };
   } else {
     parsedUrl = new URL(address);
@@ -551,10 +552,10 @@ function initAsClient(websocket, address, protocols, options) {
   }
 
   if (isWinPipe) {
-    const index = opts.path.indexOf(":", 11);
+    const index = opts.path.indexOf(':', 11);
 
     opts.socketPath = index === -1 ? opts.path : opts.path.slice(0, index);
-    opts.path = index === -1 ? "" : opts.path.slice(index + 1);
+    opts.path = index === -1 ? '' : opts.path.slice(index + 1);
   } else if (isUnixSocket) {
     const parts = opts.path.split(':');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Simple to use, blazing fast and thoroughly tested websocket client and server for Node.js",
   "keywords": [
     "HyBi",

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -116,7 +116,7 @@ describe('WebSocketServer', () => {
 
     it('uses a precreated http server listening on unix socket', function (done) {
       const server = http.createServer();
-      const sockPath = path.join(
+      let sockPath = path.join(
         os.tmpdir(),
         `ws.${crypto.randomBytes(16).toString('hex')}.sock`
       );

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -115,19 +115,15 @@ describe('WebSocketServer', () => {
     });
 
     it('uses a precreated http server listening on unix socket', function (done) {
-      //
-      // Skip this test on Windows. The URL parser:
-      //
-      // - Throws an error if the named pipe uses backward slashes.
-      // - Incorrectly parses the path if the named pipe uses forward slashes.
-      //
-      if (process.platform === 'win32') return this.skip();
-
       const server = http.createServer();
       const sockPath = path.join(
         os.tmpdir(),
         `ws.${crypto.randomBytes(16).toString('hex')}.sock`
       );
+
+      if (process.platform === 'win32') {
+        sockPath = '\\\\?\\pipe\\' + sockPath;
+      }
 
       server.listen(sockPath, () => {
         const wss = new WebSocket.Server({ server });


### PR DESCRIPTION
The `WebSocket` client has been supporting Unix socket for a long time, but lacks the support of Windows named pipe, 
because in the previous versions, the URL constructor used to parse the address cannot parse a path in windows style, 
and the following code will throw a TypeError:

```js
const ws = new WebSocket("ws+unix://\\\\?\\pipe\\C:\\example.sock");
```

To implement full support of IPC, I added two more steps for parsing the address and setting the socket path for connection,
now the above code can work as expected.