### PR TITLE
Sec-WebSocket-Key is possible to override

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -715,9 +715,9 @@ function initAsClient(websocket, address, protocols, options) {
     ? parsedUrl.hostname.slice(1, -1)
     : parsedUrl.hostname;
   opts.headers = {
+    'Sec-WebSocket-Key': key,
     ...opts.headers,
     'Sec-WebSocket-Version': opts.protocolVersion,
-    'Sec-WebSocket-Key': key,
     Connection: 'Upgrade',
     Upgrade: 'websocket'
   };


### PR DESCRIPTION
I need to use `Sec-Websocket-Key` but can't override random value selected by this module. Thanks to this change I will be able to set my own `Sec-Websocket-Key`, save it and reuse without problems.