### PR TITLE
reset compressor/decompressor instead of re-initialize

### DIFF
--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -377,12 +377,11 @@ class PerMessageDeflate {
       );
 
       if (fin && this.params[`${endpoint}_no_context_takeover`]) {
-        this._inflate.close();
-        this._inflate = null;
-      } else {
-        this._inflate[kTotalLength] = 0;
-        this._inflate[kBuffers] = [];
+        this._inflate.reset();
       }
+
+      this._inflate[kTotalLength] = 0;
+      this._inflate[kBuffers] = [];
 
       callback(null, data);
     });
@@ -449,12 +448,11 @@ class PerMessageDeflate {
       this._deflate[kCallback] = null;
 
       if (fin && this.params[`${endpoint}_no_context_takeover`]) {
-        this._deflate.close();
-        this._deflate = null;
-      } else {
-        this._deflate[kTotalLength] = 0;
-        this._deflate[kBuffers] = [];
+        this._deflate.reset();
       }
+
+      this._deflate[kTotalLength] = 0;
+      this._deflate[kBuffers] = [];
 
       callback(null, data);
     });

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -376,12 +376,12 @@ class PerMessageDeflate {
         this._inflate[kTotalLength]
       );
 
+      this._inflate[kTotalLength] = 0;
+      this._inflate[kBuffers] = [];
+
       if (fin && this.params[`${endpoint}_no_context_takeover`]) {
         this._inflate.reset();
       }
-
-      this._inflate[kTotalLength] = 0;
-      this._inflate[kBuffers] = [];
 
       callback(null, data);
     });
@@ -447,12 +447,12 @@ class PerMessageDeflate {
       //
       this._deflate[kCallback] = null;
 
+      this._deflate[kTotalLength] = 0;
+      this._deflate[kBuffers] = [];
+
       if (fin && this.params[`${endpoint}_no_context_takeover`]) {
         this._deflate.reset();
       }
-
-      this._deflate[kTotalLength] = 0;
-      this._deflate[kBuffers] = [];
 
       callback(null, data);
     });


### PR DESCRIPTION
Use `zlib.reset()` to (as per nodejs documentation `Reset the compressor/decompressor to factory defaults. Only applicable to the inflate and deflate algorithms.`)

Recently we have introduced/enabled `server_no_context_takeover` on one of our canary production servers which i monitor with nodejs with the help of this ws library (approx 250 connections on a single nodejs process connecting to the server).

With the introduction of `server_no_context_takeover` i have noticed significantly increased CPU usage on the client of approx 2x (8% -> 16%) to what it was before the parameter was added).

I have traced it down to significantly higher GC activity, which went from ~**100ms** total time/minute to ~**500ms**.
When it comes to actual GC counts, it went from ~**25 GC**/minute to ~**150**.
Minor GCs almost stopped and majority of the time was spent in the major GCs and incremental GCs.

The root cause of this overhead appears to be the constant destruction/re-initialization of the `zlib.createInflateRaw`.
The attached changes eliminate this overhead, and brings the performance back in line to where it was before the `server_no_context_takeover` parameter was introduced.
The changes are holding up fine in production/i haven't encountered any issues so far.

I don't know if there are any potential side-effects of the below changes, the changes do pass all the tests currently available for the library (although i am not sure the current tests would catch compressor/decompressor "corruption" resulting from the changes in this PR, at least i wasn't able to run into such case so far). 

Running the available speed.js points towards a very minor throughput improvement for the 5000 roundtrips part of the test.
Each benchmark run fluctuates quite a bit on my work machine so i opted for not posting the results here.

I am attaching a set of graphs showing the performance 
1. before `server_no_context_takeover` was introduced on the server side
2. with the current WS library version (v7.4.2)
3. and the performance after the patch below was pushed

Node version: LTS v14.15.4
Platform: Linux x64

![image](https://user-images.githubusercontent.com/2289413/106614529-c0791980-656b-11eb-88ce-f5305b901328.png)
![image](https://user-images.githubusercontent.com/2289413/106614547-c7a02780-656b-11eb-9235-74caa3d81998.png)
