### PR TITLE
Add the `WS_NO_{BUFFER_UTIL, UTF_8_VALIDATE}` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ necessarily need to have a C++ compiler installed on your machine.
 - `npm install --save-optional utf-8-validate`: Allows to efficiently check if a
   message contains valid UTF-8.
 
+To not even try to require and use these modules, use the
+[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) and
+[`WS_NO_UTF_8_VALIDATE`](./doc/ws.md#ws_no_utf_8_validate) environment
+variables. These might be useful to enhance security in systems where a user can
+put a package in the package search path of an application of another user, due
+to how the Node.js resolver algorithm works.
+
 ## API docs
 
 See [`/doc/ws.md`](./doc/ws.md) for Node.js-like documentation of ws classes and

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -49,6 +49,9 @@
   - [websocket.terminate()](#websocketterminate)
   - [websocket.url](#websocketurl)
 - [createWebSocketStream(websocket[, options])](#createwebsocketstreamwebsocket-options)
+- [Environment variables](#environment-variables)
+  - [WS_NO_BUFFER_UTIL](#ws_no_buffer_util)
+  - [WS_NO_UTF_8_VALIDATE](#ws_no_utf_8_validate)
 - [Error codes](#error-codes)
   - [WS_ERR_EXPECTED_FIN](#ws_err_expected_fin)
   - [WS_ERR_EXPECTED_MASK](#ws_err_expected_mask)
@@ -586,6 +589,18 @@ The URL of the WebSocket server. Server clients don't have this attribute.
 
 Returns a `Duplex` stream that allows to use the Node.js streams API on top of a
 given `WebSocket`.
+
+## Environment variables
+
+### WS_NO_BUFFER_UTIL
+
+When set to a non empty value, prevents the optional `bufferutil` dependency
+from being required.
+
+### WS_NO_UTF_8_VALIDATE
+
+When set to a non empty value, prevents the optional `utf-8-validate` dependency
+from being required.
 
 ## Error codes
 

--- a/lib/buffer-util.js
+++ b/lib/buffer-util.js
@@ -99,28 +99,29 @@ function toBuffer(data) {
   return buf;
 }
 
-try {
-  const bufferUtil = require('bufferutil');
+module.exports = {
+  concat,
+  mask: _mask,
+  toArrayBuffer,
+  toBuffer,
+  unmask: _unmask
+};
 
-  module.exports = {
-    concat,
-    mask(source, mask, output, offset, length) {
+/* istanbul ignore else  */
+if (!process.env.WS_NO_BUFFER_UTIL) {
+  try {
+    const bufferUtil = require('bufferutil');
+
+    module.exports.mask = function (source, mask, output, offset, length) {
       if (length < 48) _mask(source, mask, output, offset, length);
       else bufferUtil.mask(source, mask, output, offset, length);
-    },
-    toArrayBuffer,
-    toBuffer,
-    unmask(buffer, mask) {
+    };
+
+    module.exports.unmask = function (buffer, mask) {
       if (buffer.length < 32) _unmask(buffer, mask);
       else bufferUtil.unmask(buffer, mask);
-    }
-  };
-} catch (e) /* istanbul ignore next */ {
-  module.exports = {
-    concat,
-    mask: _mask,
-    toArrayBuffer,
-    toBuffer,
-    unmask: _unmask
-  };
+    };
+  } catch (e) {
+    // Continue regardless of the error.
+  }
 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -105,20 +105,21 @@ function _isValidUTF8(buf) {
   return true;
 }
 
-try {
-  const isValidUTF8 = require('utf-8-validate');
+module.exports = {
+  isValidStatusCode,
+  isValidUTF8: _isValidUTF8,
+  tokenChars
+};
 
-  module.exports = {
-    isValidStatusCode,
-    isValidUTF8(buf) {
+/* istanbul ignore else  */
+if (!process.env.WS_NO_UTF_8_VALIDATE) {
+  try {
+    const isValidUTF8 = require('utf-8-validate');
+
+    module.exports.isValidUTF8 = function (buf) {
       return buf.length < 150 ? _isValidUTF8(buf) : isValidUTF8(buf);
-    },
-    tokenChars
-  };
-} catch (e) /* istanbul ignore next */ {
-  module.exports = {
-    isValidStatusCode,
-    isValidUTF8: _isValidUTF8,
-    tokenChars
-  };
+    };
+  } catch (e) {
+    // Continue regardless of the error.
+  }
 }


### PR DESCRIPTION
When set to non empty values, the `WS_NO_BUFFER_UTIL` and
`WS_NO_UTF_8_VALIDATE` environment variables, prevent the optional
`bufferutil` and `utf-8-validate` dependencies  from being required,
respectively.

These might be useful to enhance security in systems where a user can
put a package in the package search path of an application of another
user, due to how the Node.js resolver algorithm works.