### PR TITLE
emit raw tcp socket error to ws client

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1317,7 +1317,7 @@ function socketOnEnd() {
  *
  * @private
  */
-function socketOnError() {
+function socketOnError(err) {
   const websocket = this[kWebSocket];
 
   this.removeListener('error', socketOnError);
@@ -1325,6 +1325,7 @@ function socketOnError() {
 
   if (websocket) {
     websocket._readyState = WebSocket.CLOSING;
+    websocket.emit('error', err);
     this.destroy();
   }
 }


### PR DESCRIPTION
currently, error event for ws client is triggered from pre-upgrade connection (econnrefused, enotfound, etc)

any tcp errors during active ws connection are not forwarded. only 1006 ws close is sent to client.

this PR will emit error event when active tcp socket throws an error.

merry christmas!