### PR TITLE
Adding a 'closing' event when the server starts the close handshake

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -365,6 +365,11 @@ ws+unix:/absolute/path/to/uds_socket
 
 it defaults to `/`.
 
+### Event: 'closing'
+
+Emitted when the remote server starts the close handshake and before the close
+frame is sent back.
+
 ### Event: 'close'
 
 - `code` {Number}

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1125,6 +1125,8 @@ function receiverOnConclude(code, reason) {
   websocket._socket.removeListener('data', socketOnData);
   process.nextTick(resume, websocket._socket);
 
+  this.emit('closing');
+  
   if (code === 1005) websocket.close();
   else websocket.close(code, reason);
 }


### PR DESCRIPTION
This event helps us control the flow of streaming data to the remote websocket server when a close handshake is initiated. The 'close' event is normally only triggered after the connection is already closed, but at this time it is possible that data has been written to the socket, which is no longer available. When the 'closing' event is now emitted, this means that it is time to stop sending any data upstream because a close event will follow soon.