### PR TITLE
First message lost after connectiong to the server, race condition.

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -325,6 +325,9 @@ This class represents a WebSocket. It extends the `EventEmitter`.
   - `skipUTF8Validation` {Boolean} Specifies whether or not to skip UTF-8
     validation for text and close messages. Defaults to `false`. Set to `true`
     only if the server is trusted.
+  - `connectImmediately` {Boolean} If set to `false` prevent connecting to the
+    server in constructor. Later you should use `connect` method to establish
+    the connection. Defaults set to `true`.
   - Any other option allowed in [`http.request()`][] or [`https.request()`][].
     Options given do not have any effect if parsed from the URL given with the
     `address` parameter.
@@ -447,6 +450,12 @@ listener for this event, an error is emitted.
 Emitted when response headers are received from the server as part of the
 handshake. This allows you to read headers from the server, for example
 'set-cookie' headers.
+
+### websocket.connect()
+
+This method used with option `connectImmediately` set to `false`. It is allow
+delay establishing connection after all user's init operation, like subscribe to
+events etc.
 
 ### websocket.addEventListener(type, listener[, options])
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -69,6 +69,13 @@ class WebSocket extends EventEmitter {
     this._sender = null;
     this._socket = null;
 
+    this._connectImmediately =
+      options !== undefined ? options.connectImmediately ?? true : true;
+    this._connectParameters = {
+      address,
+      protocols,
+      options
+    };
     if (address !== null) {
       this._bufferedAmount = 0;
       this._isServer = false;
@@ -85,11 +92,28 @@ class WebSocket extends EventEmitter {
         }
       }
 
-      initAsClient(this, address, protocols, options);
+      if (this._connectImmediately)
+        initAsClient(this, address, protocols, options);
     } else {
       this._autoPong = options.autoPong;
       this._isServer = true;
     }
+  }
+
+  /**
+   * This method used with option "connectImmediately" set to false.
+   * It is allow delay establishing connection after all user's init operation, like
+   * subscribe to events etc., has been finished.
+   */
+  connect() {
+    if (this._connectImmediately)
+      throw new Error(
+        'You should use method connect with option "connectImmediately" set to false.'
+      );
+    const address = this._connectParameters.address;
+    const protocols = this._connectParameters.protocols;
+    const options = this._connectParameters.options;
+    initAsClient(this, address, protocols, options);
   }
 
   /**

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -2836,6 +2836,31 @@ describe('WebSocket', () => {
       });
     });
 
+    it('delaying establishing connection', (done) => {
+      let isOnMessageCalled = false;
+
+      const wss = new WebSocket.Server({ port: 0 }, () => {
+        const ws = new WebSocket(`ws://localhost:${wss.address().port}`, [], {
+          connectImmediately: false
+        });
+        ws.on('message', () => {
+          isOnMessageCalled = true;
+        });
+        ws.on('error', () => {});
+        ws.on('close', () => {
+          assert.ok(isOnMessageCalled);
+        });
+        ws.connect();
+      });
+
+      wss.on('connection', (ws) => {
+        ws.send('hi', {}, () => {
+          ws.close(1000);
+          wss.close(done);
+        });
+      });
+    });
+
     it('does not override the `fin` option', (done) => {
       const wss = new WebSocket.Server({ port: 0 }, () => {
         const ws = new WebSocket(`ws://localhost:${wss.address().port}`);


### PR DESCRIPTION
Hi. I encountered a problem. When the server sends the first message after establishing a connection, the client does not always receive it. As far as I understand, this happens because after creating an instance of the WebSocket object, the process of connecting to the server immediately begins and does not always have time to subscribe to the message event. I created a small fix for this situation while maintaining backward compatibility. I would like you to look at it and comment and if everything is okay, accept it.
P.S.
I haven't figured out yet how to create a race condition in the test.