### PR TITLE
add option 'clear' mask

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -53,8 +53,8 @@ class Sender {
    * @public
    */
   static frame(data, options) {
-    const merge = options.mask && options.readOnly;
     const clear = options.mask == 'clear';
+    const merge = options.mask && options.readOnly && !clear;
     let offset = options.mask ? 6 : 2;
     let payloadLength = data.length;
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -42,8 +42,8 @@ class Sender {
    * @param {Object} options Options object
    * @param {Boolean} [options.fin=false] Specifies whether or not to set the
    *     FIN bit
-   * @param {Boolean} [options.mask=false] Specifies whether or not to mask
-   *     `data`
+   * @param {Boolean|String} [options.mask=false] Specifies whether or not to mask
+   *     `data`. A 'clear' value applies an empty mask to improve performance
    * @param {Number} options.opcode The opcode
    * @param {Boolean} [options.readOnly=false] Specifies whether `data` can be
    *     modified
@@ -54,6 +54,7 @@ class Sender {
    */
   static frame(data, options) {
     const merge = options.mask && options.readOnly;
+    const clear = options.mask == 'clear';
     let offset = options.mask ? 6 : 2;
     let payloadLength = data.length;
 
@@ -81,13 +82,15 @@ class Sender {
 
     if (!options.mask) return [target, data];
 
-    randomFillSync(mask, 0, 4);
+    clear ? mask.fill(0) : randomFillSync(mask, 0, 4);
 
     target[1] |= 0x80;
     target[offset - 4] = mask[0];
     target[offset - 3] = mask[1];
     target[offset - 2] = mask[2];
     target[offset - 1] = mask[3];
+
+    if (clear) return [target, data];
 
     if (merge) {
       applyMask(data, mask, target, offset, data.length);


### PR DESCRIPTION
There was discussion here https://github.com/websockets/ws/pull/1986 @ronag about disabling mask to improve client performance for cases when mask is not necessary, to stay spec compliant can add option to use a clear mask to skip random number generation and skip XOR on all bits, and a server will not close the connection from a missing mask