### PR TITLE
[WebSocketServer] Allow to use a custom `IncomingMessage` class

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -90,6 +90,9 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `verifyClient` {Function} A function which can be used to validate incoming
     connections. See description below. (Usage is discouraged: see
     [Issue #337](https://github.com/websockets/ws/issues/377#issuecomment-462152231))
+  - `IncomingMessage` {Function} Specifies the `IncomingMessage` class to be
+    used. Useful for extending the original `IncomingMessage`. _Defaults_ to
+    `http.IncomingMessage`
   - `WebSocket` {Function} Specifies the `WebSocket` class to be used. It must
     be extended from the original `WebSocket`. Defaults to `WebSocket`.
 - `callback` {Function}

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -49,6 +49,8 @@ class WebSocketServer extends EventEmitter {
    * @param {Boolean} [options.skipUTF8Validation=false] Specifies whether or
    *     not to skip UTF-8 validation for text and close messages
    * @param {Function} [options.verifyClient] A hook to reject connections
+   * @param {Function} [options.IncomingMessage=IncomingMessage] Specifies the `IncomingMessage`
+   *     class to be used. Useful for extending the original `IncomingMessage`.
    * @param {Function} [options.WebSocket=WebSocket] Specifies the `WebSocket`
    *     class to use. It must be the `WebSocket` class or class that extends it
    * @param {Function} [callback] A listener for the `listening` event
@@ -69,6 +71,7 @@ class WebSocketServer extends EventEmitter {
       host: null,
       path: null,
       port: null,
+      IncomingMessage: http.IncomingMessage,
       WebSocket,
       ...options
     };
@@ -85,15 +88,18 @@ class WebSocketServer extends EventEmitter {
     }
 
     if (options.port != null) {
-      this._server = http.createServer((req, res) => {
-        const body = http.STATUS_CODES[426];
+      this._server = http.createServer(
+        { IncomingMessage: options.IncomingMessage },
+        (req, res) => {
+          const body = http.STATUS_CODES[426];
 
-        res.writeHead(426, {
-          'Content-Length': body.length,
-          'Content-Type': 'text/plain'
-        });
-        res.end(body);
-      });
+          res.writeHead(426, {
+            'Content-Length': body.length,
+            'Content-Type': 'text/plain'
+          });
+          res.end(body);
+        }
+      );
       this._server.listen(
         options.port,
         options.host,

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -115,6 +115,28 @@ describe('WebSocketServer', () => {
           wss.close(done);
         });
       });
+
+      it('honors the `IncomingMessage` option', (done) => {
+        class CustomIncomingMessage extends http.IncomingMessage {
+          get bar() {
+            return 'bar';
+          }
+        }
+
+        const wss = new WebSocket.Server(
+          { port: 0, IncomingMessage: CustomIncomingMessage },
+          () => {
+            const ws = new WebSocket(`ws://localhost:${wss.address().port}`);
+            ws.on('open', ws.close);
+          }
+        );
+
+        wss.on('connection', (_ws, request) => {
+          assert.ok(request instanceof CustomIncomingMessage);
+          assert.strictEqual(request.bar, 'bar');
+          wss.close(done);
+        });
+      });
     });
 
     it('emits an error if http server bind fails', (done) => {


### PR DESCRIPTION
## Motivation

```javascript
import { IncomingMessage } from "node:http";
import { WebSocketServer } from "ws";
class MyIncomingMessage extends IncomingMessage {}
const wss = new WebSocketServer({ port: 8080, IncomingMessage: MyIncomingMessage }).on(
  "connection",
  (_ws, request) => {
    console.log(request instanceof MyIncomingMessage); // true
  }
);
```