### PR TITLE
[feature] Introduce the `httpHandler`, `ssl`, `key`, and `cert` options and `WebSocketServer#listen()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,32 @@ wss.on('connection', function connection(ws) {
 server.listen(8080);
 ```
 
+### Internal HTTP/S Server
+
+```js
+import { readFileSync } from 'fs';
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({
+  ssl: true,
+  cert: readFileSync('/path/to/cert.pem'),
+  key: readFileSync('/path/to/key.pem')
+});
+
+wss.on('connection', function connection(ws) {
+  ws.on('error', console.error);
+
+  ws.on('message', function message(data) {
+    console.log('received: %s', data);
+  });
+
+  ws.send('something');
+});
+
+wss.listen(8080);
+```
+
+
 ### Multiple servers sharing a single HTTP/S server
 
 ```js

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -11,6 +11,7 @@
   - [Event: 'listening'](#event-listening)
   - [Event: 'wsClientError'](#event-wsclienterror)
   - [server.address()](#serveraddress)
+  - [server.listen()](#serverlisten)
   - [server.clients](#serverclients)
   - [server.close([callback])](#serverclosecallback)
   - [server.handleUpgrade(request, socket, head, callback)](#serverhandleupgraderequest-socket-head-callback)
@@ -237,6 +238,10 @@ Returns an object with `port`, `family`, and `address` properties specifying the
 bound address, the address family name, and port of the server as reported by
 the operating system if listening on an IP socket. If the server is listening on
 a pipe or UNIX domain socket, the name is returned as a string.
+
+### server.listen(port, [host], [backlog], [callback])
+
+Starts the bound HTTP server listening for connections.
 
 ### server.clients
 

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -98,7 +98,11 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
     [Issue #337](https://github.com/websockets/ws/issues/377#issuecomment-462152231))
   - `WebSocket` {Function} Specifies the `WebSocket` class to be used. It must
     be extended from the original `WebSocket`. Defaults to `WebSocket`.
-- `callback` {Function}
+  - `httpHandler` {Function} The HTTP handler that will handle each request. Overrides the default "426 Upgrade Required" HTTP handler.
+  - `ssl` {Boolean} Create an HTTPS server with SSL
+  - `key` {String} The SSL private key
+  - `cert` {String} The SSL certificate
+  - `callback` {Function}
 
 Create a new server instance. One and only one of `port`, `server` or `noServer`
 must be provided or an error is thrown. An HTTP server is automatically created,

--- a/doc/ws.md
+++ b/doc/ws.md
@@ -100,9 +100,9 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `WebSocket` {Function} Specifies the `WebSocket` class to be used. It must
     be extended from the original `WebSocket`. Defaults to `WebSocket`.
   - `httpHandler` {Function} The HTTP handler that will handle each request. Overrides the default "426 Upgrade Required" HTTP handler.
-  - `ssl` {Boolean} Create an HTTPS server with SSL
-  - `key` {String} The SSL private key
-  - `cert` {String} The SSL certificate
+  - `ssl` {Boolean} Create an HTTPS server with SSL.
+  - `key` {String} The SSL private key.
+  - `cert` {String} The SSL certificate.
   - `callback` {Function}
 
 Create a new server instance. One and only one of `port`, `server` or `noServer`

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -55,6 +55,11 @@ class WebSocketServer extends EventEmitter {
    * @param {Function} [options.verifyClient] A hook to reject connections
    * @param {Function} [options.WebSocket=WebSocket] Specifies the `WebSocket`
    *     class to use. It must be the `WebSocket` class or class that extends it
+   * @param {Function} [options.httpHandler] The HTTP handler that will handle
+   *     each request. Overrides the default "426 Upgrade Required" HTTP handler.
+   * @param {Boolean} [options.ssl] Create an HTTPS server with SSL
+   * @param {String} [options.key] The SSL private key
+   * @param {String} [options.cert] The SSL certificate
    * @param {Function} [callback] A listener for the `listening` event
    */
   constructor(options, callback) {

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -4,6 +4,7 @@
 
 const EventEmitter = require('events');
 const http = require('http');
+const https = require('https');
 const { Duplex } = require('stream');
 const { createHash } = require('crypto');
 
@@ -75,11 +76,19 @@ class WebSocketServer extends EventEmitter {
       path: null,
       port: null,
       WebSocket,
+      httpHandler: null,
+      ssl: false,
+      key: null,
+      cert: null,
       ...options
     };
 
     if (
-      (options.port == null && !options.server && !options.noServer) ||
+      (options.port == null &&
+        !options.server &&
+        !options.noServer &&
+        !options.httpHandler &&
+        !options.ssl) ||
       (options.port != null && (options.server || options.noServer)) ||
       (options.server && options.noServer)
     ) {
@@ -89,16 +98,39 @@ class WebSocketServer extends EventEmitter {
       );
     }
 
-    if (options.port != null) {
-      this._server = http.createServer((req, res) => {
-        const body = http.STATUS_CODES[426];
+    if (options.ssl && (options.key == null || options.cert == null)) {
+      throw new TypeError(
+        '"key" and "cert" options must be specified for the "ssl" option'
+      );
+    }
 
-        res.writeHead(426, {
-          'Content-Length': body.length,
-          'Content-Type': 'text/plain'
-        });
-        res.end(body);
-      });
+    if (options.ssl) {
+      this._server = https.createServer(
+        { key: options.key, cert: options.cert },
+        options.httpHandler || upgradeRequiredHttpHandler
+      );
+      if (options.port != null) {
+        this._server.listen(
+          options.port,
+          options.host,
+          options.backlog,
+          callback
+        );
+      }
+    } else if (options.httpHandler) {
+      this._server = http.createServer(options.httpHandler);
+      if (options.port != null) {
+        this._server.listen(
+          options.port,
+          options.host,
+          options.backlog,
+          callback
+        );
+      }
+    } else if (options.port != null) {
+      this._server = http.createServer(
+        options.httpHandler || upgradeRequiredHttpHandler
+      );
       this._server.listen(
         options.port,
         options.host,
@@ -147,6 +179,24 @@ class WebSocketServer extends EventEmitter {
 
     if (!this._server) return null;
     return this._server.address();
+  }
+
+  /**
+   * Listens on specified port
+   *
+   * @param {Number} [port] Server port
+   * @param {String} [host] The hostname where to bind the server
+   * @param {Number} [backlog=511] The maximum length of the queue of
+   *     pending connections
+   * @param {Function} [callback] A listener for the `listening` event
+   */
+  listen(...args) {
+    if (this.options.noServer) {
+      throw new Error('The server is operating in "noServer" mode');
+    }
+
+    if (!this._server) return null;
+    return this._server.listen(...args);
   }
 
   /**
@@ -515,6 +565,23 @@ function abortHandshake(socket, code, message, headers) {
       '\r\n\r\n' +
       message
   );
+}
+
+/**
+ * HTTP handler that only responds with 426 Upgrade Required
+ *
+ * @param {http.IncomingMessage} [req] The request object
+ * @param {http.ServerResponse} [res] The response object
+ * @private
+ */
+function upgradeRequiredHttpHandler(req, res) {
+  const body = http.STATUS_CODES[426];
+
+  res.writeHead(426, {
+    'Content-Length': body.length,
+    'Content-Type': 'text/plain'
+  });
+  res.end(body);
 }
 
 /**

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -187,7 +187,7 @@ class WebSocketServer extends EventEmitter {
   }
 
   /**
-   * Listens on specified port
+   * Starts the bound HTTP server listening for connections.
    *
    * @param {Number} [port] Server port
    * @param {String} [host] The hostname where to bind the server


### PR DESCRIPTION
This adds support for the `httpHandler`, `ssl`, `key`, and `cert` options and `WebSocketServer#listen()` method to the `WebSocketServer` constructor.

With `httpHandler`, users can overwrite the existing default http handler that only responds with `426 Upgrade Required`. This is useful for implementing health checks that require a 200 status code.

```js
const httpHandler = (request, response) => {
  response.writeHead(200, {
    'Content-Type': 'text/plain'
  });
  response.end('OK');
};

const wss = new WebSocket.Server({ httpHandler, port: 8080 });
```

With the `ssl`, `key`, and `cert` options, users can create an HTTPS server over the default HTTP server. This allows for a simple API to create an HTTPS server using `ws`.

```js
const wss = new WebSocket.Server({
  ssl: true,
  cert: fs.readFileSync('/path/to/my/certificate.pem'),
  key: fs.readFileSync('/path/to/my/fixtures/key.pem'),
  port: 443
});
```

With the `WebSocketServer#listen()` method, users can create the WebSocket server and have it listen at a later time. This API is more conformant to NodeJS [http.Server](https://nodejs.org/api/http.html#serverlisten) and [https.Server](https://nodejs.org/api/https.html#serverlisten).

```js
const httpHandler = (request, response) => {
  response.writeHead(200, {
    'Content-Type': 'text/plain'
  });
  response.end('OK');
};

const wss = new WebSocket.Server({ httpHandler });

wss.listen(8080)
```