### PR TITLE
[fix] Fixing Default maxFragments still allows memory exhaustion Dos

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -87,11 +87,17 @@ This class represents a WebSocket server. It extends the `EventEmitter`.
   - `handleProtocols` {Function} A function which can be used to handle the
     WebSocket subprotocols. See description below.
   - `host` {String} The hostname where to bind the server.
+  - `maxBufferedBytes` {Number} The maximum estimated amount of memory, in
+    bytes, that may be pinned by buffered data chunks or the fragments of an
+    in-progress message. It is measured as the sum of the payload bytes plus a
+    fixed per-part overhead, so it bounds the memory actually retained rather
+    than only the payload size. The value is coerced to a 32-bit signed integer.
+    Defaults to 134217728 (128 MiB). Set to 0 to disable the limit.
   - `maxBufferedChunks` {Number} The maximum number of buffered data chunks. The
-    value is coerced to a 32-bit signed integer. Defaults to 1048576. Set to 0
-    to disable the limit.
+    value is coerced to a 32-bit signed integer. Defaults to 65536. Set to 0 to
+    disable the limit.
   - `maxFragments` {Number} The maximum number of fragments in a message. The
-    value is coerced to a 32-bit signed integer. Defaults to 131072. Set to 0 to
+    value is coerced to a 32-bit signed integer. Defaults to 16384. Set to 0 to
     disable the limit.
   - `maxPayload` {Number} The maximum allowed message size in bytes. The value
     is coerced to a 32-bit signed integer. Defaults to 104857600 (100 MiB). Set
@@ -328,11 +334,17 @@ This class represents a WebSocket. It extends the `EventEmitter`.
     cryptographically strong random bytes.
   - `handshakeTimeout` {Number} Timeout in milliseconds for the handshake
     request. This is reset after every redirection.
+  - `maxBufferedBytes` {Number} The maximum estimated amount of memory, in
+    bytes, that may be pinned by buffered data chunks or the fragments of an
+    in-progress message. It is measured as the sum of the payload bytes plus a
+    fixed per-part overhead, so it bounds the memory actually retained rather
+    than only the payload size. The value is coerced to a 32-bit signed integer.
+    Defaults to 134217728 (128 MiB). Set to 0 to disable the limit.
   - `maxBufferedChunks` {Number} The maximum number of buffered data chunks. The
-    value is coerced to a 32-bit signed integer. Defaults to 1048576. Set to 0
-    to disable the limit.
+    value is coerced to a 32-bit signed integer. Defaults to 65536. Set to 0 to
+    disable the limit.
   - `maxFragments` {Number} The maximum number of fragments in a message. The
-    value is coerced to a 32-bit signed integer. Defaults to 131072. Set to 0 to
+    value is coerced to a 32-bit signed integer. Defaults to 16384. Set to 0 to
     disable the limit.
   - `maxPayload` {Number} The maximum allowed message size in bytes. The value
     is coerced to a 32-bit signed integer. Defaults to 104857600 (100 MiB). Set
@@ -708,7 +720,8 @@ A WebSocket frame was received with the RSV2 or RSV3 bit set unexpectedly.
 ### WS_ERR_TOO_MANY_BUFFERED_PARTS
 
 The configured maximum number of buffered data chunks or message fragments was
-exceeded.
+exceeded, or the estimated memory pinned by them exceeded the configured
+`maxBufferedBytes` limit.
 
 ### WS_ERR_UNSUPPORTED_DATA_PAYLOAD_LENGTH
 

--- a/lib/receiver.js
+++ b/lib/receiver.js
@@ -14,6 +14,8 @@ const { isValidStatusCode, isValidUTF8 } = require('./validation');
 
 const FastBuffer = Buffer[Symbol.species];
 
+const BUFFER_OVERHEAD = 128;
+
 const GET_INFO = 0;
 const GET_PAYLOAD_LENGTH_16 = 1;
 const GET_PAYLOAD_LENGTH_64 = 2;
@@ -40,6 +42,9 @@ class Receiver extends Writable {
    *     extensions
    * @param {Boolean} [options.isServer=false] Specifies whether to operate in
    *     client or server mode
+   * @param {Number} [options.maxBufferedBytes=0] The maximum estimated memory,
+   *     in bytes, that may be pinned by buffered data chunks or message
+   *     fragments (payload bytes plus a fixed per-part overhead)
    * @param {Number} [options.maxBufferedChunks=0] The maximum number of
    *     buffered data chunks
    * @param {Number} [options.maxFragments=0] The maximum number of message
@@ -58,6 +63,7 @@ class Receiver extends Writable {
     this._binaryType = options.binaryType || BINARY_TYPES[0];
     this._extensions = options.extensions || {};
     this._isServer = !!options.isServer;
+    this._maxBufferedBytes = options.maxBufferedBytes | 0;
     this._maxBufferedChunks = options.maxBufferedChunks | 0;
     this._maxFragments = options.maxFragments | 0;
     this._maxPayload = options.maxPayload | 0;
@@ -114,6 +120,24 @@ class Receiver extends Writable {
 
     this._bufferedBytes += chunk.length;
     this._buffers.push(chunk);
+
+    if (
+      this._maxBufferedBytes > 0 &&
+      this._bufferedBytes + this._buffers.length * BUFFER_OVERHEAD >
+        this._maxBufferedBytes
+    ) {
+      cb(
+        this.createError(
+          RangeError,
+          'Too much buffered data',
+          false,
+          1008,
+          'WS_ERR_TOO_MANY_BUFFERED_PARTS'
+        )
+      );
+      return;
+    }
+
     this.startLoop(cb);
   }
 
@@ -527,6 +551,23 @@ class Receiver extends Writable {
       //
       this._messageLength = this._totalPayloadLength;
       this._fragments.push(data);
+
+      if (
+        this._maxBufferedBytes > 0 &&
+        this._messageLength + this._fragments.length * BUFFER_OVERHEAD >
+          this._maxBufferedBytes
+      ) {
+        cb(
+          this.createError(
+            RangeError,
+            'Too much buffered data',
+            false,
+            1008,
+            'WS_ERR_TOO_MANY_BUFFERED_PARTS'
+          )
+        );
+        return;
+      }
     }
 
     this.dataMessage(cb);
@@ -561,6 +602,23 @@ class Receiver extends Writable {
         }
 
         this._fragments.push(buf);
+
+        if (
+          this._maxBufferedBytes > 0 &&
+          this._messageLength + this._fragments.length * BUFFER_OVERHEAD >
+            this._maxBufferedBytes
+        ) {
+          cb(
+            this.createError(
+              RangeError,
+              'Too much buffered data',
+              false,
+              1008,
+              'WS_ERR_TOO_MANY_BUFFERED_PARTS'
+            )
+          );
+          return;
+        }
       }
 
       this.dataMessage(cb);

--- a/lib/websocket-server.js
+++ b/lib/websocket-server.js
@@ -43,9 +43,12 @@ class WebSocketServer extends EventEmitter {
    *     called
    * @param {Function} [options.handleProtocols] A hook to handle protocols
    * @param {String} [options.host] The hostname where to bind the server
-   * @param {Number} [options.maxBufferedChunks=1048576] The maximum number of
+   * @param {Number} [options.maxBufferedBytes=134217728] The maximum estimated
+   *     memory, in bytes, that may be pinned by buffered data chunks or message
+   *     fragments
+   * @param {Number} [options.maxBufferedChunks=65536] The maximum number of
    *     buffered data chunks
-   * @param {Number} [options.maxFragments=131072] The maximum number of message
+   * @param {Number} [options.maxFragments=16384] The maximum number of message
    *     fragments
    * @param {Number} [options.maxPayload=104857600] The maximum allowed message
    *     size
@@ -69,8 +72,9 @@ class WebSocketServer extends EventEmitter {
     options = {
       allowSynchronousEvents: true,
       autoPong: true,
-      maxBufferedChunks: 1024 * 1024,
-      maxFragments: 128 * 1024,
+      maxBufferedBytes: 128 * 1024 * 1024,
+      maxBufferedChunks: 64 * 1024,
+      maxFragments: 16 * 1024,
       maxPayload: 100 * 1024 * 1024,
       skipUTF8Validation: false,
       perMessageDeflate: false,
@@ -430,6 +434,7 @@ class WebSocketServer extends EventEmitter {
 
     ws.setSocket(socket, head, {
       allowSynchronousEvents: this.options.allowSynchronousEvents,
+      maxBufferedBytes: this.options.maxBufferedBytes,
       maxBufferedChunks: this.options.maxBufferedChunks,
       maxFragments: this.options.maxFragments,
       maxPayload: this.options.maxPayload,

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -201,6 +201,9 @@ class WebSocket extends EventEmitter {
    *     multiple times in the same tick
    * @param {Function} [options.generateMask] The function used to generate the
    *     masking key
+   * @param {Number} [options.maxBufferedBytes=0] The maximum estimated memory,
+   *     in bytes, that may be pinned by buffered data chunks or message
+   *     fragments
    * @param {Number} [options.maxBufferedChunks=0] The maximum number of
    *     buffered data chunks
    * @param {Number} [options.maxFragments=0] The maximum number of message
@@ -216,6 +219,7 @@ class WebSocket extends EventEmitter {
       binaryType: this.binaryType,
       extensions: this._extensions,
       isServer: this._isServer,
+      maxBufferedBytes: options.maxBufferedBytes,
       maxBufferedChunks: options.maxBufferedChunks,
       maxFragments: options.maxFragments,
       maxPayload: options.maxPayload,
@@ -646,9 +650,12 @@ module.exports = WebSocket;
  *     masking key
  * @param {Number} [options.handshakeTimeout] Timeout in milliseconds for the
  *     handshake request
- * @param {Number} [options.maxBufferedChunks=1048576] The maximum number of
+ * @param {Number} [options.maxBufferedBytes=134217728] The maximum estimated
+ *     memory, in bytes, that may be pinned by buffered data chunks or message
+ *     fragments
+ * @param {Number} [options.maxBufferedChunks=65536] The maximum number of
  *     buffered data chunks
- * @param {Number} [options.maxFragments=131072] The maximum number of message
+ * @param {Number} [options.maxFragments=16384] The maximum number of message
  *     fragments
  * @param {Number} [options.maxPayload=104857600] The maximum allowed message
  *     size
@@ -670,8 +677,9 @@ function initAsClient(websocket, address, protocols, options) {
     autoPong: true,
     closeTimeout: CLOSE_TIMEOUT,
     protocolVersion: protocolVersions[1],
-    maxBufferedChunks: 1024 * 1024,
-    maxFragments: 128 * 1024,
+    maxBufferedBytes: 128 * 1024 * 1024,
+    maxBufferedChunks: 64 * 1024,
+    maxFragments: 16 * 1024,
     maxPayload: 100 * 1024 * 1024,
     skipUTF8Validation: false,
     perMessageDeflate: true,
@@ -1029,6 +1037,7 @@ function initAsClient(websocket, address, protocols, options) {
     websocket.setSocket(socket, head, {
       allowSynchronousEvents: opts.allowSynchronousEvents,
       generateMask: opts.generateMask,
+      maxBufferedBytes: opts.maxBufferedBytes,
       maxBufferedChunks: opts.maxBufferedChunks,
       maxFragments: opts.maxFragments,
       maxPayload: opts.maxPayload,

--- a/test/receiver.test.js
+++ b/test/receiver.test.js
@@ -1083,6 +1083,85 @@ describe('Receiver', () => {
     receiver.write(Buffer.from([0x63]));
   });
 
+  it('emits an error if buffered chunks pin too much memory', (done) => {
+    const receiver = new Receiver({ maxBufferedBytes: 200 });
+
+    receiver.on('error', (err) => {
+      assert.ok(err instanceof RangeError);
+      assert.strictEqual(err.code, 'WS_ERR_TOO_MANY_BUFFERED_PARTS');
+      assert.strictEqual(err.message, 'Too much buffered data');
+      assert.strictEqual(err[kStatusCode], 1008);
+      done();
+    });
+
+    receiver.write(Buffer.from([0x82, 0x05]));
+    receiver.write(Buffer.from([0x61]));
+    receiver.write(Buffer.from([0x62]));
+  });
+
+  it('emits an error if message fragments pin too much memory', (done) => {
+    const receiver = new Receiver({ maxBufferedBytes: 200 });
+
+    receiver.on('error', (err) => {
+      assert.ok(err instanceof RangeError);
+      assert.strictEqual(err.code, 'WS_ERR_TOO_MANY_BUFFERED_PARTS');
+      assert.strictEqual(err.message, 'Too much buffered data');
+      assert.strictEqual(err[kStatusCode], 1008);
+      done();
+    });
+
+    //
+    // Tiny fragments keep the summed payload length far below `maxPayload` but
+    // the retained `Buffer` views pin much more memory than the payload bytes.
+    //
+    receiver.write(
+      Buffer.from([
+        0x01,
+        0x01,
+        0x61, // First non-final text fragment.
+        0x00,
+        0x01,
+        0x62 // Continuation fragment that crosses the memory limit.
+      ])
+    );
+  });
+
+  it('emits an error if compressed message fragments pin too much memory', (done) => {
+    const perMessageDeflate = new PerMessageDeflate();
+    perMessageDeflate.accept([{}]);
+
+    const receiver = new Receiver({
+      extensions: {
+        'permessage-deflate': perMessageDeflate
+      },
+      maxBufferedBytes: 200
+    });
+    const fragment1 = Buffer.from('foo');
+    const fragment2 = Buffer.from('bar');
+
+    receiver.on('error', (err) => {
+      assert.ok(err instanceof RangeError);
+      assert.strictEqual(err.code, 'WS_ERR_TOO_MANY_BUFFERED_PARTS');
+      assert.strictEqual(err.message, 'Too much buffered data');
+      assert.strictEqual(err[kStatusCode], 1008);
+      done();
+    });
+
+    perMessageDeflate.compress(fragment1, false, (err, data) => {
+      if (err) return done(err);
+
+      receiver.write(Buffer.from([0x41, data.length]));
+      receiver.write(data);
+
+      perMessageDeflate.compress(fragment2, true, (err, data) => {
+        if (err) return done(err);
+
+        receiver.write(Buffer.from([0x80, data.length]));
+        receiver.write(data);
+      });
+    });
+  });
+
   it("honors the 'nodebuffer' binary type", (done) => {
     const receiver = new Receiver();
     const frags = [

--- a/test/websocket-server.test.js
+++ b/test/websocket-server.test.js
@@ -67,12 +67,14 @@ describe('WebSocketServer', () => {
       });
 
       it('accepts the receiver limit options', (done) => {
+        const maxBufferedBytes = 262144;
         const maxBufferedChunks = 1024;
         const maxFragments = 512;
         const maxPayload = 20480;
         const wss = new WebSocket.Server(
           {
             perMessageDeflate: true,
+            maxBufferedBytes,
             maxBufferedChunks,
             maxFragments,
             maxPayload,
@@ -86,6 +88,7 @@ describe('WebSocketServer', () => {
         );
 
         wss.on('connection', (ws) => {
+          assert.strictEqual(ws._receiver._maxBufferedBytes, maxBufferedBytes);
           assert.strictEqual(
             ws._receiver._maxBufferedChunks,
             maxBufferedChunks

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -136,6 +136,7 @@ describe('WebSocket', () => {
       });
 
       it('accepts the receiver limit options', (done) => {
+        const maxBufferedBytes = 262144;
         const maxBufferedChunks = 1024;
         const maxFragments = 512;
         const maxPayload = 20480;
@@ -147,12 +148,17 @@ describe('WebSocket', () => {
           () => {
             const ws = new WebSocket(`ws://localhost:${wss.address().port}`, {
               perMessageDeflate: true,
+              maxBufferedBytes,
               maxBufferedChunks,
               maxFragments,
               maxPayload
             });
 
             ws.on('open', () => {
+              assert.strictEqual(
+                ws._receiver._maxBufferedBytes,
+                maxBufferedBytes
+              );
               assert.strictEqual(
                 ws._receiver._maxBufferedChunks,
                 maxBufferedChunks


### PR DESCRIPTION
Issue: https://github.com/websockets/ws/issues/2331

**Problem:**

The GHSA-96hv-2xvq-fx4p fix added the count-based guards maxFragments and maxBufferedChunks, but their defaults are high enough that a default-configured server can still be OOM-crashed by a single unauthenticated peer.

Both guards count parts, and the only byte-based guard (maxPayload) counts payload bytes only. Nothing accounts for the per-Buffer-view object overhead (~128 B each). An attacker can exploit this:

Send a text frame with FIN=0, then maxFragments - 2 one-byte continuation frames, and never send FIN.
The message never completes, so the fragment array is retained indefinitely.
_totalPayloadLength stays ~128 KB (far below maxPayload of 100 MB) and the fragment count stays just under maxFragments (131072), so no guard ever fires.
Reproduced on the current tree (default server options): ~0.87 MB of wire traffic pins ~13–16 MB of heap (≈15× amplification). A few dozen such connections OOM-kill a default-heap Node process.

**Fix**
Two complementary changes:

1. New maxBufferedBytes option (structural fix). Charges a fixed per-part overhead (BUFFER_OVERHEAD = 128) on top of payload bytes, so the limit bounds the memory actually pinned rather than only the payload size. Enforced on all three retention paths — buffered input chunks (_write), uncompressed fragments (getData), and compressed fragments (decompress). Exceeding it emits WS_ERR_TOO_MANY_BUFFERED_PARTS (close code 1008).

2. Lowered the default count limits (defense-in-depth)
maxBufferedBytes defaults above maxPayload (100 MiB) so that a legitimate max-size message is never rejected; the tighter count defaults are what cap per-connection retained memory in the default configuration

New behavior is opt-in at the Receiver level (maxBufferedBytes defaults to 0 = disabled there). The lowered maxFragments/maxBufferedChunks defaults are a behavior change only for peers sending an unusually large number of fragments/chunks in a single message, all limits remain configurable (set to 0 to disable).