### PR TITLE
docs: clarify legacy deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm install --save-optional utf-8-validate
 This contains a binary polyfill for [`buffer.isUtf8()`][].
 
 To force `ws` to not use `utf-8-validate`, use the
-[`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable.
+[`WS_NO_UTF_8_VALIDATE`](./doc/ws.md#ws_no_utf_8_validate) environment variable.
 
 ## API docs
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ npm install ws
 
 ### Opt-in for performance
 
-`bufferutil` is an optional module that can be installed alongside the `ws` module:
+`bufferutil` is an optional module that can be installed alongside the `ws`
+module:
 
 ```
 npm install --save-optional bufferutil

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm install --save-optional utf-8-validate
 
 This contains a binary polyfill for [`buffer.isUtf8()`][].
 
-To force `ws` to not use `bufferutil`, use the
+To force `ws` to not use `utf-8-validate`, use the
 [`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable. If
 this is set, `require()` will not be called.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ can be useful to enhance security in systems where a user can put a package in
 the package search path of an application of another user, due to how the Node.js
 resolver algorithm works.
 
+#### Legacy Opt-in for performance
+
+If you are running on am old version of Node.js (prior to v18.14.0), `ws` also
+supports the `utf-8-validate` module:
+
+```
+npm install --save-optional utf-8-validate
+```
+
+This contains a binary polyfill for [`buffer.isUtf8()`](https://nodejs.org/api/buffer.html#bufferisutf8input).
+
+To force `ws` to not use `bufferutil`, use the
+[`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable.
+
 ## API docs
 
 See [`/doc/ws.md`](./doc/ws.md) for Node.js-like documentation of ws classes and

--- a/README.md
+++ b/README.md
@@ -57,27 +57,22 @@ npm install ws
 
 ### Opt-in for performance
 
-There are 2 optional modules that can be installed along side with the ws
-module. These modules are binary addons that improve the performance of certain
-operations. Prebuilt binaries are available for the most popular platforms so
-you don't necessarily need to have a C++ compiler installed on your machine.
+`bufferutil` is an optional module that can be installed alongside the `ws` module:
 
-- `npm install --save-optional bufferutil`: Allows to efficiently perform
-  operations such as masking and unmasking the data payload of the WebSocket
-  frames.
-- `npm install --save-optional utf-8-validate`: Allows to efficiently check if a
-  message contains valid UTF-8.
+```
+npm install --save-optional bufferutil
+```
 
-To not even try to require and use these modules, use the
-[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) and
-[`WS_NO_UTF_8_VALIDATE`](./doc/ws.md#ws_no_utf_8_validate) environment
-variables. These might be useful to enhance security in systems where a user can
-put a package in the package search path of an application of another user, due
-to how the Node.js resolver algorithm works.
+This is a binary addon that improves the performance of certain operations such
+as masking and unmasking the data payload of the WebSocket frames. Prebuilt
+binaries are available for the most popular platforms, so you don't necessarily
+need to have a C++ compiler installed on your machine.
 
-The `utf-8-validate` module is not needed and is not required, even if it is
-already installed, regardless of the value of the `WS_NO_UTF_8_VALIDATE`
-environment variable, if [`buffer.isUtf8()`][] is available.
+To force `ws` to not use `bufferutil`, use the
+[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) environment variable. This
+can be useful to enhance security in systems where a user can put a package in
+the package search path of an application of another user, due to how the Node.js
+resolver algorithm works.
 
 ## API docs
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ binaries are available for the most popular platforms, so you don't necessarily
 need to have a C++ compiler installed on your machine.
 
 To force `ws` to not use `bufferutil`, use the
-[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) environment variable. This
-can be useful to enhance security in systems where a user can put a package in
-the package search path of an application of another user, due to how the Node.js
-resolver algorithm works.
+[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) environment variable. If
+this is set, `require()` will not be called. This can be useful to enhance
+security in systems where a user can put a package in the package search path
+of an application of another user, due to how the Node.js resolver algorithm
+works.
 
 #### Legacy opt-in for performance
 
@@ -86,7 +87,8 @@ npm install --save-optional utf-8-validate
 This contains a binary polyfill for [`buffer.isUtf8()`][].
 
 To force `ws` to not use `bufferutil`, use the
-[`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable.
+[`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable. If
+this is set, `require()` will not be called.
 
 ## API docs
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ works.
 
 #### Legacy opt-in for performance
 
-If you are running on am old version of Node.js (prior to v18.14.0), `ws` also
+If you are running on an old version of Node.js (prior to v18.14.0), `ws` also
 supports the `utf-8-validate` module:
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ can be useful to enhance security in systems where a user can put a package in
 the package search path of an application of another user, due to how the Node.js
 resolver algorithm works.
 
-#### Legacy Opt-in for performance
+#### Legacy opt-in for performance
 
 If you are running on am old version of Node.js (prior to v18.14.0), `ws` also
 supports the `utf-8-validate` module:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ supports the `utf-8-validate` module:
 npm install --save-optional utf-8-validate
 ```
 
-This contains a binary polyfill for [`buffer.isUtf8()`](https://nodejs.org/api/buffer.html#bufferisutf8input).
+This contains a binary polyfill for [`buffer.isUtf8()`][].
 
 To force `ws` to not use `bufferutil`, use the
 [`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,10 @@ binaries are available for the most popular platforms, so you don't necessarily
 need to have a C++ compiler installed on your machine.
 
 To force `ws` to not use `bufferutil`, use the
-[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) environment variable. If
-this is set, `require()` will not be called. This can be useful to enhance
-security in systems where a user can put a package in the package search path
-of an application of another user, due to how the Node.js resolver algorithm
-works.
+[`WS_NO_BUFFER_UTIL`](./doc/ws.md#ws_no_buffer_util) environment variable. This
+can be useful to enhance security in systems where a user can put a package in
+the package search path of an application of another user, due to how the
+Node.js resolver algorithm works.
 
 #### Legacy opt-in for performance
 
@@ -87,8 +86,7 @@ npm install --save-optional utf-8-validate
 This contains a binary polyfill for [`buffer.isUtf8()`][].
 
 To force `ws` to not use `utf-8-validate`, use the
-[`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable. If
-this is set, `require()` will not be called.
+[`WS_NO_UTF_8_VALIDATE`]((./doc/ws.md#ws_no_utf_8_validate) environment variable.
 
 ## API docs
 


### PR DESCRIPTION
Since `isUtf8` is automatically present in modern versions of Node.js, we can cleanup this old info that doesn't apply anymore in order to simplify things and make the docs easier to read.

(It's also a footgun for people reading this passage and then installing both `bufferutil` and `utf-8-validate`.)