### PR TITLE
Added WebSocketServer.createClient()

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -12,6 +12,7 @@
   - [server.address()](#serveraddress)
   - [server.clients](#serverclients)
   - [server.close([callback])](#serverclosecallback)
+  - [server.createClient(extensions, key, protocols, request, socket, head)](#servercreateclientextensions-key-protocols-request-socket-head)
   - [server.handleUpgrade(request, socket, head, callback)](#serverhandleupgraderequest-socket-head-callback)
   - [server.shouldHandle(request)](#servershouldhandlerequest)
 - [Class: WebSocket](#class-websocket)
@@ -225,6 +226,21 @@ connections are closed unless an external HTTP server is used and client
 tracking is disabled. In this case the `'close'` event is emitted in the next
 tick. The optional callback is called when the `'close'` event occurs and
 receives an `Error` if the server is already closed.
+
+### server.createClient(extensions, key, protocols, request, socket, head)
+
+- `extensions` {Object} The accepted extensions.
+- `key` {String} The value of the `Sec-WebSocket-Key` header.
+- `protocols` {Set} The subprotocols.
+- `request` {http.IncomingMessage} The request object.
+- `socket` {(net.Socket|tls.Socket)} The network socket between the server and
+  client.
+- `head` {Buffer} The first packet of the upgraded stream
+
+Creates a new `WebSocket` client instance.
+
+This method can be overridden to provide custom constructor arguments to your
+custom `WebSocket` class (see the [`WebSocket` option](#new-websocketserveroptions-callback)).
 
 ### server.handleUpgrade(request, socket, head, callback)
 

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -239,8 +239,9 @@ receives an `Error` if the server is already closed.
 
 Creates a new `WebSocket` client instance.
 
-This method can be overridden to provide custom constructor arguments to your
-custom `WebSocket` class (see the [`WebSocket` option](#new-websocketserveroptions-callback)).
+An alternative to [the `WebSocket` option](#new-websocketserveroptions-callback),
+this method can be overridden when you need to construct custom `WebSocket`
+instances that require extended constructor arguments.
 
 ### server.handleUpgrade(request, socket, head, callback)
 

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -359,7 +359,7 @@ class WebSocketServer extends EventEmitter {
       `Sec-WebSocket-Accept: ${digest}`
     ];
 
-    const ws = new this.options.WebSocket(null);
+    const ws = this.createClient(extensions, key, protocols, req, socket, head);
 
     if (protocols.size) {
       //
@@ -410,6 +410,23 @@ class WebSocketServer extends EventEmitter {
 
     cb(ws, req);
   }
+
+  /**
+   * Create a new WebSocket instance.
+   *
+   * @param {Object} extensions The accepted extensions
+   * @param {String} key The value of the `Sec-WebSocket-Key` header
+   * @param {Set} protocols The subprotocols
+   * @param {http.IncomingMessage} req The request object
+   * @param {(net.Socket|tls.Socket)} socket The network socket between the
+   *     server and client
+   * @param {Buffer} head The first packet of the upgraded stream
+   * @return {WebSocket} The created WebSocket instance
+   * @public
+   */
+ createClient(extensions, key, protocols, req, socket, head) {
+  return new this.options.WebSocket(null);
+ }
 }
 
 module.exports = WebSocketServer;


### PR DESCRIPTION
While it's possible to customise the `WebSocket` class used by `WebSocketServer` (using the `WebSocket` option), it's not possible to pass custom constructor arguments to it.

This PR isolates the creation of the `WebSocket` instance in an extensible way allowing `WebSocketServer` subclasses to pass custom constructor arguments - based on the `request`, for example.

The same arguments provided to `WebSocketServer.completeUpgrade()` are passed to `WebSocketServer.createClient()` for broader use-cases.

Rationale...

I want to attach metadata to each `WebSocket` instance based on the incoming request URL. Every `WebSocket.open` event should be logged, and the log message should include this metadata.

Problem is, the `WebSocket.open` event is fired before the `WebSocketServer.handleUpgrade()` callback is executed so by then it's too late to attach the metadata. Providing the metadata at instantiation solves it.