### PR TITLE
fix(Sender): Clear RSV2/RSV3 bits on outgoing WebSocket frames

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -140,7 +140,7 @@ class Sender {
 
     target[0] = options.fin ? options.opcode | 0x80 : options.opcode;
     if (options.rsv1) target[0] |= 0x40;
-
+    target[0] &= ~0x30;
     target[1] = payloadLength;
 
     if (payloadLength === 126) {


### PR DESCRIPTION
This PR fixes a protocol violation where outgoing frames could include RSV2 or RSV3 bits set, even though no extension negotiates them.

According to RFC 6455 §5.2, RSV2 and RSV3 must be 0 unless an extension specifically uses them.

This change ensures the bits are cleared before frames are sent, restoring compatibility with strict WebSocket clients.

Also includes a warning if such bits are requested by mistake.