### PR TITLE
Support for the oppurtunity to set frame headers before connection upgrade on the serverside

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,39 @@ server.on('upgrade', function upgrade(request, socket, head) {
 server.listen(8080);
 ```
 
+### Modifying upgrade headers if needed
+
+```js
+import { WebSocketServer } from 'ws';
+import { createServer } from 'http';
+import crypto from 'crypto';
+
+const server = createServer((req, res) => {
+  //Checks if there is already a cookie called 'myCookie' in the clients browser. If there's not, sets the 'Set-Cookie' header with a new randomly generated one.
+  const customHeaders = !(
+    req.headers.cookie && req.headers.cookie.includes('myCookie')
+  )
+    ? {
+        'Set-Cookie': `myCookie=${crypto.randomUUID()};expires=${new Date(
+          Date.now() + 1000 * 60 * 60 * 24 * 60
+        ).toUTCString()};SameSite=None;`
+      }
+    : {};
+
+  wss.handleUpgrade(
+    req,
+    req.socket,
+    '',
+    (client, req) => {
+      wss.emit('connection', client, req);
+    },
+    customHeaders
+  );
+}).listen(6678);
+
+const wss = new WebSocketServer({ noServer: true });
+```
+
 ### Client authentication
 
 ```js

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ can use one of the many wrappers available on npm, like
   - [Simple server](#simple-server)
   - [External HTTP/S server](#external-https-server)
   - [Multiple servers sharing a single HTTP/S server](#multiple-servers-sharing-a-single-https-server)
+  - [Modifying upgrade headers if needed](#modifying-upgrade-headers-if-needed)
   - [Client authentication](#client-authentication)
   - [Server broadcast](#server-broadcast)
   - [Round-trip time](#round-trip-time)

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -13,7 +13,7 @@
   - [server.address()](#serveraddress)
   - [server.clients](#serverclients)
   - [server.close([callback])](#serverclosecallback)
-  - [server.handleUpgrade(request, socket, head, callback)](#serverhandleupgraderequest-socket-head-callback)
+  - [server.handleUpgrade(request, socket, head, callback[, customHeaders])](#serverhandleupgraderequest-socket-head-callback)
   - [server.shouldHandle(request)](#servershouldhandlerequest)
 - [Class: WebSocket](#class-websocket)
   - [Ready state constants](#ready-state-constants)
@@ -252,6 +252,7 @@ receives an `Error` if the server is already closed.
 - `socket` {stream.Duplex} The network socket between the server and client.
 - `head` {Buffer} The first packet of the upgraded stream.
 - `callback` {Function}.
+- `customHeaders` {http.OutgoingHttpHeaders} Custom headers to append to the upgrade frame response. Optional.
 
 Handle a HTTP upgrade request. When the HTTP server is created internally or
 when the HTTP server is passed via the `server` option, this method is called

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -222,9 +222,10 @@ class WebSocketServer extends EventEmitter {
    * @param {Duplex} socket The network socket between the server and client
    * @param {Buffer} head The first packet of the upgraded stream
    * @param {Function} cb Callback
+   * @param {http.OutgoingHttpHeaders} [customHeaders] Custom headers to append to the upgrade frame response.
    * @public
    */
-  handleUpgrade(req, socket, head, cb) {
+  handleUpgrade(req, socket, head, cb, customHeaders) {
     socket.on('error', socketOnError);
 
     const key = req.headers['sec-websocket-key'];
@@ -324,7 +325,8 @@ class WebSocketServer extends EventEmitter {
             req,
             socket,
             head,
-            cb
+            cb,
+            customHeaders
           );
         });
         return;
@@ -333,7 +335,16 @@ class WebSocketServer extends EventEmitter {
       if (!this.options.verifyClient(info)) return abortHandshake(socket, 401);
     }
 
-    this.completeUpgrade(extensions, key, protocols, req, socket, head, cb);
+    this.completeUpgrade(
+      extensions,
+      key,
+      protocols,
+      req,
+      socket,
+      head,
+      cb,
+      customHeaders
+    );
   }
 
   /**
@@ -346,10 +357,20 @@ class WebSocketServer extends EventEmitter {
    * @param {Duplex} socket The network socket between the server and client
    * @param {Buffer} head The first packet of the upgraded stream
    * @param {Function} cb Callback
+   * @param {http.OutgoingHttpHeaders} [customHeaders] Custom headers to append to the upgrade frame response.
    * @throws {Error} If called more than once with the same socket
    * @private
    */
-  completeUpgrade(extensions, key, protocols, req, socket, head, cb) {
+  completeUpgrade(
+    extensions,
+    key,
+    protocols,
+    req,
+    socket,
+    head,
+    cb,
+    customHeaders
+  ) {
     //
     // Destroy the socket if the client has already sent a FIN packet.
     //
@@ -374,6 +395,19 @@ class WebSocketServer extends EventEmitter {
       'Connection: Upgrade',
       `Sec-WebSocket-Accept: ${digest}`
     ];
+
+    if (customHeaders && customHeaders !== null) {
+      for (const header in customHeaders) {
+        const has =
+          headers.findIndex((el) => {
+            if (!el.includes(':')) return false;
+            return el.split(':')[0].toLowerCase() == el.toLowerCase();
+          }) != -1;
+        if (!has) {
+          headers.push(`${header}: ${customHeaders[header]}`);
+        }
+      }
+    }
 
     const ws = new this.options.WebSocket(null);
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -806,8 +806,8 @@ function initAsClient(websocket, address, protocols, options) {
           ? opts.socketPath === websocket._originalHostOrSocketPath
           : false
         : websocket._originalIpc
-        ? false
-        : parsedUrl.host === websocket._originalHostOrSocketPath;
+          ? false
+          : parsedUrl.host === websocket._originalHostOrSocketPath;
 
       if (!isSameHost || (websocket._originalSecure && !isSecure)) {
         //


### PR DESCRIPTION
# The idea
I wanted to implement a cookie based authentication system to [my WS library](https://zilaws.com/), however I could not find a solution to do so via the `Set-Cookie` header.

# Usage

My implementation requires some extra work to do when upgrading a connection, but lets you set any headers you want.

If I can already do that with the `handleUpgrade`'s header param, then I'm sorry, but I couldn't find out how It would affect frame or what value I should give it to.

```js
import { WebSocketServer } from 'ws';
import { createServer } from 'http';
import crypto from 'crypto';

const server = createServer((req, res) => {
    const customHeaders = !(req.headers.cookie && req.headers.cookie.includes('myCookie')) ? {
        'Set-Cookie': `myCookie=${crypto.randomUUID()};expires=${new Date(Date.now() + 1000 * 60 * 60 * 24 * 60).toUTCString()};SameSite=None;`
    } : {};
    
    wss.handleUpgrade(req, req.socket, '', (client, req) => {
        wss.emit("connection", client, req);
    }, customHeaders);

}).listen(6678, () => {
    console.log("Listening...");
});

const wss = new WebSocketServer({ noServer: true });

wss.on("connection", (socket, req) => {
    //Logs out the cookies the client already has in their browser
    console.log(cookie.parse(req.headers.cookie ?? ""));
});
```