### PR TITLE
Close the connection cleanly when an error occurs

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -48,6 +48,7 @@ function duplexOnError(err) {
  */
 function createWebSocketStream(ws, options) {
   let resumeOnReceiverDrain = true;
+  let terminateOnDestroy = true;
 
   function receiverOnDrain() {
     if (resumeOnReceiverDrain) ws._socket.resume();
@@ -81,6 +82,16 @@ function createWebSocketStream(ws, options) {
   ws.once('error', function error(err) {
     if (duplex.destroyed) return;
 
+    // Prevent `ws.terminate()` from being called by `duplex._destroy()`.
+    //
+    // - If the state of the `WebSocket` connection is `CONNECTING`,
+    //   `ws.terminate()` is a noop as no socket was assigned.
+    // - Otherwise, the error was re-emitted from the listener of the `'error'`
+    //   event of the `Receiver` object. The listener already closes the
+    //   connection by calling `ws.close()`. This allows a close frame to be
+    //   sent to the other peer. If `ws.terminate()` is called right after this,
+    //   the close frame might not be sent.
+    terminateOnDestroy = false;
     duplex.destroy(err);
   });
 
@@ -108,7 +119,8 @@ function createWebSocketStream(ws, options) {
       if (!called) callback(err);
       process.nextTick(emitClose, duplex);
     });
-    ws.terminate();
+
+    if (terminateOnDestroy) ws.terminate();
   };
 
   duplex._final = function (callback) {

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -808,11 +808,10 @@ function receiverOnError(err) {
   const websocket = this[kWebSocket];
 
   websocket._socket.removeListener('data', socketOnData);
+  websocket._socket.resume();
 
-  websocket._readyState = WebSocket.CLOSING;
-  websocket._closeCode = err[kStatusCode];
+  websocket.close(err[kStatusCode]);
   websocket.emit('error', err);
-  websocket._socket.destroy();
 }
 
 /**


### PR DESCRIPTION
Instead of destroying the socket, try to close the connection cleanly
if an error (such as a data framing error) occurs after the opening
handshake has completed.

Also, to comply with the specification, use the 1006 status code if no
close frame is received, even if the connection is closed due to an
error.

Fixes #1898