### PR TITLE
Fix typo in table of contents

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -9,7 +9,7 @@
   - [Event: 'error'](#event-error)
   - [Event: 'headers'](#event-headers)
   - [Event: 'listening'](#event-listening)
-  - [Event: 'wsClientError'](event-wsclienterror)
+  - [Event: 'wsClientError'](#event-wsclienterror)
   - [server.address()](#serveraddress)
   - [server.clients](#serverclients)
   - [server.close([callback])](#serverclosecallback)


### PR DESCRIPTION
This PR fixes a small typo where the link was not pointing to an anchor.