### PR TITLE
Concatenate small buffers

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -88,7 +88,8 @@ class Sender {
     if (typeof data === 'string') {
       if (
         (!options.mask || skipMasking) &&
-        options[kByteLength] !== undefined
+        options[kByteLength] !== undefined &&
+        options[kByteLength] > 125
       ) {
         dataLength = options[kByteLength];
       } else {
@@ -99,6 +100,8 @@ class Sender {
       dataLength = data.length;
       merge = options.mask && options.readOnly && !skipMasking;
     }
+
+    if (dataLength < 126) merge = true;
 
     let payloadLength = dataLength;
 
@@ -124,22 +127,30 @@ class Sender {
       target.writeUIntBE(dataLength, 4, 6);
     }
 
-    if (!options.mask) return [target, data];
-
-    target[1] |= 0x80;
-    target[offset - 4] = mask[0];
-    target[offset - 3] = mask[1];
-    target[offset - 2] = mask[2];
-    target[offset - 1] = mask[3];
-
-    if (skipMasking) return [target, data];
+    if (options.mask) {
+      target[1] |= 0x80;
+      target[offset - 4] = mask[0];
+      target[offset - 3] = mask[1];
+      target[offset - 2] = mask[2];
+      target[offset - 1] = mask[3];
+    }
 
     if (merge) {
-      applyMask(data, mask, target, offset, dataLength);
+      if (options.mask && !skipMasking) {
+        applyMask(data, mask, target, offset, dataLength);
+      } else {
+        for (let i = 0; i < dataLength; i++) {
+          target[i + offset] = data[i];
+        }
+      }
+
       return [target];
     }
 
-    applyMask(data, mask, data, 0, dataLength);
+    if (options.mask && !skipMasking) {
+      applyMask(data, mask, data, 0, dataLength);
+    }
+
     return [target, data];
   }
 

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -4035,7 +4035,7 @@ describe('WebSocket', () => {
             ];
 
             for (let i = 0; i < 399; i++) {
-              list.push(list[list.length - 2], list[list.length - 1]);
+              list.push(list[list.length - 1]);
             }
 
             // This hack is used because there is no guarantee that more than


### PR DESCRIPTION
Make `Sender.frame()` always return a single buffer if the payload length is less than 126 bytes. This is done by copying the data but for small buffers it is more efficient than using `socket._writev()`.