### PR TITLE
Allow to drop custom sensitive headers when following redirects

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -794,7 +794,7 @@ function initAsClient(websocket, address, protocols, options) {
 
       if (Symbol.iterator in Object(opts.followRedirects)) {
         for (const key of opts.followRedirects) {
-          delete opts.headers[key];
+          delete opts.headers[key.toLowerCase()];
         }
       }
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -792,7 +792,7 @@ function initAsClient(websocket, address, protocols, options) {
       delete opts.headers.cookie;
       delete opts.headers.host;
 
-      if (opts.followRedirects instanceof Set) {
+      if (Symbol.iterator in Object(opts.followRedirects)) {
         for (const key of opts.followRedirects) {
           delete opts.headers[key];
         }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -791,6 +791,13 @@ function initAsClient(websocket, address, protocols, options) {
       delete opts.headers.authorization;
       delete opts.headers.cookie;
       delete opts.headers.host;
+
+      if (opts.followRedirects instanceof Set) {
+        for (const key of opts.followRedirects) {
+          delete opts.headers[key];
+        }
+      }
+
       opts.auth = undefined;
     }
 

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -1268,10 +1268,10 @@ describe('WebSocket', () => {
               Authorization: 'Basic Zm9vOmJhcg==',
               Cookie: 'foo=bar',
               Host: 'foo',
-              'x-api-key': 'secret-api-key',
-              'x-api-signature': 'secret-api-signature'
+              'X-API-KEY': 'secret-api-key',
+              'X-API-SIGNATURE': 'secret-api-signature'
             },
-            followRedirects: new Set(['x-api-key', 'x-api-signature'])
+            followRedirects: new Set(['X-API-KEY', 'X-API-SIGNATURE'])
           });
 
           assert.strictEqual(
@@ -1280,9 +1280,9 @@ describe('WebSocket', () => {
           );
           assert.strictEqual(ws._req.getHeader('Cookie'), 'foo=bar');
           assert.strictEqual(ws._req.getHeader('Host'), 'foo');
-          assert.strictEqual(ws._req.getHeader('x-api-key'), 'secret-api-key');
+          assert.strictEqual(ws._req.getHeader('X-API-KEY'), 'secret-api-key');
           assert.strictEqual(
-            ws._req.getHeader('x-api-signature'),
+            ws._req.getHeader('X-API-SIGNATURE'),
             'secret-api-signature'
           );
 


### PR DESCRIPTION
@lpinca What do you think about using the existing option `followRedirects` to achieve that?