### PR TITLE
[fix] ensure handleUpgrade doesn't break if socket is just a stream

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -224,7 +224,10 @@ class WebSocket extends EventEmitter {
     receiver.on('pong', receiverOnPong);
 
     socket.setTimeout(0);
-    socket.setNoDelay();
+    if (socket.setNoDelay) {
+      // May not be available if 'socket' is actually a stream
+      socket.setNoDelay();
+    }
 
     if (head.length > 0) socket.unshift(head);
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -223,9 +223,11 @@ class WebSocket extends EventEmitter {
     receiver.on('ping', receiverOnPing);
     receiver.on('pong', receiverOnPong);
 
-    socket.setTimeout(0);
+    // These methods may not be available if `socket` is actually just a stream:
+    if (socket.setTimeout) {
+      socket.setTimeout(0);
+    }
     if (socket.setNoDelay) {
-      // May not be available if 'socket' is actually a stream
       socket.setNoDelay();
     }
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "mocha": "^8.4.0",
+    "native-duplexpair": "^1.0.0",
     "nyc": "^15.0.0",
     "prettier": "^3.0.0",
     "utf-8-validate": "^6.0.0"


### PR DESCRIPTION
If you attempt to handle a websocket over a connection that is a stream but not a `net.Socket`, right now WS fails to do so. With this very small change (very similar to the [equivalent handling](https://github.com/nodejs/node/blob/fcf5de008a59229fe65a7b8e4e45fb4cfef4de81/lib/net.js#L2144-L2147) in Node itself) it's possible to call `handleUpgrade` with a socket argument that's actually just a duplex stream, and then successfully handle websocket traffic that way.

This can be useful in some cases: in my specific case this is required to proxy WebSockets over non-sockets, such as HTTP/2 streams (note that this is not the same as real WS-over-HTTP/2 support - I receive a proxy CONNECT sent on an HTTP/2 stream, and then the client does an HTTP/1.1 upgrade on that proxied stream, resulting in running an HTTP/1.1 websocket over an HTTP/2 stream instead of a raw socket).

With this change, that works flawlessly for me, proxying real websocket traffic from Chrome in an HTTP/2 proxy.

This is also a small step towards https://github.com/websockets/ws/issues/1458, since the same change will also eventually be required to add full HTTP/2 support, where the entire underlying connection is HTTP/2 throughout, with no proxying involved.

(Arguably the same could be done for the `socket.setTimeout` above too, but in my case that doesn't seem to be required, and I wanted to avoid changing anything else unnecessarily).