### PR TITLE
Add "Server" alias to wrapper.mjs to match index.js exports and types

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -4,5 +4,7 @@ import Sender from './lib/sender.js';
 import WebSocket from './lib/websocket.js';
 import WebSocketServer from './lib/websocket-server.js';
 
-export { createWebSocketStream, Receiver, Sender, WebSocket, WebSocketServer };
+const Server = WebSocketServer;
+
+export { createWebSocketStream, Server, Receiver, Sender, WebSocket, WebSocketServer };
 export default WebSocket;


### PR DESCRIPTION
`index.js` exports the contents of `.lib/websocket-server` under the aliases of both `WebSocketServer` and `Server`.  Unfortunately, `wrapper.mjs` only exports `WebSocketServer` not `Server`.  Only exporting `WebSocketServer` breaks the types (i.e. `@types/ws`) and causes build errors (which is how I caught this).  

This commit adds the `Server` alias to `wrapper.mjs`.