### PR TITLE
Add named pipe support for Windows

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -2,68 +2,71 @@
 
 ## Table of Contents
 
-- [Class: WebSocketServer](#class-websocketserver)
-  - [new WebSocketServer(options[, callback])](#new-websocketserveroptions-callback)
-  - [Event: 'close'](#event-close)
-  - [Event: 'connection'](#event-connection)
-  - [Event: 'error'](#event-error)
-  - [Event: 'headers'](#event-headers)
-  - [Event: 'listening'](#event-listening)
-  - [Event: 'wsClientError'](#event-wsclienterror)
-  - [server.address()](#serveraddress)
-  - [server.clients](#serverclients)
-  - [server.close([callback])](#serverclosecallback)
-  - [server.handleUpgrade(request, socket, head, callback)](#serverhandleupgraderequest-socket-head-callback)
-  - [server.shouldHandle(request)](#servershouldhandlerequest)
-- [Class: WebSocket](#class-websocket)
-  - [Ready state constants](#ready-state-constants)
-  - [new WebSocket(address[, protocols][, options])](#new-websocketaddress-protocols-options)
-    - [UNIX Domain Sockets](#unix-domain-sockets)
-  - [Event: 'close'](#event-close-1)
-  - [Event: 'error'](#event-error-1)
-  - [Event: 'message'](#event-message)
-  - [Event: 'open'](#event-open)
-  - [Event: 'ping'](#event-ping)
-  - [Event: 'pong'](#event-pong)
-  - [Event: 'redirect'](#event-redirect)
-  - [Event: 'unexpected-response'](#event-unexpected-response)
-  - [Event: 'upgrade'](#event-upgrade)
-  - [websocket.addEventListener(type, listener[, options])](#websocketaddeventlistenertype-listener-options)
-  - [websocket.binaryType](#websocketbinarytype)
-  - [websocket.bufferedAmount](#websocketbufferedamount)
-  - [websocket.close([code[, reason]])](#websocketclosecode-reason)
-  - [websocket.extensions](#websocketextensions)
-  - [websocket.isPaused](#websocketispaused)
-  - [websocket.onclose](#websocketonclose)
-  - [websocket.onerror](#websocketonerror)
-  - [websocket.onmessage](#websocketonmessage)
-  - [websocket.onopen](#websocketonopen)
-  - [websocket.pause()](#websocketpause)
-  - [websocket.ping([data[, mask]][, callback])](#websocketpingdata-mask-callback)
-  - [websocket.pong([data[, mask]][, callback])](#websocketpongdata-mask-callback)
-  - [websocket.protocol](#websocketprotocol)
-  - [websocket.readyState](#websocketreadystate)
-  - [websocket.removeEventListener(type, listener)](#websocketremoveeventlistenertype-listener)
-  - [websocket.resume()](#websocketresume)
-  - [websocket.send(data[, options][, callback])](#websocketsenddata-options-callback)
-  - [websocket.terminate()](#websocketterminate)
-  - [websocket.url](#websocketurl)
-- [createWebSocketStream(websocket[, options])](#createwebsocketstreamwebsocket-options)
-- [Environment variables](#environment-variables)
-  - [WS_NO_BUFFER_UTIL](#ws_no_buffer_util)
-  - [WS_NO_UTF_8_VALIDATE](#ws_no_utf_8_validate)
-- [Error codes](#error-codes)
-  - [WS_ERR_EXPECTED_FIN](#ws_err_expected_fin)
-  - [WS_ERR_EXPECTED_MASK](#ws_err_expected_mask)
-  - [WS_ERR_INVALID_CLOSE_CODE](#ws_err_invalid_close_code)
-  - [WS_ERR_INVALID_CONTROL_PAYLOAD_LENGTH](#ws_err_invalid_control_payload_length)
-  - [WS_ERR_INVALID_OPCODE](#ws_err_invalid_opcode)
-  - [WS_ERR_INVALID_UTF8](#ws_err_invalid_utf8)
-  - [WS_ERR_UNEXPECTED_MASK](#ws_err_unexpected_mask)
-  - [WS_ERR_UNEXPECTED_RSV_1](#ws_err_unexpected_rsv_1)
-  - [WS_ERR_UNEXPECTED_RSV_2_3](#ws_err_unexpected_rsv_2_3)
-  - [WS_ERR_UNSUPPORTED_DATA_PAYLOAD_LENGTH](#ws_err_unsupported_data_payload_length)
-  - [WS_ERR_UNSUPPORTED_MESSAGE_LENGTH](#ws_err_unsupported_message_length)
+- [ws](#ws)
+  - [Table of Contents](#table-of-contents)
+  - [Class: WebSocketServer](#class-websocketserver)
+    - [new WebSocketServer(options[, callback])](#new-websocketserveroptions-callback)
+    - [Event: 'close'](#event-close)
+    - [Event: 'connection'](#event-connection)
+    - [Event: 'error'](#event-error)
+    - [Event: 'headers'](#event-headers)
+    - [Event: 'listening'](#event-listening)
+    - [Event: 'wsClientError'](#event-wsclienterror)
+    - [server.address()](#serveraddress)
+    - [server.clients](#serverclients)
+    - [server.close([callback])](#serverclosecallback)
+    - [server.handleUpgrade(request, socket, head, callback)](#serverhandleupgraderequest-socket-head-callback)
+    - [server.shouldHandle(request)](#servershouldhandlerequest)
+  - [Class: WebSocket](#class-websocket)
+    - [Ready state constants](#ready-state-constants)
+    - [new WebSocket(address, protocols)](#new-websocketaddress-protocols)
+      - [UNIX Domain Sockets](#unix-domain-sockets)
+      - [Windows Named Pipes](#windows-named-pipes)
+    - [Event: 'close'](#event-close-1)
+    - [Event: 'error'](#event-error-1)
+    - [Event: 'message'](#event-message)
+    - [Event: 'open'](#event-open)
+    - [Event: 'ping'](#event-ping)
+    - [Event: 'pong'](#event-pong)
+    - [Event: 'redirect'](#event-redirect)
+    - [Event: 'unexpected-response'](#event-unexpected-response)
+    - [Event: 'upgrade'](#event-upgrade)
+    - [websocket.addEventListener(type, listener[, options])](#websocketaddeventlistenertype-listener-options)
+    - [websocket.binaryType](#websocketbinarytype)
+    - [websocket.bufferedAmount](#websocketbufferedamount)
+    - [websocket.close([code[, reason]])](#websocketclosecode-reason)
+    - [websocket.isPaused](#websocketispaused)
+    - [websocket.extensions](#websocketextensions)
+    - [websocket.onclose](#websocketonclose)
+    - [websocket.onerror](#websocketonerror)
+    - [websocket.onmessage](#websocketonmessage)
+    - [websocket.onopen](#websocketonopen)
+    - [websocket.pause()](#websocketpause)
+    - [websocket.ping([data[, mask]][, callback])](#websocketpingdata-mask-callback)
+    - [websocket.pong([data[, mask]][, callback])](#websocketpongdata-mask-callback)
+    - [websocket.protocol](#websocketprotocol)
+    - [websocket.resume()](#websocketresume)
+    - [websocket.readyState](#websocketreadystate)
+    - [websocket.removeEventListener(type, listener)](#websocketremoveeventlistenertype-listener)
+    - [websocket.send(data, options)](#websocketsenddata-options)
+    - [websocket.terminate()](#websocketterminate)
+    - [websocket.url](#websocketurl)
+  - [createWebSocketStream(websocket[, options])](#createwebsocketstreamwebsocket-options)
+  - [Environment variables](#environment-variables)
+    - [WS_NO_BUFFER_UTIL](#ws_no_buffer_util)
+    - [WS_NO_UTF_8_VALIDATE](#ws_no_utf_8_validate)
+  - [Error codes](#error-codes)
+    - [WS_ERR_EXPECTED_FIN](#ws_err_expected_fin)
+    - [WS_ERR_EXPECTED_MASK](#ws_err_expected_mask)
+    - [WS_ERR_INVALID_CLOSE_CODE](#ws_err_invalid_close_code)
+    - [WS_ERR_INVALID_CONTROL_PAYLOAD_LENGTH](#ws_err_invalid_control_payload_length)
+    - [WS_ERR_INVALID_OPCODE](#ws_err_invalid_opcode)
+    - [WS_ERR_INVALID_UTF8](#ws_err_invalid_utf8)
+    - [WS_ERR_UNEXPECTED_MASK](#ws_err_unexpected_mask)
+    - [WS_ERR_UNEXPECTED_RSV_1](#ws_err_unexpected_rsv_1)
+    - [WS_ERR_UNEXPECTED_RSV_2_3](#ws_err_unexpected_rsv_2_3)
+    - [WS_ERR_UNSUPPORTED_DATA_PAYLOAD_LENGTH](#ws_err_unsupported_data_payload_length)
+    - [WS_ERR_UNSUPPORTED_MESSAGE_LENGTH](#ws_err_unsupported_message_length)
 
 ## Class: WebSocketServer
 
@@ -337,6 +340,23 @@ URL path is omitted
 
 ```
 ws+unix:///absolute/path/to/uds_socket
+```
+
+it defaults to `/`.
+
+#### Windows Named Pipes
+
+`ws` supports Windows named pipes. To make a request to a named pipe, prepend `\\\\.\\path` to the named pipe path:
+
+```
+ws+unix:///\\\\.\\path\\os_tempdir\\named_pipe:/pathname?search_params
+```
+
+Note that `:` is the separator between the socket path and the URL path. If the
+URL path is omitted
+
+```
+ws+unix:///\\\\.\\path\\os_tempdir\\named_pipe
 ```
 
 it defaults to `/`.

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -677,13 +677,13 @@ function initAsClient(websocket, address, protocols, options) {
   }
 
   const isSecure = parsedUrl.protocol === 'wss:';
-  const isUnixSocket = parsedUrl.protocol === 'ws+unix:';
+  const isIPCUrl = parsedUrl.protocol === 'ws+unix:';
   let invalidURLMessage;
 
-  if (parsedUrl.protocol !== 'ws:' && !isSecure && !isUnixSocket) {
+  if (parsedUrl.protocol !== 'ws:' && !isSecure && !isIPCUrl) {
     invalidURLMessage =
       'The URL\'s protocol must be one of "ws:", "wss:", or "ws+unix:"';
-  } else if (isUnixSocket && !parsedUrl.pathname) {
+  } else if (isIPCUrl && !parsedUrl.pathname) {
     invalidURLMessage = "The URL's pathname is empty";
   } else if (parsedUrl.hash) {
     invalidURLMessage = 'The URL contains a fragment identifier';
@@ -760,20 +760,27 @@ function initAsClient(websocket, address, protocols, options) {
     opts.auth = `${parsedUrl.username}:${parsedUrl.password}`;
   }
 
-  if (isUnixSocket) {
-    const parts = opts.path.split(':');
+  if (isIPCUrl) {
+    if (opts.path.startsWith('\\\\.\\pipe\\', 1)) {
+      const [socketPath, path] = opts.path.split(':/');
 
-    opts.socketPath = parts[0];
-    opts.path = parts[1];
+      opts.socketPath = socketPath.slice(1);
+      opts.path = path ? `/${path}` : '/';
+    } else {
+      const [socketPath, path] = opts.path.split(':');
+
+      opts.socketPath = socketPath;
+      opts.path = path;
+    }
   }
 
   let req;
 
   if (opts.followRedirects) {
     if (websocket._redirects === 0) {
-      websocket._originalUnixSocket = isUnixSocket;
+      websocket._originalUnixSocket = isIPCUrl;
       websocket._originalSecure = isSecure;
-      websocket._originalHostOrSocketPath = isUnixSocket
+      websocket._originalHostOrSocketPath = isIPCUrl
         ? opts.socketPath
         : parsedUrl.host;
 
@@ -791,7 +798,7 @@ function initAsClient(websocket, address, protocols, options) {
         }
       }
     } else if (websocket.listenerCount('redirect') === 0) {
-      const isSameHost = isUnixSocket
+      const isSameHost = isIPCUrl
         ? websocket._originalUnixSocket
           ? opts.socketPath === websocket._originalHostOrSocketPath
           : false

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -179,14 +179,6 @@ describe('WebSocketServer', () => {
     });
 
     it('uses a precreated http server listening on unix socket', function (done) {
-      //
-      // Skip this test on Windows. The URL parser:
-      //
-      // - Throws an error if the named pipe uses backward slashes.
-      // - Incorrectly parses the path if the named pipe uses forward slashes.
-      //
-      if (process.platform === 'win32') return this.skip();
-
       const server = http.createServer();
       const sockPath = path.join(
         os.tmpdir(),


### PR DESCRIPTION
This PR applies the suggestions from #1808 to add support to the client for named pipes on Windows.

### Cross Platform Example

This example works on both MacOS and Windows.

```javascript
// paths.js

import * as os from 'os'
import { join } from 'path'

let sockPath = join(os.tmpdir(), `ws.example.sock`)
if (os.platform() === 'win32') {
  sockPath = join('\\\\.\\pipe', sockPath)
  console.log('updated sockPath', sockPath)
}

export const sockUrl = `ws+unix:///${sockPath}`
export { sockPath }
```

```javascript
// server.js

import { existsSync, unlinkSync } from 'fs'
import { createServer } from 'http'
import * as os from 'os'
import { WebSocketServer } from 'ws'
import { sockPath } from './paths.js'

const server = createServer()
const wss = new WebSocketServer({ server })

wss.on('connection', function connection(ws) {
  console.log('server connected')

  ws.on('message', (data) => {
    console.log('data from client', data.toString())
  })

  ws.send('hello')
})

// server.listen() throws if unix domain socket exists
if (os.platform() !== 'win32' && existsSync(sockPath)) {
  unlinkSync(sockPath)
}

server.listen(sockPath)
```

```js
// client.js

import { WebSocket } from 'ws'
import { sockUrl } from './paths.js'

const ws = new WebSocket(sockUrl)
ws.on('open', () => {
  console.log('client socket open')
  ws.send('hello')
})
```