### PR TITLE
minor jsdoc improvements

### DIFF
--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -21,8 +21,6 @@ const INFLATING = 5;
 
 /**
  * HyBi Receiver implementation.
- *
- * @extends stream.Writable
  */
 class Receiver extends Writable {
   /**
@@ -586,7 +584,7 @@ module.exports = Receiver;
 /**
  * Builds an error object.
  *
- * @param {(Error|RangeError)} ErrorCtor The error constructor
+ * @param {(typeof Error|typeof RangeError)} ErrorCtor The error constructor
  * @param {String} message The error message
  * @param {Boolean} prefix Specifies whether or not to add a default prefix to
  *     `message`

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -9,6 +9,9 @@ const { mask: applyMask, toBuffer } = require('./buffer-util');
 
 const mask = Buffer.alloc(4);
 
+
+/** @typedef {import('net').Socket} Socket */
+
 /**
  * HyBi Sender implementation.
  */
@@ -16,7 +19,7 @@ class Sender {
   /**
    * Creates a Sender instance.
    *
-   * @param {net.Socket} socket The connection socket
+   * @param {Socket} socket The connection socket
    * @param {Object} [extensions] An object containing the negotiated extensions
    */
   constructor(socket, extensions) {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -5,7 +5,7 @@ const { Duplex } = require('stream');
 /**
  * Emits the `'close'` event on a stream.
  *
- * @param {stream.Duplex} The stream.
+ * @param {Duplex} stream The stream.
  * @private
  */
 function emitClose(stream) {
@@ -43,7 +43,7 @@ function duplexOnError(err) {
  *
  * @param {WebSocket} ws The `WebSocket` to wrap
  * @param {Object} [options] The options for the `Duplex` constructor
- * @return {stream.Duplex} The duplex stream
+ * @return {Duplex} The duplex stream
  * @public
  */
 function createWebSocketStream(ws, options) {

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -9,13 +9,14 @@ const WebSocket = require('./websocket');
 const { format, parse } = require('./extension');
 const { GUID, kWebSocket } = require('./constants');
 
+
+/** @typedef {import('http').Server} Server */
+/** @typedef {import('http').IncomingMessage} IncomingMessage */
+/** @typedef {import('net').Socket} Socket */
+
 const keyRegex = /^[+/0-9A-Za-z]{22}==$/;
 
-/**
- * Class representing a WebSocket server.
- *
- * @extends EventEmitter
- */
+/** Class representing a WebSocket server. */
 class WebSocketServer extends EventEmitter {
   /**
    * Create a `WebSocketServer` instance.
@@ -34,7 +35,7 @@ class WebSocketServer extends EventEmitter {
    * @param {(Boolean|Object)} [options.perMessageDeflate=false] Enable/disable
    *     permessage-deflate
    * @param {Number} [options.port] The port where to bind the server
-   * @param {http.Server} [options.server] A pre-created HTTP/S server to use
+   * @param {Server} [options.server] A pre-created HTTP/S server to use
    * @param {Function} [options.verifyClient] A hook to reject connections
    * @param {Function} [callback] A listener for the `listening` event
    */
@@ -154,7 +155,7 @@ class WebSocketServer extends EventEmitter {
   /**
    * See if a given request should be handled by this server instance.
    *
-   * @param {http.IncomingMessage} req Request object to inspect
+   * @param {IncomingMessage} req Request object to inspect
    * @return {Boolean} `true` if the request is valid, else `false`
    * @public
    */
@@ -172,8 +173,8 @@ class WebSocketServer extends EventEmitter {
   /**
    * Handle a HTTP Upgrade request.
    *
-   * @param {http.IncomingMessage} req The request object
-   * @param {net.Socket} socket The network socket between the server and client
+   * @param {IncomingMessage} req The request object
+   * @param {Socket} socket The network socket between the server and client
    * @param {Buffer} head The first packet of the upgraded stream
    * @param {Function} cb Callback
    * @public
@@ -251,8 +252,8 @@ class WebSocketServer extends EventEmitter {
    *
    * @param {String} key The value of the `Sec-WebSocket-Key` header
    * @param {Object} extensions The accepted extensions
-   * @param {http.IncomingMessage} req The request object
-   * @param {net.Socket} socket The network socket between the server and client
+   * @param {IncomingMessage} req The request object
+   * @param {Socket} socket The network socket between the server and client
    * @param {Buffer} head The first packet of the upgraded stream
    * @param {Function} cb Callback
    * @throws {Error} If called more than once with the same socket
@@ -375,7 +376,7 @@ function socketOnError() {
 /**
  * Close the connection when preconditions are not fulfilled.
  *
- * @param {net.Socket} socket The socket of the upgrade request
+ * @param {Socket} socket The socket of the upgrade request
  * @param {Number} code The HTTP response status code
  * @param {String} [message] The HTTP response body
  * @param {Object} [headers] Additional HTTP response headers

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -36,7 +36,7 @@ class WebSocket extends EventEmitter {
   /**
    * Create a new `WebSocket`.
    *
-   * @param {(String|url.URL)} address The URL to which to connect
+   * @param {(String|URL)} address The URL to which to connect
    * @param {(String|String[])} [protocols] The subprotocols
    * @param {Object} [options] Connection options
    */
@@ -60,15 +60,14 @@ class WebSocket extends EventEmitter {
       this._bufferedAmount = 0;
       this._isServer = false;
       this._redirects = 0;
+      let proto = Array.isArray(protocols) ? protocols.join(', ') : protocols;
 
-      if (Array.isArray(protocols)) {
-        protocols = protocols.join(', ');
-      } else if (typeof protocols === 'object' && protocols !== null) {
+      if (typeof protocols === 'object' && protocols !== null) {
         options = protocols;
-        protocols = undefined;
+        proto = undefined;
       }
 
-      initAsClient(this, address, protocols, options);
+      initAsClient(this, address, proto, options);
     } else {
       this._isServer = true;
     }
@@ -392,6 +391,11 @@ class WebSocket extends EventEmitter {
   }
 }
 
+WebSocket.CONNECTING = 0
+WebSocket.OPEN = 1
+WebSocket.CLOSING = 2
+WebSocket.CLOSED = 3
+
 readyStates.forEach((readyState, i) => {
   const descriptor = { enumerable: true, value: i };
 
@@ -460,7 +464,7 @@ module.exports = WebSocket;
  * Initialize a WebSocket client.
  *
  * @param {WebSocket} websocket The client to initialize
- * @param {(String|url.URL)} address The URL to which to connect
+ * @param {(String|URL)} address The URL to which to connect
  * @param {String} [protocols] The subprotocols
  * @param {Object} [options] Connection options
  * @param {(Boolean|Object)} [options.perMessageDeflate=true] Enable/disable

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -60,14 +60,15 @@ class WebSocket extends EventEmitter {
       this._bufferedAmount = 0;
       this._isServer = false;
       this._redirects = 0;
-      let proto = Array.isArray(protocols) ? protocols.join(', ') : protocols;
 
-      if (typeof protocols === 'object' && protocols !== null) {
+      if (Array.isArray(protocols)) {
+        protocols = protocols.join(', ');
+      } else if (typeof protocols === 'object' && protocols !== null) {
         options = protocols;
-        proto = undefined;
+        protocols = undefined;
       }
 
-      initAsClient(this, address, proto, options);
+      initAsClient(this, address, protocols, options);
     } else {
       this._isServer = true;
     }
@@ -397,7 +398,7 @@ WebSocket.CLOSING = 2
 WebSocket.CLOSED = 3
 
 readyStates.forEach((readyState, i) => {
-  const descriptor = { enumerable: true, value: i };
+  const descriptor = { enumerable: true, value: i, configurable: false, writable: false };
 
   Object.defineProperty(WebSocket.prototype, readyState, descriptor);
   Object.defineProperty(WebSocket, readyState, descriptor);


### PR DESCRIPTION
I use this settings on by default in VS code
```
    "javascript.suggest.completeFunctionCalls": true,
    "javascript.suggest.completeJSDocs": true,
    "javascript.suggest.autoImports": true,
    "js/ts.implicitProjectConfig.checkJs": true,
```

It was showing red lines a bit here and there. With this changes it could figure out more what things where with autocompletion

Could improve some bits even further if i may use private fields, But it requires node v12 and you are testing v8...
could we perhaps drop some older versions and align a bit more with current targeted support versions?