### PR TITLE
docs: simple example that work locally out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,26 +100,18 @@ See [the docs][ws-server-options] for more options.
 import WebSocket, { WebSocketServer } from 'ws';
 
 const wss = new WebSocketServer({
+  host: "127.0.0.1",
   port: 8080,
-  perMessageDeflate: {
-    zlibDeflateOptions: {
-      // See zlib defaults.
-      chunkSize: 1024,
-      memLevel: 7,
-      level: 3
-    },
-    zlibInflateOptions: {
-      chunkSize: 10 * 1024
-    },
-    // Other options settable:
-    clientNoContextTakeover: true, // Defaults to negotiated value.
-    serverNoContextTakeover: true, // Defaults to negotiated value.
-    serverMaxWindowBits: 10, // Defaults to negotiated value.
-    // Below options specified as default values.
-    concurrencyLimit: 10, // Limits zlib concurrency for perf.
-    threshold: 1024 // Size (in bytes) below which messages
-    // should not be compressed if context takeover is disabled.
-  }
+});
+
+wss.on('connection', function connection(ws) {
+  console.log("Connection from client received")
+
+  ws.on('message', function message(data) {
+    console.log('received: %s', data);
+  });
+
+  ws.send('something to send');
 });
 ```
 
@@ -176,7 +168,28 @@ ws.on('open', function open() {
 ```js
 import { WebSocketServer } from 'ws';
 
-const wss = new WebSocketServer({ port: 8080 });
+const wss = new WebSocketServer({ 
+  port: 8080,
+  perMessageDeflate: {
+    zlibDeflateOptions: {
+      // See zlib defaults.
+      chunkSize: 1024,
+      memLevel: 7,
+      level: 3
+    },
+    zlibInflateOptions: {
+      chunkSize: 10 * 1024
+    },
+    // Other options settable:
+    clientNoContextTakeover: true, // Defaults to negotiated value.
+    serverNoContextTakeover: true, // Defaults to negotiated value.
+    serverMaxWindowBits: 10, // Defaults to negotiated value.
+    // Below options specified as default values.
+    concurrencyLimit: 10, // Limits zlib concurrency for perf.
+    threshold: 1024 // Size (in bytes) below which messages
+    // should not be compressed if context takeover is disabled.
+  }
+});
 
 wss.on('connection', function connection(ws) {
   ws.on('message', function message(data) {


### PR DESCRIPTION
Was trying to quickly set up a websocket using `ws` and to test it using the browser. 

With the new policies of Chrome, it is not possible to send messages to the localhost if not specified as a parameter `host` of the websocket server when not using WSS.

When testing a library, we want to quickly see the result and if it's working. We don't want to set a TLS certificat and it should directly work locally since it should not be tested on a remote server (that should have opened port).

I am suggesting to clear the README.md so that the example will work and display console message out of the box by copying the first example. 