### PR TITLE
feat: add `sec-websocket-version` to response headers when request `sec-websocket-version` is invalid

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const WEBSOCKET_SUPPORT_VERSIONS_DESC = [13, 8];
 const BINARY_TYPES = ['nodebuffer', 'arraybuffer', 'fragments'];
 const hasBlob = typeof Blob !== 'undefined';
 
 if (hasBlob) BINARY_TYPES.push('blob');
 
 module.exports = {
-  WEBSOCKET_SUPPORT_VERSIONS_DESC,
   BINARY_TYPES,
   EMPTY_BUFFER: Buffer.alloc(0),
   GUID: '258EAFA5-E914-47DA-95CA-C5AB0DC85B11',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const WEBSOCKET_SUPPORT_VERSIONS_DESC = [13, 8];
 const BINARY_TYPES = ['nodebuffer', 'arraybuffer', 'fragments'];
 const hasBlob = typeof Blob !== 'undefined';
 
 if (hasBlob) BINARY_TYPES.push('blob');
 
 module.exports = {
+  WEBSOCKET_SUPPORT_VERSIONS_DESC,
   BINARY_TYPES,
   EMPTY_BUFFER: Buffer.alloc(0),
   GUID: '258EAFA5-E914-47DA-95CA-C5AB0DC85B11',

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -11,7 +11,11 @@ const extension = require('./extension');
 const PerMessageDeflate = require('./permessage-deflate');
 const subprotocol = require('./subprotocol');
 const WebSocket = require('./websocket');
-const { GUID, kWebSocket } = require('./constants');
+const {
+  GUID,
+  kWebSocket,
+  WEBSOCKET_SUPPORT_VERSIONS_DESC
+} = require('./constants');
 
 const keyRegex = /^[+/0-9A-Za-z]{22}==$/;
 
@@ -256,9 +260,11 @@ class WebSocketServer extends EventEmitter {
       return;
     }
 
-    if (version !== 8 && version !== 13) {
+    if (!WEBSOCKET_SUPPORT_VERSIONS_DESC.includes(version)) {
       const message = 'Missing or invalid Sec-WebSocket-Version header';
-      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
+      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message, {
+        'Sec-WebSocket-Version': WEBSOCKET_SUPPORT_VERSIONS_DESC.toString()
+      });
       return;
     }
 
@@ -526,15 +532,23 @@ function abortHandshake(socket, code, message, headers) {
  * @param {Duplex} socket The socket of the upgrade request
  * @param {Number} code The HTTP response status code
  * @param {String} message The HTTP response body
+ * @param {Object} [headers] The HTTP response headers
  * @private
  */
-function abortHandshakeOrEmitwsClientError(server, req, socket, code, message) {
+function abortHandshakeOrEmitwsClientError(
+  server,
+  req,
+  socket,
+  code,
+  message,
+  headers
+) {
   if (server.listenerCount('wsClientError')) {
     const err = new Error(message);
     Error.captureStackTrace(err, abortHandshakeOrEmitwsClientError);
 
     server.emit('wsClientError', err, socket, req);
   } else {
-    abortHandshake(socket, code, message);
+    abortHandshake(socket, code, message, headers);
   }
 }

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -11,11 +11,7 @@ const extension = require('./extension');
 const PerMessageDeflate = require('./permessage-deflate');
 const subprotocol = require('./subprotocol');
 const WebSocket = require('./websocket');
-const {
-  GUID,
-  kWebSocket,
-  WEBSOCKET_SUPPORT_VERSIONS_DESC
-} = require('./constants');
+const { GUID, kWebSocket } = require('./constants');
 
 const keyRegex = /^[+/0-9A-Za-z]{22}==$/;
 
@@ -260,10 +256,10 @@ class WebSocketServer extends EventEmitter {
       return;
     }
 
-    if (!WEBSOCKET_SUPPORT_VERSIONS_DESC.includes(version)) {
+    if (version !== 13 && version !== 8) {
       const message = 'Missing or invalid Sec-WebSocket-Version header';
       abortHandshakeOrEmitwsClientError(this, req, socket, 400, message, {
-        'Sec-WebSocket-Version': WEBSOCKET_SUPPORT_VERSIONS_DESC.toString()
+        'Sec-WebSocket-Version': '13, 8'
       });
       return;
     }

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -14,7 +14,7 @@ const os = require('os');
 const makeDuplexPair = require('./duplex-pair');
 const Sender = require('../lib/sender');
 const WebSocket = require('..');
-const { NOOP } = require('../lib/constants');
+const { NOOP, WEBSOCKET_SUPPORT_VERSIONS_DESC } = require('../lib/constants');
 
 describe('WebSocketServer', () => {
   describe('#ctor', () => {
@@ -813,6 +813,10 @@ describe('WebSocketServer', () => {
 
         req.on('response', (res) => {
           assert.strictEqual(res.statusCode, 400);
+          assert.strictEqual(
+            res.headers['sec-websocket-version'],
+            WEBSOCKET_SUPPORT_VERSIONS_DESC.toString()
+          );
 
           const chunks = [];
 
@@ -849,6 +853,10 @@ describe('WebSocketServer', () => {
 
         req.on('response', (res) => {
           assert.strictEqual(res.statusCode, 400);
+          assert.strictEqual(
+            res.headers['sec-websocket-version'],
+            WEBSOCKET_SUPPORT_VERSIONS_DESC.toString()
+          );
 
           const chunks = [];
 

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -14,7 +14,7 @@ const os = require('os');
 const makeDuplexPair = require('./duplex-pair');
 const Sender = require('../lib/sender');
 const WebSocket = require('..');
-const { NOOP, WEBSOCKET_SUPPORT_VERSIONS_DESC } = require('../lib/constants');
+const { NOOP } = require('../lib/constants');
 
 describe('WebSocketServer', () => {
   describe('#ctor', () => {
@@ -813,10 +813,7 @@ describe('WebSocketServer', () => {
 
         req.on('response', (res) => {
           assert.strictEqual(res.statusCode, 400);
-          assert.strictEqual(
-            res.headers['sec-websocket-version'],
-            WEBSOCKET_SUPPORT_VERSIONS_DESC.toString()
-          );
+          assert.strictEqual(res.headers['sec-websocket-version'], '13, 8');
 
           const chunks = [];
 
@@ -853,10 +850,7 @@ describe('WebSocketServer', () => {
 
         req.on('response', (res) => {
           assert.strictEqual(res.statusCode, 400);
-          assert.strictEqual(
-            res.headers['sec-websocket-version'],
-            WEBSOCKET_SUPPORT_VERSIONS_DESC.toString()
-          );
+          assert.strictEqual(res.headers['sec-websocket-version'], '13, 8');
 
           const chunks = [];
 


### PR DESCRIPTION
While test locally with postman, send invalid `sec-websocket-version`, I found that the server doesn't include `sec-websocket-version: 13,8` in response headers
![no-sec-websocket-version-header-present](https://github.com/user-attachments/assets/becd4259-d12d-438b-8288-643402c1c7a4)

1. Based on MDN Document
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Version

```
If the server doesn't support the version, or any header in the handshake is not understood or has an incorrect value, the server should send a response with status [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/400) and immediately close the socket. It should also include Sec-WebSocket-Version in the 400 response, listing the versions that it does support.
```

2. Based on RFC6455
https://datatracker.ietf.org/doc/html/rfc6455#section-4.4

```
The following example demonstrates version negotiation described above:

      GET /chat HTTP/1.1
      Host: server.example.com
      Upgrade: websocket
      Connection: Upgrade
      ...
      Sec-WebSocket-Version: 25

   The response from the server might look as follows:

      HTTP/1.1 400 Bad Request
      ...
      Sec-WebSocket-Version: 13, 8, 7

   Note that the last response from the server might also look like:

      HTTP/1.1 400 Bad Request
      ...
      Sec-WebSocket-Version: 13
      Sec-WebSocket-Version: 8, 7

   The client now repeats the handshake that conforms to version 13:

      GET /chat HTTP/1.1
      Host: server.example.com
      Upgrade: websocket
      Connection: Upgrade
      ...
      Sec-WebSocket-Version: 13
```

This PR add `sec-websocket-version` to response headers when request `sec-websocket-version` is invalid.

- [x] npm run lint
- [x] npm run test
- [x] npm run integration