### PR TITLE
doc: which events are proxied through `createWebSocketStream`

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -625,7 +625,14 @@ The URL of the WebSocket server. Server clients don't have this attribute.
   constructor.
 
 Returns a `Duplex` stream that allows to use the Node.js streams API on top of a
-given `WebSocket`.
+given `WebSocket` which emits the following events:
+
+- `end`
+- `close`
+- `error`
+- `data`
+- `drain`
+- `timeout`
 
 ## Environment variables
 

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -630,6 +630,7 @@ given `WebSocket` which emits the following events:
 - `end`
 - `close`
 - `error`
+- `readable`
 - `data`
 - `drain`
 - `timeout`


### PR DESCRIPTION
The documentation doesn't specify how the `ws` module stream maps to which type of Node Duplex Stream.

I assume that it behaves like a TCP Duplex Stream: <https://nodejs.org/api/net.html#class-netsocket>.

I also assume that the ping and pong and keepalive timeouts are proxied in a meaningful way.