### PR TITLE
extending ws to support 48bit values

### DIFF
--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -356,7 +356,7 @@ class Receiver extends Writable {
       );
     }
 
-    this._payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4);
+    this._payloadLength = buf.readUIntBE(2, 6);
     return this.haveLength();
   }
 

--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -356,7 +356,7 @@ class Receiver extends Writable {
       );
     }
 
-    this._payloadLength = buf.readUIntBE(2, 6);
+    this._payloadLength = num * Math.pow(2, 32) + buf.readUInt32BE(4);
     return this.haveLength();
   }
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -75,8 +75,7 @@ class Sender {
     if (payloadLength === 126) {
       target.writeUInt16BE(data.length, 2);
     } else if (payloadLength === 127) {
-      target.writeUInt32BE(0, 2);
-      target.writeUInt32BE(data.length, 6);
+      target.writeUIntBE(data.length, 4, 6);
     }
 
     if (!options.mask) return [target, data];

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -75,6 +75,8 @@ class Sender {
     if (payloadLength === 126) {
       target.writeUInt16BE(data.length, 2);
     } else if (payloadLength === 127) {
+      target[2] = 0;
+      target[3] = 0;
       target.writeUIntBE(data.length, 4, 6);
     }
 


### PR DESCRIPTION
The ws library is using 32 bit values on the read and write for payload length.  This is because web sockets supports 63 bit payload lengths if the payload flag is 127 but JavaScript's max number is 53 bits - 1.

Node.js supports a 48 bit read and write operation.  The maximum payload length supported by 32 bits is 2.1gb.  The maximum payload length supported by 48 bits is 281tb.

Is there test automation or CI I can run this against?