### PR TITLE
Allow cb to be optional for WebSocketServer.handleUpgrade

### DIFF
--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -121,6 +121,7 @@ class WebSocketServer extends EventEmitter {
 
     this.options = options;
     this._state = RUNNING;
+    //if (options.noServer && typeof(callback)=='function') setImmediate(callback);
   }
 
   /**
@@ -221,11 +222,18 @@ class WebSocketServer extends EventEmitter {
    * @param {(net.Socket|tls.Socket)} socket The network socket between the
    *     server and client
    * @param {Buffer} head The first packet of the upgraded stream
-   * @param {Function} cb Callback
+   * @param {Function} cb Callback optional, if not provided the server will
+   *     trigger default behaviour firing connection even
    * @public
    */
   handleUpgrade(req, socket, head, cb) {
     socket.on('error', socketOnError);
+    if (cb===undefined) {
+      const that=this;
+      cb = function (ws,req) {
+        that.emit('connection',ws,req);
+      }
+    }
 
     const key =
       req.headers['sec-websocket-key'] !== undefined

--- a/test/handleupgrade-default-cb.test.js
+++ b/test/handleupgrade-default-cb.test.js
@@ -1,0 +1,37 @@
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "^ws$" }] */
+
+'use strict';
+
+const WebSocket = require('..');
+const http= require('http'); 
+
+describe('WebSocketServer.handleUpgrade', () => { 
+  it('successfully triggers connection event with default callback', (done) => {
+  let ws;
+  const server = http.createServer();
+  const wss = new WebSocket.Server({ noServer: true });
+  wss.on('connection', function (ws) {
+    done();
+    server.close();
+    if (ws) ws.close();
+  });
+  wss.on('error',(err)=>{
+    done(new Error("WSS: got error event"));
+    if (ws) ws.close();
+    server.close();
+  });
+
+  server.on('upgrade', function upgrade(request, socket, head) {
+    wss.handleUpgrade(request, socket, head);
+  });
+
+  server.listen(0,function(){
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`);
+    ws.on('error',(err)=>{
+      done(new Error("WS: got error event"));
+      ws.close();
+      server.close();
+    });
+});
+
+})});


### PR DESCRIPTION
this allows WebSocketServer.handleUpgrade to be called without a callback, in which case the default behaviour will be triggered  and the `connection` event will be fired