### PR TITLE
[doc] document defaults for maxPayload

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -72,7 +72,8 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `handleProtocols` {Function} A function which can be used to handle the
     WebSocket subprotocols. See description below.
   - `host` {String} The hostname where to bind the server.
-  - `maxPayload` {Number} The maximum allowed message size in bytes.
+  - `maxPayload` {Number} The maximum allowed message size in bytes. Defaults
+    to 100 MiB (104857600 bytes).
   - `noServer` {Boolean} Enable no server mode.
   - `path` {String} Accept only connections matching this path.
   - `perMessageDeflate` {Boolean|Object} Enable/disable permessage-deflate.
@@ -279,7 +280,8 @@ This class represents a WebSocket. It extends the `EventEmitter`.
     cryptographically strong random bytes.
   - `handshakeTimeout` {Number} Timeout in milliseconds for the handshake
     request. This is reset after every redirection.
-  - `maxPayload` {Number} The maximum allowed message size in bytes.
+  - `maxPayload` {Number} The maximum allowed message size in bytes. Defaults
+    to 100 MiB (104857600 bytes).
   - `maxRedirects` {Number} The maximum number of redirects allowed. Defaults
     to 10.
   - `origin` {String} Value of the `Origin` or `Sec-WebSocket-Origin` header

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -280,8 +280,8 @@ This class represents a WebSocket. It extends the `EventEmitter`.
     cryptographically strong random bytes.
   - `handshakeTimeout` {Number} Timeout in milliseconds for the handshake
     request. This is reset after every redirection.
-  - `maxPayload` {Number} The maximum allowed message size in bytes. Defaults
-    to 100 MiB (104857600 bytes).
+  - `maxPayload` {Number} The maximum allowed message size in bytes. Defaults to
+    100 MiB (104857600 bytes).
   - `maxRedirects` {Number} The maximum number of redirects allowed. Defaults
     to 10.
   - `origin` {String} Value of the `Origin` or `Sec-WebSocket-Origin` header

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -72,8 +72,8 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `handleProtocols` {Function} A function which can be used to handle the
     WebSocket subprotocols. See description below.
   - `host` {String} The hostname where to bind the server.
-  - `maxPayload` {Number} The maximum allowed message size in bytes. Defaults
-    to 100 MiB (104857600 bytes).
+  - `maxPayload` {Number} The maximum allowed message size in bytes. Defaults to
+    100 MiB (104857600 bytes).
   - `noServer` {Boolean} Enable no server mode.
   - `path` {String} Accept only connections matching this path.
   - `perMessageDeflate` {Boolean|Object} Enable/disable permessage-deflate.


### PR DESCRIPTION
This documents the default values for `maxPayload`.
I got these by looking at the code here:

1. [WebSocket.Server](https://github.com/websockets/ws/blob/e1ddacce06d302884e674f50c12cb376e000c6ea/lib/websocket-server.js#L40)
2. [WebSocket client](https://github.com/websockets/ws/blob/6946f5fe781bafe99a36ed954904966203422b3d/lib/websocket.js#L622)