### PR TITLE
Flip the default value of `allowSynchronousEvents`

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -76,8 +76,8 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
     in response to a ping. Defaults to `true`.
   - `allowSynchronousEvents` {Boolean} Specifies whether any of the `'message'`,
     `'ping'`, and `'pong'` events can be emitted multiple times in the same
-    tick. To improve compatibility with the WHATWG standard, the default value
-    is `false`. Setting it to `true` improves performance slightly.
+    tick. Defaults to `true`. Setting it to `false` improves compatibility with
+    the WHATWG standardbut may negatively impact performance.
   - `backlog` {Number} The maximum length of the queue of pending connections.
   - `clientTracking` {Boolean} Specifies whether or not to track clients.
   - `handleProtocols` {Function} A function which can be used to handle the
@@ -302,8 +302,8 @@ This class represents a WebSocket. It extends the `EventEmitter`.
     in response to a ping. Defaults to `true`.
   - `allowSynchronousEvents` {Boolean} Specifies whether any of the `'message'`,
     `'ping'`, and `'pong'` events can be emitted multiple times in the same
-    tick. To improve compatibility with the WHATWG standard, the default value
-    is `false`. Setting it to `true` improves performance slightly.
+    tick. Defaults to `true`. Setting it to `false` improves compatibility with
+    the WHATWG standardbut may negatively impact performance.
   - `finishRequest` {Function} A function which can be used to customize the
     headers of each HTTP request before it is sent. See description below.
   - `followRedirects` {Boolean} Whether or not to follow redirects. Defaults to

--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -32,7 +32,7 @@ class Receiver extends Writable {
    * Creates a Receiver instance.
    *
    * @param {Object} [options] Options object
-   * @param {Boolean} [options.allowSynchronousEvents=false] Specifies whether
+   * @param {Boolean} [options.allowSynchronousEvents=true] Specifies whether
    *     any of the `'message'`, `'ping'`, and `'pong'` events can be emitted
    *     multiple times in the same tick
    * @param {String} [options.binaryType=nodebuffer] The type for binary data
@@ -47,7 +47,10 @@ class Receiver extends Writable {
   constructor(options = {}) {
     super();
 
-    this._allowSynchronousEvents = !!options.allowSynchronousEvents;
+    this._allowSynchronousEvents =
+      options.allowSynchronousEvents !== undefined
+        ? options.allowSynchronousEvents
+        : true;
     this._binaryType = options.binaryType || BINARY_TYPES[0];
     this._extensions = options.extensions || {};
     this._isServer = !!options.isServer;

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -29,7 +29,7 @@ class WebSocketServer extends EventEmitter {
    * Create a `WebSocketServer` instance.
    *
    * @param {Object} options Configuration options
-   * @param {Boolean} [options.allowSynchronousEvents=false] Specifies whether
+   * @param {Boolean} [options.allowSynchronousEvents=true] Specifies whether
    *     any of the `'message'`, `'ping'`, and `'pong'` events can be emitted
    *     multiple times in the same tick
    * @param {Boolean} [options.autoPong=true] Specifies whether or not to
@@ -60,7 +60,7 @@ class WebSocketServer extends EventEmitter {
     super();
 
     options = {
-      allowSynchronousEvents: false,
+      allowSynchronousEvents: true,
       autoPong: true,
       maxPayload: 100 * 1024 * 1024,
       skipUTF8Validation: false,

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -623,7 +623,7 @@ module.exports = WebSocket;
  * @param {(String|URL)} address The URL to which to connect
  * @param {Array} protocols The subprotocols
  * @param {Object} [options] Connection options
- * @param {Boolean} [options.allowSynchronousEvents=false] Specifies whether any
+ * @param {Boolean} [options.allowSynchronousEvents=true] Specifies whether any
  *     of the `'message'`, `'ping'`, and `'pong'` events can be emitted multiple
  *     times in the same tick
  * @param {Boolean} [options.autoPong=true] Specifies whether or not to
@@ -652,7 +652,7 @@ module.exports = WebSocket;
  */
 function initAsClient(websocket, address, protocols, options) {
   const opts = {
-    allowSynchronousEvents: false,
+    allowSynchronousEvents: true,
     autoPong: true,
     protocolVersion: protocolVersions[1],
     maxPayload: 100 * 1024 * 1024,


### PR DESCRIPTION
Flip the default value of the `allowSynchronousEvents` option to `true`.

Refs: https://github.com/websockets/ws/pull/2218