### PR TITLE
chore: fix dep warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint --ignore-path .gitignore . && prettier --check --ignore-path .gitignore \"**/*.{json,md,yaml,yml}\""
   },
   "peerDependencies": {
-    "bufferutil": "^4.0.1",
-    "utf-8-validate": "^5.0.2"
+    "bufferutil": "^4.0.3",
+    "utf-8-validate": "^5.0.4"
   },
   "peerDependenciesMeta": {
     "bufferutil": {
@@ -44,13 +44,13 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "bufferutil": "^4.0.1",
-    "eslint": "^7.2.0",
+    "bufferutil": "^4.0.3",
+    "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "mocha": "^7.0.0",
-    "nyc": "^15.0.0",
-    "prettier": "^2.0.5",
-    "utf-8-validate": "^5.0.2"
+    "eslint-plugin-prettier": "^3.3.1",
+    "mocha": "^8.3.0",
+    "nyc": "^15.1.0",
+    "prettier": "^2.2.1",
+    "utf-8-validate": "^5.0.4"
   }
 }


### PR DESCRIPTION
Fix dependency warnings.

```console
warning mocha > debug@3.2.6: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)                                                                 
warning mocha > chokidar > fsevents@2.1.3: "Please update to latest v2.3 or v2.2" 
```