### PR TITLE
[fix] Real object mode for streams

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -60,8 +60,14 @@ function createWebSocketStream(ws, options) {
   });
 
   ws.on('message', function message(msg, isBinary) {
-    const data =
-      !isBinary && duplex._readableState.objectMode ? msg.toString() : msg;
+    let data = msg;
+    try {
+      if (!isBinary && duplex._readableState.objectMode)
+        data = JSON.parse(msg.toString());
+    } catch (err) {
+      this.emit('error', err);
+      return;
+    }
 
     if (!duplex.push(data)) ws.pause();
   });


### PR DESCRIPTION
objectMode should emit objects in data, not strings.

This could be a breaking change (see the adapted test), but since objectMode never worked anyway, it should be ok.