### PR TITLE
Bugfix: missing else wsconnect

### DIFF
--- a/examples/express-session-parse/public/app.js
+++ b/examples/express-session-parse/public/app.js
@@ -40,19 +40,19 @@
     if (ws) {
       ws.onerror = ws.onopen = ws.onclose = null;
       ws.close();
+    } else {
+      ws = new WebSocket(`ws://${location.host}`);
+      ws.onerror = function () {
+        showMessage('WebSocket error');
+      };
+      ws.onopen = function () {
+        showMessage('WebSocket connection established');
+      };
+      ws.onclose = function () {
+        showMessage('WebSocket connection closed');
+        ws = null;
+      };
     }
-
-    ws = new WebSocket(`ws://${location.host}`);
-    ws.onerror = function () {
-      showMessage('WebSocket error');
-    };
-    ws.onopen = function () {
-      showMessage('WebSocket connection established');
-    };
-    ws.onclose = function () {
-      showMessage('WebSocket connection closed');
-      ws = null;
-    };
   };
 
   wsSendButton.onclick = function () {


### PR DESCRIPTION
The connection logic needs to be moved into the else block to stop the client from immediately reconnecting after pressing the button to disconnect.