### PR TITLE
[fix] make test/create-websocket-stream.test.js compatible with domains

### DIFF
--- a/test/create-websocket-stream.test.js
+++ b/test/create-websocket-stream.test.js
@@ -295,11 +295,14 @@ describe('createWebSocketStream', () => {
         ws._socket.write(Buffer.from([0x85, 0x00]));
       });
 
-      assert.strictEqual(process.listenerCount('uncaughtException'), 1);
+      assert.strictEqual(
+        process.listenerCount('uncaughtException'),
+        EventEmitter.usingDomains ? 2 : 1
+      );
 
-      const [listener] = process.listeners('uncaughtException');
+      const listener = process.listeners('uncaughtException').pop();
 
-      process.removeAllListeners('uncaughtException');
+      process.removeListener('uncaughtException', listener);
       process.once('uncaughtException', (err) => {
         assert.ok(err instanceof Error);
         assert.strictEqual(


### PR DESCRIPTION
Fix a failure in test/create-websocket-stream.test.js if the node:domain module is loaded (e.g. due to NODE_OPTIONS in environment).

The cause of the failure was that installing an 'uncaughtException' event handler on process will cause node:domain to prepend its own handler for the same event, which confused the test.

Fixes: #2124