### PR TITLE
Ignore the `threshold` option if context takeover is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const wss = new WebSocketServer({
     // Below options specified as default values.
     concurrencyLimit: 10, // Limits zlib concurrency for perf.
     threshold: 1024 // Size (in bytes) below which messages
-    // should not be compressed.
+    // should not be compressed if context takeover is disabled.
   }
 });
 ```

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -147,8 +147,8 @@ value). If an object is provided then that is extension parameters:
   zlib on deflate.
 - `zlibInflateOptions` {Object} [Additional options][zlib-options] to pass to
   zlib on inflate.
-- `threshold` {Number} Payloads smaller than this will not be compressed.
-  Defaults to 1024 bytes.
+- `threshold` {Number} Payloads smaller than this will not be compressed if
+  context takeover is disabled. Defaults to 1024 bytes.
 - `concurrencyLimit` {Number} The number of concurrent calls to zlib. Calls
   above this limit will be queued. Default 10. You usually won't need to touch
   this option. See [this issue][concurrency-limit] for more details.

--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -41,7 +41,7 @@ class PerMessageDeflate {
    * @param {Boolean} [options.serverNoContextTakeover=false] Request/accept
    *     disabling of server context takeover
    * @param {Number} [options.threshold=1024] Size (in bytes) below which
-   *     messages should not be compressed
+   *     messages should not be compressed if context takeover is disabled
    * @param {Object} [options.zlibDeflateOptions] Options to pass to zlib on
    *     deflate
    * @param {Object} [options.zlibInflateOptions] Options to pass to zlib on

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -274,7 +274,15 @@ class Sender {
 
     if (this._firstFragment) {
       this._firstFragment = false;
-      if (rsv1 && perMessageDeflate) {
+      if (
+        rsv1 &&
+        perMessageDeflate &&
+        perMessageDeflate.params[
+          perMessageDeflate._isServer
+            ? 'server_no_context_takeover'
+            : 'client_no_context_takeover'
+        ]
+      ) {
         rsv1 = buf.length >= perMessageDeflate._threshold;
       }
       this._compress = rsv1;

--- a/test/permessage-deflate.test.js
+++ b/test/permessage-deflate.test.js
@@ -344,7 +344,7 @@ describe('PerMessageDeflate', () => {
 
   describe('#compress and #decompress', () => {
     it('works with unfragmented messages', (done) => {
-      const perMessageDeflate = new PerMessageDeflate({ threshold: 0 });
+      const perMessageDeflate = new PerMessageDeflate();
       const buf = Buffer.from([1, 2, 3]);
 
       perMessageDeflate.accept([{}]);
@@ -361,7 +361,7 @@ describe('PerMessageDeflate', () => {
     });
 
     it('works with fragmented messages', (done) => {
-      const perMessageDeflate = new PerMessageDeflate({ threshold: 0 });
+      const perMessageDeflate = new PerMessageDeflate();
       const buf = Buffer.from([1, 2, 3, 4]);
 
       perMessageDeflate.accept([{}]);
@@ -388,7 +388,6 @@ describe('PerMessageDeflate', () => {
 
     it('works with the negotiated parameters', (done) => {
       const perMessageDeflate = new PerMessageDeflate({
-        threshold: 0,
         memLevel: 5,
         level: 9
       });
@@ -415,11 +414,9 @@ describe('PerMessageDeflate', () => {
 
     it('honors the `level` option', (done) => {
       const lev0 = new PerMessageDeflate({
-        threshold: 0,
         zlibDeflateOptions: { level: 0 }
       });
       const lev9 = new PerMessageDeflate({
-        threshold: 0,
         zlibDeflateOptions: { level: 9 }
       });
       const extensionStr =
@@ -459,7 +456,6 @@ describe('PerMessageDeflate', () => {
 
     it('honors the `zlib{Deflate,Inflate}Options` option', (done) => {
       const lev0 = new PerMessageDeflate({
-        threshold: 0,
         zlibDeflateOptions: {
           level: 0,
           chunkSize: 256
@@ -469,7 +465,6 @@ describe('PerMessageDeflate', () => {
         }
       });
       const lev9 = new PerMessageDeflate({
-        threshold: 0,
         zlibDeflateOptions: {
           level: 9,
           chunkSize: 128
@@ -523,7 +518,7 @@ describe('PerMessageDeflate', () => {
     });
 
     it("doesn't use contex takeover if not allowed", (done) => {
-      const perMessageDeflate = new PerMessageDeflate({ threshold: 0 }, true);
+      const perMessageDeflate = new PerMessageDeflate({}, true);
       const extensions = extension.parse(
         'permessage-deflate;server_no_context_takeover'
       );
@@ -554,7 +549,7 @@ describe('PerMessageDeflate', () => {
     });
 
     it('uses contex takeover if allowed', (done) => {
-      const perMessageDeflate = new PerMessageDeflate({ threshold: 0 }, true);
+      const perMessageDeflate = new PerMessageDeflate({}, true);
       const extensions = extension.parse('permessage-deflate');
       const buf = Buffer.from('foofoo');
 
@@ -583,7 +578,7 @@ describe('PerMessageDeflate', () => {
     });
 
     it('calls the callback when an error occurs (inflate)', (done) => {
-      const perMessageDeflate = new PerMessageDeflate({ threshold: 0 });
+      const perMessageDeflate = new PerMessageDeflate();
       const data = Buffer.from('something invalid');
 
       perMessageDeflate.accept([{}]);
@@ -596,11 +591,7 @@ describe('PerMessageDeflate', () => {
     });
 
     it("doesn't call the callback twice when `maxPayload` is exceeded", (done) => {
-      const perMessageDeflate = new PerMessageDeflate(
-        { threshold: 0 },
-        false,
-        25
-      );
+      const perMessageDeflate = new PerMessageDeflate({}, false, 25);
       const buf = Buffer.from('A'.repeat(50));
 
       perMessageDeflate.accept([{}]);
@@ -616,7 +607,7 @@ describe('PerMessageDeflate', () => {
     });
 
     it('calls the callback if the deflate stream is closed prematurely', (done) => {
-      const perMessageDeflate = new PerMessageDeflate({ threshold: 0 });
+      const perMessageDeflate = new PerMessageDeflate();
       const buf = Buffer.from('A'.repeat(50));
 
       perMessageDeflate.accept([{}]);


### PR DESCRIPTION
When context takeover is enabled, compress messages even if their size
is below the value of `threshold` option.

Refs: https://github.com/websockets/ws/issues/1950