### PR TITLE
[fix] Use the native `Event` class when available

### DIFF
--- a/lib/event-target.js
+++ b/lib/event-target.js
@@ -11,10 +11,22 @@ const kTarget = Symbol('kTarget');
 const kType = Symbol('kType');
 const kWasClean = Symbol('kWasClean');
 
+// Use the native `Event` class as the base class if it is available (Node.js
+// 15.0.0+). This makes `ws` events instances of the native `Event` class so
+// that they can be dispatched on a native `EventTarget` without throwing an
+// `ERR_INVALID_ARG_TYPE` error. The `Object` class is used as a fallback on
+// older Node.js versions where the native `Event` class is not available.
+const SuperEvent =
+  typeof globalThis !== 'undefined' && globalThis.Event
+    ? globalThis.Event
+    : Object;
+
 /**
  * Class representing an event.
+ *
+ * @extends SuperEvent
  */
-class Event {
+class Event extends SuperEvent {
   /**
    * Create a new `Event`.
    *
@@ -22,6 +34,8 @@ class Event {
    * @throws {TypeError} If the `type` argument is not specified
    */
   constructor(type) {
+    super(type);
+
     this[kTarget] = null;
     this[kType] = type;
   }

--- a/test/event-target.test.js
+++ b/test/event-target.test.js
@@ -55,6 +55,39 @@ describe('Event', () => {
   });
 });
 
+describe('Native `Event` interoperability', () => {
+  it('extends the native `Event` class if available', function () {
+    if (typeof globalThis.Event !== 'function') return this.skip();
+
+    assert.ok(new Event('foo') instanceof globalThis.Event);
+    assert.ok(new CloseEvent('close') instanceof globalThis.Event);
+    assert.ok(new ErrorEvent('error') instanceof globalThis.Event);
+    assert.ok(new MessageEvent('message') instanceof globalThis.Event);
+  });
+
+  it('can be dispatched on a native `EventTarget`', function () {
+    if (
+      typeof globalThis.Event !== 'function' ||
+      typeof globalThis.EventTarget !== 'function'
+    ) {
+      return this.skip();
+    }
+
+    const target = new globalThis.EventTarget();
+    const events = [];
+
+    target.addEventListener('message', (event) => {
+      events.push(event);
+    });
+
+    const event = new MessageEvent('message', { data: 'foo' });
+
+    assert.doesNotThrow(() => target.dispatchEvent(event));
+    assert.deepStrictEqual(events, [event]);
+    assert.strictEqual(events[0].data, 'foo');
+  });
+});
+
 describe('CloseEvent', () => {
   it('inherits from `Event`', () => {
     assert.ok(CloseEvent.prototype instanceof Event);


### PR DESCRIPTION
This makes `ws` events extend the native `Event` class on Node.js 15.0.0+ where it exists. Mixing `ws` events with code that uses a native `EventTarget` currently throws:

    TypeError [ERR_INVALID_ARG_TYPE]: The "event" argument must be an instance of Event. Received an instance of Event

because `EventTarget.prototype.dispatchEvent()` validates that the event is an `instanceof` the native `Event`, which the custom `ws` classes were not.

This implements the first of the two tasks outlined in #1818 — using the native `Event` as a data container — without switching `WebSocket` to a native `EventTarget`, so there are no breaking changes or performance regressions to the `EventEmitter`-based dispatch.

- `Event` now extends `globalThis.Event` when available, falling back to the previous behavior (`extends Object`) on older Node.js versions. The existing `target`/`type` getters and the manual `event.target` assignment are preserved, so the public event payload shape is unchanged.
- Added tests verifying the events are instances of the native `Event` and interoperate with a native `EventTarget`.

Closes #1818