### PR TITLE
Add some extra closing handshake tests

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -123,7 +123,7 @@ class WebSocket extends EventEmitter {
    * @type {Number}
    */
   get readyState() {
-    return this._readyState;
+    return this._readyState === -2 ? WebSocket.CLOSING : this._readyState;
   }
 
   /**
@@ -159,6 +159,7 @@ class WebSocket extends EventEmitter {
     receiver.on('conclude', receiverOnConclude);
     receiver.on('drain', receiverOnDrain);
     receiver.on('error', receiverOnError);
+    receiver.on('finish', receiverOnFinish);
     receiver.on('message', receiverOnMessage);
     receiver.on('ping', receiverOnPing);
     receiver.on('pong', receiverOnPong);
@@ -201,31 +202,25 @@ class WebSocket extends EventEmitter {
   /**
    * Start a closing handshake.
    *
-   *          +----------+   +-----------+   +----------+
-   *     - - -|ws.close()|-->|close frame|-->|ws.close()|- - -
-   *    |     +----------+   +-----------+   +----------+     |
-   *          +----------+   +-----------+         |
-   * CLOSING  |ws.close()|<--|close frame|<--+-----+       CLOSING
-   *          +----------+   +-----------+   |
-   *    |           |                        |   +---+        |
-   *                +------------------------+-->|fin| - - - -
-   *    |         +---+                      |   +---+
-   *     - - - - -|fin|<---------------------+
-   *              +---+
-   *
    * @param {Number} [code] Status code explaining why the connection is closing
    * @param {String} [data] A string explaining why the connection is closing
    * @public
    */
   close(code, data) {
-    if (this.readyState === WebSocket.CLOSED) return;
     if (this.readyState === WebSocket.CONNECTING) {
       const msg = 'WebSocket was closed before the connection was established';
       return abortHandshake(this, this._req, msg);
     }
 
-    if (this.readyState === WebSocket.CLOSING) {
-      if (this._closeFrameSent && this._closeFrameReceived) this._socket.end();
+    //
+    // `this._readyState` below is not a typo. The
+    // `WebSocket.prototype.readyState` getter returns `WebSocket.CLOSING` even
+    // if `this._readyState` is `-2`.
+    //
+    if (
+      this._readyState === WebSocket.CLOSING ||
+      this.readyState === WebSocket.CLOSED
+    ) {
       return;
     }
 
@@ -238,7 +233,7 @@ class WebSocket extends EventEmitter {
       if (err) return;
 
       this._closeFrameSent = true;
-      if (this._closeFrameReceived) this._socket.end();
+      this._socket.end();
     });
 
     //
@@ -610,6 +605,15 @@ function initAsClient(websocket, address, protocols, options) {
   });
 
   req.on('upgrade', (res, socket, head) => {
+    //
+    // `tls.connect()` does not support the `allowHalfOpen` option in Node.js <
+    // 12.9.0. Also, the socket creation is not always under our control as the
+    // user might use the `http{,s}.request()` `agent` option and by default
+    // `net.connect()` and `tls.connect()` create a socket not allowed to be
+    // half-open.
+    //
+    socket.allowHalfOpen = true;
+
     websocket.emit('upgrade', res);
 
     //
@@ -679,6 +683,7 @@ function initAsClient(websocket, address, protocols, options) {
  * @private
  */
 function netConnect(options) {
+  options.allowHalfOpen = true;
   options.path = options.socketPath;
   return net.connect(options);
 }
@@ -691,6 +696,7 @@ function netConnect(options) {
  * @private
  */
 function tlsConnect(options) {
+  options.allowHalfOpen = true;
   options.path = undefined;
 
   if (!options.servername && options.servername !== '') {
@@ -820,6 +826,17 @@ function receiverOnError(err) {
  * @private
  */
 function receiverOnFinish() {
+  const websocket = this[kWebSocket];
+
+  if (!websocket._closeFrameReceived) websocket.close();
+}
+
+/**
+ * A listener for the `Receiver` `'error'` or `'finish'` event.
+ *
+ * @private
+ */
+function receiverOnErrorOrFinish() {
   this[kWebSocket].emitClose();
 }
 
@@ -893,8 +910,8 @@ function socketOnClose() {
   ) {
     websocket.emitClose();
   } else {
-    websocket._receiver.on('error', receiverOnFinish);
-    websocket._receiver.on('finish', receiverOnFinish);
+    websocket._receiver.on('error', receiverOnErrorOrFinish);
+    websocket._receiver.on('finish', receiverOnErrorOrFinish);
   }
 }
 
@@ -918,9 +935,13 @@ function socketOnData(chunk) {
 function socketOnEnd() {
   const websocket = this[kWebSocket];
 
-  websocket._readyState = WebSocket.CLOSING;
+  //
+  // This is a special state. It indicates that the connection is going through
+  // the closing handshake but unlike `WebSocket.CLOSING` it does not prevent
+  // `WebSocket.prototype.close()` from sending a close frame.
+  //
+  websocket._readyState = -2;
   websocket._receiver.end();
-  this.end();
 }
 
 /**

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -940,7 +940,9 @@ function socketOnEnd() {
   // the closing handshake but unlike `WebSocket.CLOSING` it does not prevent
   // `WebSocket.prototype.close()` from sending a close frame.
   //
-  websocket._readyState = -2;
+  if (websocket._readyState === WebSocket.OPEN) {
+    websocket._readyState = -2;
+  }
   websocket._receiver.end();
 }
 

--- a/test/fixtures/slow-deflate.js
+++ b/test/fixtures/slow-deflate.js
@@ -1,0 +1,28 @@
+const PerMessageDeflate = require('../../lib/permessage-deflate');
+
+// Wrap a PerMessageDeflate, making its compress & decompress methods slow so that
+// can reliably test race conditions.
+exports.makeDeflateSlow = (ws, delayMs) => {
+  const perMessageDeflateInstance =
+    ws._extensions[PerMessageDeflate.extensionName];
+
+  const compress = perMessageDeflateInstance.compress;
+  const decompress = perMessageDeflateInstance.decompress;
+
+  const slowDeflate = Object.assign(perMessageDeflateInstance, {
+    compress() {
+      setTimeout(
+        () => compress.apply(perMessageDeflateInstance, arguments),
+        delayMs
+      );
+    },
+    decompress() {
+      setTimeout(
+        () => decompress.apply(perMessageDeflateInstance, arguments),
+        delayMs
+      );
+    }
+  });
+
+  ws._extensions[PerMessageDeflate.extensionName] = slowDeflate;
+};

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -2791,6 +2791,10 @@ describe('WebSocket', () => {
             assert.strictEqual(code, 1006);
             assert.strictEqual(reason, '');
             clientClosedCleanly = true;
+
+            if (serverClosedCleanly) {
+              wss.close(done);
+            }
           });
         });
       });
@@ -2807,10 +2811,8 @@ describe('WebSocket', () => {
           assert.strictEqual(reason, '');
           serverClosedCleanly = true;
 
-          if (clientClosedCleanly && serverClosedCleanly) {
+          if (clientClosedCleanly) {
             wss.close(done);
-          } else {
-            assert.fail('Server closed before client');
           }
         });
 


### PR DESCRIPTION
This is an attempt to test some of the behaviour discussed in https://github.com/websockets/ws/pull/1899#discussion_r647348110 and test how that's improved with the changes currently pending in #1902.

The tests are a bit rough in places, feel free to tweak or drop some of them if you think they aren't relevant. When run against master, 2 of these tests currently fail:

* "cleanly shuts down after simultaneous errors"
* "handles socket shutdown while compressing outgoing frames"

Both of these are current bugs on master: simultaneous errors (or anything else that means the remote peer doesn't respond) will break clean connection shutdown so the socket stays fully open until timeout, and also a remote `ws.end()` that starts socket shutdown immediately drops all pending outgoing data, incorrectly & unnecessarily.

Various tests here fail in interesting ways given the partial fixes I suggested in that PR thread, basically as predicted there. When run against the new PR with the full set of changes though, all the tests do happily pass, which is great!

This tries to cover the shutdown for the various half-open combinations too, by directly simulating no-half-open behaviour rather than using allowHalfOpen=false, so that it's still effective even when the new PR resets that. It's not a super rigorous real-world test by any means, and it doesn't test various possible data loss cases for each combination, but from this alone it seems like the basic behaviour is working great :+1: