### PR TITLE
Fix example: http post instead of delete

### DIFF
--- a/examples/express-session-parse/public/app.js
+++ b/examples/express-session-parse/public/app.js
@@ -26,7 +26,7 @@
   };
 
   logout.onclick = function () {
-    fetch('/logout', { method: 'DELETE', credentials: 'same-origin' })
+    fetch('/logout', { method: 'POST', credentials: 'same-origin' })
       .then(handleResponse)
       .then(showMessage)
       .catch(function (err) {


### PR DESCRIPTION
Logout endpoint does not meet spec for HTTP DELETE per https://httpwg.org/specs/rfc7231.html#DELETE, use POST instead.