### PR TITLE
fix: count empty continuation frames toward the maxFragments limit

### DIFF
--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -77,6 +77,7 @@ class Receiver extends Writable {
 
     this._totalPayloadLength = 0;
     this._messageLength = 0;
+    this._numFragments = 0;
     this._fragments = [];
 
     this._errored = false;
@@ -500,6 +501,19 @@ class Receiver extends Writable {
       return;
     }
 
+    if (this._maxFragments > 0 && ++this._numFragments > this._maxFragments) {
+      const error = this.createError(
+        RangeError,
+        'Too many message fragments',
+        false,
+        1008,
+        'WS_ERR_TOO_MANY_BUFFERED_PARTS'
+      );
+
+      cb(error);
+      return;
+    }
+
     if (this._compressed) {
       this._state = INFLATING;
       this.decompress(data, cb);
@@ -507,22 +521,6 @@ class Receiver extends Writable {
     }
 
     if (data.length) {
-      if (
-        this._maxFragments > 0 &&
-        this._fragments.length >= this._maxFragments
-      ) {
-        const error = this.createError(
-          RangeError,
-          'Too many message fragments',
-          false,
-          1008,
-          'WS_ERR_TOO_MANY_BUFFERED_PARTS'
-        );
-
-        cb(error);
-        return;
-      }
-
       //
       // This message is not compressed so its length is the sum of the payload
       // length of all fragments.
@@ -562,22 +560,6 @@ class Receiver extends Writable {
           return;
         }
 
-        if (
-          this._maxFragments > 0 &&
-          this._fragments.length >= this._maxFragments
-        ) {
-          const error = this.createError(
-            RangeError,
-            'Too many message fragments',
-            false,
-            1008,
-            'WS_ERR_TOO_MANY_BUFFERED_PARTS'
-          );
-
-          cb(error);
-          return;
-        }
-
         this._fragments.push(buf);
       }
 
@@ -604,6 +586,7 @@ class Receiver extends Writable {
     this._totalPayloadLength = 0;
     this._messageLength = 0;
     this._fragmented = 0;
+    this._numFragments = 0;
     this._fragments = [];
 
     if (this._opcode === 2) {

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1027,9 +1027,9 @@ describe('Receiver', () => {
 
     receiver.write(
       Buffer.from([
-        0x02, 0x01, 0x61, // opcode=2, FIN=0, payload='a'
-        0x00, 0x00,       // opcode=0 (continuation), FIN=0, payload length=0
-        0x00, 0x00        // opcode=0 (continuation), FIN=0, payload length=0
+        0x02, 0x01,
+        0x00, 0x00,
+        0x00, 0x00
       ])
     );
   });

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1025,8 +1025,6 @@ describe('Receiver', () => {
       done();
     });
 
-    // First non-final binary fragment (non-empty).
-    // Then two zero-byte continuation frames; the second must trigger the limit.
     receiver.write(
       Buffer.from([
         0x02, 0x01, 0x61, // opcode=2, FIN=0, payload='a'

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1027,7 +1027,7 @@ describe('Receiver', () => {
 
     receiver.write(
       Buffer.from([
-        0x02, 0x01,
+        0x02, 0x00,
         0x00, 0x00,
         0x00, 0x00
       ])

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1014,6 +1014,28 @@ describe('Receiver', () => {
     );
   });
 
+  it('emits an error if there are too many message fragments (empty frames)', (done) => {
+    const receiver = new Receiver({ maxFragments: 2 });
+
+    receiver.on('error', (err) => {
+      assert.ok(err instanceof RangeError);
+      assert.strictEqual(err.code, 'WS_ERR_TOO_MANY_BUFFERED_PARTS');
+      assert.strictEqual(err.message, 'Too many message fragments');
+      assert.strictEqual(err[kStatusCode], 1008);
+      done();
+    });
+
+    // First non-final binary fragment (non-empty).
+    // Then two zero-byte continuation frames; the second must trigger the limit.
+    receiver.write(
+      Buffer.from([
+        0x02, 0x01, 0x61, // opcode=2, FIN=0, payload='a'
+        0x00, 0x00,       // opcode=0 (continuation), FIN=0, payload length=0
+        0x00, 0x00        // opcode=0 (continuation), FIN=0, payload length=0
+      ])
+    );
+  });
+
   it('emits an error if there are too many message fragments (2/2)', (done) => {
     const perMessageDeflate = new PerMessageDeflate();
     perMessageDeflate.accept([{}]);


### PR DESCRIPTION
## Problem

The `maxFragments` limit in `Receiver` is intended to cap the number of
message fragments a peer can send before an error is raised with close
code 1008. However, the check was placed inside `if (data.length)` in
`getData()`, so **zero-byte continuation frames were never counted
against the limit**.

A peer could send one non-empty opening fragment followed by an
unbounded number of empty (`payload-length = 0`) continuation frames
(opcode `0x00`, FIN = 0). Each frame is parsed in `getInfo()` and
`getData()` with O(1) work per frame, but the limit never fires.
This allows a remote endpoint to keep the receiver spinning through
`startLoop` indefinitely, constituting a denial-of-service vector
against any server or client that sets `maxFragments`.

The same gap existed in the `decompress()` callback for compressed
fragmented messages.

## Fix

Introduce a `_numFragments` counter (initialized in the constructor and
reset in `dataMessage()` at the end of every message, alongside
`_fragments`). The counter is incremented once per data frame in
`getData()`, before branching on whether the frame is compressed or
whether the payload is non-empty. The two previous `_fragments.length
>= _maxFragments` checks are removed; the single early check replaces
both uniformly.

The threshold semantics are preserved: the error fires when the
`(_maxFragments + 1)`-th frame arrives, matching the previous behaviour
for non-empty frames.

## Changes

- `lib/receiver.js` — add `_numFragments` counter; move limit check to
  cover all data frames regardless of payload length or compression.
- `test/receiver.test.js` — add a test that sends `maxFragments: 2`
  with one non-empty opening fragment followed by two empty continuation
  frames and asserts the second empty frame triggers the error.

## Test results

```
436 passing (1s)
receiver.js | 100% Stmts | 100% Branch | 100% Funcs | 100% Lines
```