### PR TITLE
Fixed code issue in docs for broadcasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ const wss = new WebSocket.Server({ port: 8080 });
 wss.on('connection', function connection(ws) {
   ws.on('message', function incoming(data) {
     wss.clients.forEach(function each(client) {
-      if (client !== ws && client.readyState === WebSocket.OPEN) {
+      if (client !== wss && client.readyState === WebSocket.OPEN) {
         client.send(data);
       }
     });


### PR DESCRIPTION
in the example 

```js
const WebSocket = require('ws');

const wss = new WebSocket.Server({ port: 8080 });

wss.on('connection', function connection(ws) {
  ws.on('message', function incoming(data) {
    wss.clients.forEach(function each(client) {
      if (client !== ws && client.readyState === WebSocket.OPEN) {
        client.send(data);
      }
    });
  });
});
```

`ws` is not defined and throws an error. It should be `wss`. Just had this error myself and contribute to fix the docs.