### PR TITLE
[fix] Reject offers where client_max_window_bits is less than configuration

### DIFF
--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -167,7 +167,9 @@ class PerMessageDeflate {
             (typeof opts.serverMaxWindowBits === 'number' &&
               opts.serverMaxWindowBits > params.server_max_window_bits))) ||
         (typeof opts.clientMaxWindowBits === 'number' &&
-          !params.client_max_window_bits)
+          (typeof params.client_max_window_bits === 'number'
+            ? opts.clientMaxWindowBits > params.client_max_window_bits
+            : !params.client_max_window_bits))
       ) {
         return false;
       }

--- a/test/permessage-deflate.test.js
+++ b/test/permessage-deflate.test.js
@@ -213,6 +213,21 @@ describe('PerMessageDeflate', () => {
         );
       });
 
+      it('throws an error if client_max_window_bits is less than configuration', () => {
+        const perMessageDeflate = new PerMessageDeflate({
+          isServer: true,
+          clientMaxWindowBits: 11
+        });
+        const extensions = extension.parse(
+          'permessage-deflate; client_max_window_bits=10'
+        );
+
+        assert.throws(
+          () => perMessageDeflate.accept(extensions['permessage-deflate']),
+          /^Error: None of the extension offers can be accepted$/
+        );
+      });
+
       it('throws an error if client_max_window_bits is unsupported on client', () => {
         const perMessageDeflate = new PerMessageDeflate({
           isServer: true,


### PR DESCRIPTION
## Bug

When a WebSocket server is configured with `clientMaxWindowBits = N` and a
client sends `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=M`
where `M < N`, the server incorrectly accepts the offer and responds with
`client_max_window_bits = N`.

This violates RFC 7692 Section 7.1.2.2:

> The value of the `client_max_window_bits` extension parameter in the response
> MUST NOT be greater than the value of the `client_max_window_bits` extension
> parameter in the client's offer.

The analogous rejection for `serverMaxWindowBits` (when
`opts.serverMaxWindowBits > params.server_max_window_bits`) already exists in
`acceptAsServer`, but the symmetric guard for `clientMaxWindowBits` was absent.

**Minimal reproduction:**
```js
const pmd = new PerMessageDeflate({ clientMaxWindowBits: 11, isServer: true });
const offers = parse('permessage-deflate; client_max_window_bits=10');
const result = pmd.accept(offers['permessage-deflate']);
// Before fix: { client_max_window_bits: 11 }  ← 11 > 10, violates RFC
// After fix:  throws 'None of the extension offers can be accepted'
```

## Fix

In `acceptAsServer`, change the `clientMaxWindowBits` rejection guard from:

```js
(typeof opts.clientMaxWindowBits === 'number' &&
  !params.client_max_window_bits)
```

to:

```js
(typeof opts.clientMaxWindowBits === 'number' &&
  (typeof params.client_max_window_bits === 'number'
    ? opts.clientMaxWindowBits > params.client_max_window_bits
    : !params.client_max_window_bits))
```

- When client omits `client_max_window_bits` (absent/falsy): same behaviour as before, reject.
- When client includes it as a bare flag (`true`): still accept, server may use any value.
- When client includes a specific numeric value smaller than the server's configured value: now reject, preserving RFC compliance.

## Verification

```
npm test
# 436 passing
```

The new test `'throws an error if client_max_window_bits is less than configuration'`
mirrors the existing `'throws an error if server_max_window_bits is less than configuration'`.

> AI-assisted contribution.