### PR TITLE
Drop sensitive headers when following redirects

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -766,6 +766,45 @@ function initAsClient(websocket, address, protocols, options) {
     opts.path = parts[1];
   }
 
+  if (opts.followRedirects) {
+    if (websocket._redirects === 0) {
+      websocket._originalHost = parsedUrl.host;
+
+      const headers = options && options.headers;
+
+      //
+      // Shallow copy the user provided options so that headers can be changed
+      // without mutating the original object.
+      //
+      options = { ...options, headers: {} };
+
+      if (headers) {
+        for (const [key, value] of Object.entries(headers)) {
+          options.headers[key.toLowerCase()] = value;
+        }
+      }
+    } else if (parsedUrl.host !== websocket._originalHost) {
+      //
+      // Match curl 7.77.0 behavior and drop the following headers. These
+      // headers are also dropped when following a redirect to a subdomain.
+      //
+      delete opts.headers.authorization;
+      delete opts.headers.cookie;
+      delete opts.headers.host;
+      opts.auth = undefined;
+    }
+
+    //
+    // Match curl 7.77.0 behavior and make the first `Authorization` header win.
+    // If the `Authorization` header is set, then there is nothing to do as it
+    // will take precedence.
+    //
+    if (opts.auth && !options.headers.authorization) {
+      options.headers.authorization =
+        'Basic ' + Buffer.from(opts.auth).toString('base64');
+    }
+  }
+
   let req = (websocket._req = get(opts));
 
   if (opts.timeout) {


### PR DESCRIPTION
Do not forward the `Authorization` and `Cookie` headers if the redirect
host is different from the original host.