### PR TITLE
Enable on headers handler to reject connection modifying headers param

### DIFF
--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -389,6 +389,13 @@ class WebSocketServer extends EventEmitter {
     socket.write(headers.concat('\r\n').join('\r\n'));
     socket.removeListener('error', socketOnError);
 
+    if (headers.length==0 || !headers[0].startsWith('HTTP/1.1 101 ')) { 
+      //An error status and headers were just send. Terminate the connection
+      socket.end();
+      //as the socket is not writable the code will not be used
+      return abortHandshake(socket, 500); 
+    }
+
     ws.setSocket(socket, head, {
       maxPayload: this.options.maxPayload,
       skipUTF8Validation: this.options.skipUTF8Validation

--- a/test/onheaeder-httperr.test.js
+++ b/test/onheaeder-httperr.test.js
@@ -1,0 +1,53 @@
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "^ws$" }] */
+
+'use strict';
+
+const WebSocket = require('..');
+
+
+describe('WebSocketServer', () => { 
+  it('successfully rejects a connection via error heders in on headers handler', (done) => {
+  const wss = new WebSocket.Server(
+    {
+      port: 0
+    },
+    () => {
+      const ws = new WebSocket(`ws://localhost:${wss.address().port}`);
+      wss.on('connection', (ws) => {
+        done(new Error("WSS: on connection?! We should not be here!"));
+        ws.close();
+        wss.close();
+      });
+      wss.on('headers', (headers,req)=>{
+        headers.length=0;
+        headers.push('HTTP/1.1 418 I\'m a teapot');
+        headers.push('Connection: close');
+      });
+
+      ws.on('open', () => {
+       done(new Error("WS: on connection?! We should not be here!"));
+       ws.close();
+       wss.close();
+      });
+      ws.on('error',(err)=>{
+        if (err instanceof Error) {
+          if (err.message.endsWith(' 418')) {
+            //end with no error
+            done();
+            ws.close();
+            wss.close();
+          } else {
+            done(new Error("WS: on err but err is not as expected!"));
+            ws.close();
+            wss.close();
+          }
+        } else {
+          done(new Error("WS: on err but err is not instance of Error!"));
+          ws.close();
+          wss.close();
+        }
+      });
+    }
+  );
+
+})});


### PR DESCRIPTION
A common problem is authenticating and rejecting websocket clients.  The `headers` handler of the server is in unique position to easily reject the client after expecting all the available information from the request. This minimal patch detects the attempt to close the connection and does so in graceful manner.  See the added test for easy client rejection