### PR TITLE
options Undefined error fixed

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -84,7 +84,7 @@ class WebSocket extends EventEmitter {
 
       initAsClient(this, address, protocols, options);
     } else {
-      this._autoPong = options.autoPong;
+      this._autoPong = options ? options.autoPong : false;
       this._isServer = true;
     }
   }


### PR DESCRIPTION
The new version broke http2 proxy example, as `new WebSocket(null)` fails with error `unable to read autoPong from undefined`. This simple check will prevent this error.