### PR TITLE
[fix] Do not exceed the offered client window size

### DIFF
--- a/lib/permessage-deflate.js
+++ b/lib/permessage-deflate.js
@@ -189,7 +189,14 @@ class PerMessageDeflate {
       accepted.server_max_window_bits = opts.serverMaxWindowBits;
     }
     if (typeof opts.clientMaxWindowBits === 'number') {
-      accepted.client_max_window_bits = opts.clientMaxWindowBits;
+      //
+      // If the offer specifies a value, the response must not exceed it.
+      // Ref: https://datatracker.ietf.org/doc/html/rfc7692#section-7.1.2.2
+      //
+      accepted.client_max_window_bits =
+        typeof accepted.client_max_window_bits === 'number'
+          ? Math.min(opts.clientMaxWindowBits, accepted.client_max_window_bits)
+          : opts.clientMaxWindowBits;
     } else if (
       accepted.client_max_window_bits === true ||
       opts.clientMaxWindowBits === false

--- a/test/permessage-deflate.test.js
+++ b/test/permessage-deflate.test.js
@@ -150,6 +150,24 @@ describe('PerMessageDeflate', () => {
         );
       });
 
+      it('does not exceed the offered client_max_window_bits value', () => {
+        const perMessageDeflate = new PerMessageDeflate({
+          isServer: true,
+          clientMaxWindowBits: 12
+        });
+        const extensions = extension.parse(
+          'permessage-deflate; client_max_window_bits=10'
+        );
+
+        assert.deepStrictEqual(
+          perMessageDeflate.accept(extensions['permessage-deflate']),
+          {
+            client_max_window_bits: 10,
+            __proto__: null
+          }
+        );
+      });
+
       it('accepts the first supported offer', () => {
         const perMessageDeflate = new PerMessageDeflate({
           isServer: true,

--- a/test/websocket.test.js
+++ b/test/websocket.test.js
@@ -4421,6 +4421,35 @@ describe('WebSocket', () => {
       });
     });
 
+    it('negotiates a client window size smaller than the server one', (done) => {
+      const wss = new WebSocket.Server(
+        {
+          perMessageDeflate: { clientMaxWindowBits: 15, threshold: 0 },
+          port: 0
+        },
+        () => {
+          const ws = new WebSocket(`ws://localhost:${wss.address().port}`, {
+            perMessageDeflate: { clientMaxWindowBits: 10, threshold: 0 }
+          });
+
+          ws.on('error', (err) => {
+            wss.close(() => done(err));
+          });
+
+          ws.on('message', (message, isBinary) => {
+            assert.deepStrictEqual(message, Buffer.from('hi'));
+            assert.ok(!isBinary);
+            ws.close();
+            wss.close(done);
+          });
+        }
+      );
+
+      wss.on('connection', (ws) => {
+        ws.send('hi');
+      });
+    });
+
     it('consumes all received data when connection is closed (1/2)', (done) => {
       const wss = new WebSocket.Server(
         {


### PR DESCRIPTION
When an extension negotiation offer specifies a value for the `client_max_window_bits` parameter, the response must use a value equal to or smaller than the offered one:

> If the "client_max_window_bits" extension parameter in a received extension negotiation offer has a value, the server may either ignore this value or use this value to avoid allocating an unnecessarily big LZ77 sliding window by including the "client_max_window_bits" extension parameter in the corresponding extension negotiation response to the offer with a value equal to or smaller than the received value.
>
> — [RFC 7692, section 7.1.2.2](https://datatracker.ietf.org/doc/html/rfc7692#section-7.1.2.2)

`acceptAsServer()` ignores the offered value and unconditionally echoes back the configured `clientMaxWindowBits` option, so a server configured with a larger window than the one the client offered replies with an invalid response.

A conforming client fails the connection in that case, and `ws` itself does too (`acceptAsClient()` throws, which is asserted by the existing test "throws an error if client_max_window_bits is greater than configuration"). The result is that a `ws` client cannot connect to a `ws` server when the client offers a smaller window than the server is configured with, even though both configurations are individually valid:

```js
const WebSocket = require("ws");

const wss = new WebSocket.Server(
  { port: 0, perMessageDeflate: { clientMaxWindowBits: 15 } },
  () => {
    const ws = new WebSocket(`ws://localhost:${wss.address().port}`, {
      perMessageDeflate: { clientMaxWindowBits: 10 }
    });

    ws.on("open", () => console.log("client: open"));
    ws.on("error", (err) => console.log("client: error ->", err.message));
  }
);

wss.on("connection", () => console.log("server: connection established"));
```

Before:

```
server: connection established
client: error -> Invalid Sec-WebSocket-Extensions header
```

The offer is `permessage-deflate; client_max_window_bits=10` and the response is `permessage-deflate; client_max_window_bits=15`. Note that the server considers the connection established while the client tears it down, so the failure is only visible on the client.

After:

```
server: connection established
client: open
```

The fix uses the smaller of the two values. This is already what the analogous `server_max_window_bits` path does, where an offer that cannot be satisfied is declined outright ("throws an error if server_max_window_bits is less than configuration"). Clamping is also the safe direction for the server: `_decompress()` derives the inflate `windowBits` from this parameter, so the server ends up allocating the smaller window that the client will actually deflate with.

The existing "prefers the configuration options" test already covers the opposite case (offer `13`, option `11` → `11`), which is unaffected since the configured value is the smaller one there.

Tests: both added tests fail on `master` and pass with the fix. The unit test asserts the negotiated parameter; the `websocket.test.js` one exercises a real handshake plus a compressed message round trip, which is the user-visible symptom. Full suite is green (437 passing), `eslint` and `prettier` clean.