### PR TITLE
Update websocket.js

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -84,7 +84,7 @@ class WebSocket extends EventEmitter {
 
       initAsClient(this, address, protocols, options);
     } else {
-      this._autoPong = options.autoPong;
+      this._autoPong = options?.autoPong ?? true;
       this._isServer = true;
     }
   }


### PR DESCRIPTION
Fix TypeError: Cannot read properties of undefined (reading 'autoPong') error

if i make an inheriting class like
```
class AntaresWebsocket extends WebSocket {
  constructor() {
    super(null);
  }
```

and then 

```
    this.wss = new WebSocketServer({
      WebSocket: AntaresWebsocket,
    });
```

take TypeError after client connection