### PR TITLE
feat(websocket.js): compatible with the case where the return value o…

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -921,7 +921,7 @@ function initAsClient(websocket, address, protocols, options) {
     const serverProt = res.headers['sec-websocket-protocol'];
     let protError;
 
-    if (serverProt !== undefined) {
+    if (serverProt !== undefined && serverProt !== '') {
       if (!protocolSet.size) {
         protError = 'Server sent a subprotocol but none was requested';
       } else if (!protocolSet.has(serverProt)) {


### PR DESCRIPTION
This change is compatible with the case where the return value of `sec-websocket-protocol` is an empty string. I think we can treat empty string as 'server send no subprotocol'.

There is a real case: the value of `sec-websocket-protocol` returned by k8s exec api endpoint is empty string , so `ws` can not be used to connect to the websocket server of k8s exec api endpoint.

The headers returned by k8s api endpoint is like this:
```
{
  upgrade: 'websocket',
  connection: 'Upgrade',
  'sec-websocket-accept': 'dTe3nco5ctKEtJDda/4Cgg/5IaA=',
  'sec-websocket-protocol': ''
}
```

The steps for reproduction using minikube are as follows:
## Install minkube and start a cluster
```bash
brew install minikube
```
```bash
minikube start
```
## Run a pod named nginx using nignx image
```bash
kubectl run nginx --image=nginx
```
## Find out the endpoint in the kubectl exec logs
```bash
kubectl exec --v=8 nginx echo foo
```
We can find out the endpoint in the output logs, my endpoint is `//127.0.0.1:53696/api/v1/namespaces/default/pods/nginx`
## Connect the websocket server using ws
```javascript
// client.js
import WebSocket from 'ws'
import fs from 'fs'

const url = 'wss://127.0.0.1:53696/api/v1/namespaces/default/pods/nginx/exec?command=/bin/bash&stdin=true&stderr=true&stdout=true&tty=true'

const ws = new WebSocket(url, {
  ca: fs.readFileSync(`${process.env.HOME}/.minikube/ca.crt`), // The ca file of minikube
})

ws.on('upgrade', x => console.log('upgrade', x.headers));
ws.on('open', () => console.log('open'));
ws.on('message', x => {
  console.log('message', x.toString())
});
ws.on('close', () => console.log('close'));
ws.on('error', (e) => console.log(e))
```
## Run client.js
```bash
node client.js
```
We will receive the error:
```
Error: Server sent a subprotocol but none was requested
```

