### PR TITLE
Default empty sec-websocket-protocol header to undefined

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -877,7 +877,7 @@ function initAsClient(websocket, address, protocols, options) {
       return;
     }
 
-    const serverProt = res.headers['sec-websocket-protocol'];
+    const serverProt = res.headers['sec-websocket-protocol'] || undefined;
     let protError;
 
     if (serverProt !== undefined) {


### PR DESCRIPTION
Hi! How are you doing? 
First of all, thank you for all of your hard work on this great library!
I'm definitely not an expert on web sockets, but I've noticed that some servers respond with an empty `sec-websocket-protocol` header instead of not returning one at all. 
For those servers, the connection ends up failing with `Server sent a subprotocol but none was requested` because the validation expects an `undefined` header as opposed to an empty `""` header. 
This change solves that issue, allowing the connection to succeed.

Please let me know if you have any comments or if I can be of any help!