### PR TITLE
Examples update: Fix HTTP method

### DIFF
--- a/examples/express-session-parse/index.js
+++ b/examples/express-session-parse/index.js
@@ -37,7 +37,7 @@ app.post('/login', function (req, res) {
   res.send({ result: 'OK', message: 'Session updated' });
 });
 
-app.delete('/logout', function (request, response) {
+app.post('/logout', function (request, response) {
   const ws = map.get(request.session.userId);
 
   console.log('Destroying session');


### PR DESCRIPTION
Logout endpoint does not meet spec for HTTP DELETE per https://httpwg.org/specs/rfc7231.html#DELETE, use POST instead.