### PR TITLE
Update websocket.js

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -630,7 +630,7 @@ function initAsClient(websocket, address, protocols, options) {
     }
 
     const serverProt = res.headers['sec-websocket-protocol'];
-    const protList = (protocols || '').split(/, */);
+    const protList = (protocols || '').split(/, */).join(',');
     let protError;
 
     if (!protocols && serverProt) {


### PR DESCRIPTION
When **protList** is an array of length greater than 2, it always return 'Server sent an invalid subprotocol'。