### PR TITLE
Add a space between subprotocols in Sec-WebSocket-Protocol header

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -774,7 +774,7 @@ function initAsClient(websocket, address, protocols, options) {
       protocolSet.add(protocol);
     }
 
-    opts.headers['Sec-WebSocket-Protocol'] = protocols.join(',');
+    opts.headers['Sec-WebSocket-Protocol'] = protocols.join(', ');
   }
   if (opts.origin) {
     if (opts.protocolVersion < 13) {


### PR DESCRIPTION
Some servers fail to parse this value when passed without a space[1].

Both websocket package[2] and Node undici[3] have a space.

[1] https://github.com/deepgram/deepgram-js-sdk/issues/321
[2] https://github.com/theturtle32/WebSocket-Node/blob/d87afb7ef2/lib/WebSocketClient.js#L200
[3] https://github.com/nodejs/undici/blob/53350135c8/lib/web/fetch/headers.js#L176