### PR TITLE
Improve JSDoc Types (Part 1)

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -551,7 +551,7 @@ class Sender {
   /**
    * Sends a frame.
    *
-   * @param {Buffer[]} list The frame to send
+   * @param {(Buffer | String)[]} list The frame to send
    * @param {Function} [cb] Callback
    * @private
    */

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,5 +1,7 @@
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "^WebSocket$" }] */
 'use strict';
 
+const WebSocket = require('./websocket');
 const { Duplex } = require('stream');
 
 /**


### PR DESCRIPTION
## Description

This is an initial amount of work for improving the JSDocs in the codebase (as mentioned in #2241).

---

I figured it would make more sense to apply the JSDoc improvements incrementally. This has a few benefits:
- PRs end up being smaller to review (compared to if everything was done at once)
- Maintainers can more easily determine if #2241 is worth pursuing (in case they want to cancel everything or only accept fragments of the work)
- Contributors can make progress more asynchronously (in case there are gaps in free time)

Note: If the preference is only to merge everything at once, then this PR can be kept in a Draft State until it is "sufficiently complete".

## Additional Notes

When using JSDocs, TypeScript is fine with using `String` or `string`, `*` or `any`, and the like interchangeably. Not as idiomatic, but I'm not focused on that at the moment.