### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,7 @@ wss2.on('connection', function connection(ws) {
 });
 
 server.on('upgrade', function upgrade(request, socket, head) {
-  const baseURL = request.protocol + '://' + request.headers.host + '/';
-  const { pathname } = new URL(request.url, baseURL);
+  const { pathname } = new URL(request.url, 'wss://base.url');
 
   if (pathname === '/foo') {
     wss1.handleUpgrade(request, socket, head, function done(ws) {

--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ server.listen(8080);
 
 ```js
 import { createServer } from 'http';
-import { parse } from 'url';
 import { WebSocketServer } from 'ws';
 
 const server = createServer();
@@ -265,7 +264,8 @@ wss2.on('connection', function connection(ws) {
 });
 
 server.on('upgrade', function upgrade(request, socket, head) {
-  const { pathname } = parse(request.url);
+  const baseURL = request.protocol + '://' + request.headers.host + '/';
+  const { pathname } = new URL(request.url, baseURL);
 
   if (pathname === '/foo') {
     wss1.handleUpgrade(request, socket, head, function done(ws) {


### PR DESCRIPTION
url.parse() is deprecated 

https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost

Use new URL() instead