### PR TITLE
docs: Fixing `send` data type

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -417,7 +417,8 @@ receives an `OpenEvent` named "open".
 
 ### websocket.ping([data[, mask]][, callback])
 
-- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The data to send in the ping frame.
+- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The
+  data to send in the ping frame.
 - `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults to
   `true` when `websocket` is not a server client.
 - `callback` {Function} An optional callback which is invoked when the ping

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -456,7 +456,7 @@ Removes an event listener emulating the `EventTarget` interface.
 
 ### websocket.send(data[, options][, callback])
 
-- `data` {string | Buffer} The data to send.
+- `data` {number | array | arrayBuffer | buffer | object | string} The data to send.
 - `options` {Object}
   - `compress` {Boolean} Specifies whether `data` should be compressed or not.
     Defaults to `true` when permessage-deflate is enabled.

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -428,7 +428,8 @@ Send a ping.
 
 ### websocket.pong([data[, mask]][, callback])
 
-- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The data to send in the pong frame.
+- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The
+  data to send in the pong frame.
 - `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults to
   `true` when `websocket` is not a server client.
 - `callback` {Function} An optional callback which is invoked when the pong

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -456,7 +456,7 @@ Removes an event listener emulating the `EventTarget` interface.
 
 ### websocket.send(data[, options][, callback])
 
-- `data` {number | array | arrayBuffer | buffer | object | string} The data to send.
+- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The data to send.
 - `options` {Object}
   - `compress` {Boolean} Specifies whether `data` should be compressed or not.
     Defaults to `true` when permessage-deflate is enabled.

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -456,7 +456,7 @@ Removes an event listener emulating the `EventTarget` interface.
 
 ### websocket.send(data[, options][, callback])
 
-- `data` {Any} The data to send.
+- `data` {string | Buffer} The data to send.
 - `options` {Object}
   - `compress` {Boolean} Specifies whether `data` should be compressed or not.
     Defaults to `true` when permessage-deflate is enabled.

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -417,7 +417,7 @@ receives an `OpenEvent` named "open".
 
 ### websocket.ping([data[, mask]][, callback])
 
-- `data` {Any} The data to send in the ping frame.
+- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The data to send in the ping frame.
 - `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults to
   `true` when `websocket` is not a server client.
 - `callback` {Function} An optional callback which is invoked when the ping
@@ -427,7 +427,7 @@ Send a ping.
 
 ### websocket.pong([data[, mask]][, callback])
 
-- `data` {Any} The data to send in the pong frame.
+- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The data to send in the pong frame.
 - `mask` {Boolean} Specifies whether `data` should be masked or not. Defaults to
   `true` when `websocket` is not a server client.
 - `callback` {Function} An optional callback which is invoked when the pong

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -458,7 +458,8 @@ Removes an event listener emulating the `EventTarget` interface.
 
 ### websocket.send(data[, options][, callback])
 
-- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The data to send.
+- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The
+  data to send.
 - `options` {Object}
   - `compress` {Boolean} Specifies whether `data` should be compressed or not.
     Defaults to `true` when permessage-deflate is enabled.


### PR DESCRIPTION
The type for `data` within the `send()` function is not `any`, but instead `<string> | <Buffer>`.

Try to say pass an object, and you'll be met with: 

```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object
```