### PR TITLE
[fix] Really apply input duplex options

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -52,11 +52,11 @@ function createWebSocketStream(ws, options) {
   let terminateOnDestroy = true;
 
   const duplex = new Duplex({
-    ...options,
     autoDestroy: false,
     emitClose: false,
     objectMode: false,
-    writableObjectMode: false
+    writableObjectMode: false,
+    ...options
   });
 
   ws.on('message', function message(msg, isBinary) {


### PR DESCRIPTION
Passing `objectMode: true` had no effect.