### PR TITLE
Add `WebSocket.WebSocket{,Server}` aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,7 @@ WebSocket.Server = require('./lib/websocket-server');
 WebSocket.Receiver = require('./lib/receiver');
 WebSocket.Sender = require('./lib/sender');
 
+WebSocket.WebSocket = WebSocket;
+WebSocket.WebSocketServer = WebSocket.Server;
+
 module.exports = WebSocket;


### PR DESCRIPTION
Add `WebSocket.WebSocket` as an alias for `WebSocket` and
`WebSocket.WebSocketServer` as an alias for `WebSocket.Server` to fix
name consistency and improve interoperability with the ES module
wrapper.

Refs: https://github.com/websockets/ws/issues/1877
Refs: https://github.com/websockets/ws/issues/1932