### PR TITLE
Update wrapper.mjs

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,8 +1,12 @@
-import createWebSocketStream from './lib/stream.js';
-import Receiver from './lib/receiver.js';
-import Sender from './lib/sender.js';
-import WebSocket from './lib/websocket.js';
-import WebSocketServer from './lib/websocket-server.js';
+// Our SRC is CJS so we need to import default named
+import { default as createWebSocketStream } from './lib/stream.js';
+import { default as Receiver } from './lib/receiver.js';
+import { default as Sender } from './lib/sender.js';
+import { default as WebSocket } from './lib/websocket.js';
+import { default as WebSocketServer } from './lib/websocket-server.js';
 
 export { createWebSocketStream, Receiver, Sender, WebSocket, WebSocketServer };
-export default WebSocket;
+// import * as WS from 'ws' => works
+// import { WebSocket } from 'ws'; => works
+export default { createWebSocketStream, Receiver, Sender, WebSocket, WebSocketServer };
+// import WS from 'ws' => Works


### PR DESCRIPTION
Fixed: esm warapper which exported nested default

Why this is Correct:
When an ESM file imports a CJS file that uses module.exports = SomeValue;, Node.js (and most transpilers/bundlers) treats that exported value as the default export.
To capture that value and give it a specific named binding (like createWebSocketStream) within the current ESM scope, you must use the explicit named import syntax: import { default as <Name> } from 'module';.
This ensures that the main exports of the underlying CJS files are correctly mapped into the local environment for re-exporting.

```js
export { createWebSocketStream, Receiver, Sender, WebSocket, WebSocketServer };
export default { createWebSocketStream, Receiver, Sender, WebSocket, WebSocketServer };
```

Why this is Correct:
The module is explicitly listing the imported bindings and exporting them as named exports. This is the standard, modern way to expose library functions and classes, ensuring consumers must use named imports: import { WebSocket } from 'ws';.

the ESM entry point (as determined by the exports map), must explicitly provide a binding named default to satisfy the syntax import WS from 'ws'.

